### PR TITLE
Fix lyrics input field

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -33,9 +33,9 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field appearance="outline">
+          <mat-form-field appearance="outline" class="lyrics-field">
             <mat-label>Text</mat-label>
-            <input matInput formControlName="lycris" placeholder="">
+            <textarea matInput formControlName="lycris"></textarea>
           </mat-form-field>
 
           <mat-form-field appearance="outline">


### PR DESCRIPTION
## Summary
- change lyrics input from `input` to `textarea`

## Testing
- `npx --yes -p @angular/cli ng test --configuration development --browsers=ChromeHeadless --watch=false --output-path=/tmp/test-results` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d41b19520832087e9db24b593574c