### PR TITLE
Fix admin layout spec after component rename

### DIFF
--- a/choir-app-frontend/src/app/features/admin/admin-layout/admin-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/admin-layout/admin-layout.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { AdminLayout } from './admin-layout.component';
+import { AdminLayoutComponent } from './admin-layout.component';
 
-describe('AdminLayout', () => {
-  let component: AdminLayout;
-  let fixture: ComponentFixture<AdminLayout>;
+describe('AdminLayoutComponent', () => {
+  let component: AdminLayoutComponent;
+  let fixture: ComponentFixture<AdminLayoutComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminLayout]
+      imports: [AdminLayoutComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(AdminLayout);
+    fixture = TestBed.createComponent(AdminLayoutComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
## Summary
- update the AdminLayout test to import `AdminLayoutComponent`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d077516808320894afec80cb74925