### PR TITLE
Fix admin layout component class name

### DIFF
--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -13,7 +13,7 @@ import { ImprintComponent } from '@features/legal/imprint/imprint.component';
 import { PrivacyComponent } from '@features/legal/privacy/privacy.component';
 import { AdminGuard } from '@core/guards/admin-guard';
 import { ManageComposersComponent } from '@features/admin/manage-composers/manage-composers.component';
-import { AdminLayoutComponnent } from '@features/admin/admin-layout/admin-layout.component';
+import { AdminLayoutComponent } from '@features/admin/admin-layout/admin-layout.component';
 import { LoginGuard } from '@core/guards/login.guard';
 import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
@@ -77,7 +77,7 @@ export const routes: Routes = [
     },
     {
         path: 'admin',
-        component: AdminLayoutComponnent,
+        component: AdminLayoutComponent,
         canActivate: [AuthGuard, AdminGuard], // Muss eingeloggt UND Admin sein
         children: [
             { path: '', redirectTo: 'composers', pathMatch: 'full' },

--- a/choir-app-frontend/src/app/features/admin/admin-layout/admin-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/admin-layout/admin-layout.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { AdminLayout } from './admin-layout.component';
+import { AdminLayoutComponent } from './admin-layout.component';
 
-describe('AdminLayout', () => {
-  let component: AdminLayout;
-  let fixture: ComponentFixture<AdminLayout>;
+describe('AdminLayoutComponent', () => {
+  let component: AdminLayoutComponent;
+  let fixture: ComponentFixture<AdminLayoutComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminLayout]
+      imports: [AdminLayoutComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(AdminLayout);
+    fixture = TestBed.createComponent(AdminLayoutComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/admin/admin-layout/admin-layout.component.ts
+++ b/choir-app-frontend/src/app/features/admin/admin-layout/admin-layout.component.ts
@@ -5,13 +5,13 @@ import { MaterialModule } from '@modules/material.module';
 @Component({
   selector: 'app-admin-layout',
   templateUrl: './admin-layout.component.html',
-  styleUrl: './admin-layout.component.scss',
+  styleUrls: ['./admin-layout.component.scss'],
   standalone: true,
   imports: [
     MaterialModule,
     RouterModule
   ]
 })
-export class AdminLayoutComponnent {
+export class AdminLayoutComponent {
 
 }


### PR DESCRIPTION
## Summary
- correct typo in AdminLayout class name
- fix styleUrls property
- update imports in routing and tests

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d077b21548320a1bc2d407fcd8fe0