### PR TITLE
Add singable filter with pagination

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -34,15 +34,23 @@ export class ApiService {
     composerId?: number,
     categoryId?: number,
     collectionId?: number,
-    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection'
-  ): Observable<Piece[]> {
+    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection',
+    page: number = 1,
+    limit: number = 25,
+    status?: string,
+    sortDir: 'ASC' | 'DESC' = 'ASC'
+  ): Observable<{ data: Piece[]; total: number }> {
     let params = new HttpParams();
     if (composerId) params = params.set('composerId', composerId.toString());
     if (categoryId) params = params.set('categoryId', categoryId.toString());
     if (collectionId) params = params.set('collectionId', collectionId.toString());
     if (sortBy) params = params.set('sortBy', sortBy);
+    params = params.set('page', page);
+    params = params.set('limit', limit);
+    params = params.set('sortDir', sortDir);
+    if (status) params = params.set('status', status);
 
-    return this.http.get<Piece[]>(`${this.apiUrl}/repertoire`, { params });
+    return this.http.get<{ data: Piece[]; total: number }>(`${this.apiUrl}/repertoire`, { params });
   }
 
   getRepertoireForLookup(): Observable<LookupPiece[]> {

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -7,18 +7,35 @@
     </button>
   </div>
 
-  <!-- Filter controls row -->
-  <div class="filter-controls">
-    <mat-form-field appearance="outline">
-      <mat-label>Filter by Collection</mat-label>
-      <mat-select [value]="filterByCollectionId$.value" (selectionChange)="onCollectionFilterChange($event.value)">
-        <mat-option [value]="null">All Pieces in Repertoire</mat-option>
-        <mat-option *ngFor="let collection of collections$ | async" [value]="collection.id">
-          {{ collection.title }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-  </div>
+  <!-- Filter controls row inside expansion panel -->
+  <mat-expansion-panel [(expanded)]="filtersExpanded" class="filter-panel">
+    <mat-expansion-panel-header>
+      <mat-panel-title>Filters</mat-panel-title>
+    </mat-expansion-panel-header>
+    <div class="filter-controls">
+      <mat-form-field appearance="outline">
+        <mat-label>Collection</mat-label>
+        <mat-select [value]="filterByCollectionId$.value" (selectionChange)="onCollectionFilterChange($event.value)">
+          <mat-option [value]="null">All</mat-option>
+          <mat-option *ngFor="let collection of collections$ | async" [value]="collection.id">
+            {{ collection.title }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Category</mat-label>
+        <mat-select [value]="filterByCategoryId$.value" (selectionChange)="onCategoryFilterChange($event.value)">
+          <mat-option [value]="null">All</mat-option>
+          <mat-option *ngFor="let cat of categories$ | async" [value]="cat.id">{{cat.name}}</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-checkbox [checked]="onlySingable$.value" (change)="onSingableToggle($event.checked)">
+        Only singable
+      </mat-checkbox>
+      <span class="spacer"></span>
+      <button mat-button (click)="clearFilters()">Clear Filters</button>
+    </div>
+  </mat-expansion-panel>
 
   <div class="table-wrapper mat-elevation-z8">
     <div *ngIf="isLoading" class="loading-shade">

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -17,8 +17,10 @@
 
 // Filter-Controls
 .filter-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   padding: 1rem 0;
-  // Dieser Bereich hat ebenfalls eine feste Höhe.
   flex-shrink: 0;
   mat-form-field {
     width: 300px;
@@ -26,6 +28,13 @@
       color: currentColor;
     }
   }
+  .spacer {
+    flex: 1 1 auto;
+  }
+}
+
+.filter-panel {
+  width: 320px;
 }
 
 // Wrapper für Tabelle und Paginator


### PR DESCRIPTION
## Summary
- filter repertoire by status and paginate results
- surface new filter options on the frontend
- remember filter state in local storage
- request data page by page and prefetch next page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4485ff588320bb71c27e6fa82650