### PR TITLE
Fix missing Sequelize import

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -4,6 +4,7 @@ const Piece = db.piece;
 const Composer = db.composer;
 const Collection = db.collection;
 const CollectionPiece = db.collection_piece;
+const { Op } = require("sequelize");
 
 exports.create = async (req, res) => {
     const { date, type, notes, pieceIds } = req.body;


### PR DESCRIPTION
## Summary
- fix undefined `Op` reference in event controller by adding Sequelize import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test` in frontend *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d049547d08320b8edcaea13cbc1b0