### PR TITLE
Update event.controller to use active choir and user IDs

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -8,7 +8,8 @@ const { Op } = require("sequelize");
 
 exports.create = async (req, res) => {
     const { date, type, notes, pieceIds } = req.body;
-    const { choirId, userId } = req;
+    const choirId = req.activeChoirId;
+    const userId = req.userId;
 
     if (!date || !type) {
         return res.status(400).send({ message: "Date and Type are required." });


### PR DESCRIPTION
## Summary
- use `activeChoirId` and `userId` properties in event creation
- keep Sequelize `Op` import at the top of the file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d077a45e88320a8bde7f61d48f403