### PR TITLE
Add admin event privileges and display metadata

### DIFF
--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -5,6 +5,9 @@ export interface Event {
   date: string;
   type: 'REHEARSAL' | 'SERVICE';
   notes?: string;
+  createdAt: string;
+  updatedAt: string;
+  director?: { name: string };
   pieces: Piece[];
 }
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -12,11 +12,12 @@
 <mat-list>
   <mat-list-item *ngFor="let ev of events$ | async" (click)="selectEvent(ev)">
     <div matListItemTitle>{{ ev.date | date:'shortDate' }} - {{ ev.type }}</div>
+    <div matListItemLine class="meta-info">Zuletzt geändert am {{ ev.updatedAt | date:'short' }} von {{ ev.director?.name }}</div>
     <span class="spacer"></span>
     <button mat-icon-button (click)="editEvent(ev); $event.stopPropagation()">
       <mat-icon>edit</mat-icon>
     </button>
-    <button *ngIf="isChoirAdmin" mat-icon-button color="warn" (click)="deleteEvent(ev); $event.stopPropagation()">
+    <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button color="warn" (click)="deleteEvent(ev); $event.stopPropagation()">
       <mat-icon>delete</mat-icon>
     </button>
   </mat-list-item>

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
+import { AuthService } from '@core/services/auth.service';
 import { Event } from '@core/models/event';
 import { Observable, switchMap } from 'rxjs';
 import { startWith } from 'rxjs/operators';
@@ -24,13 +25,15 @@ export class EventListComponent implements OnInit {
   events$!: Observable<Event[]>;
   selectedEvent: Event | null = null;
   isChoirAdmin = false;
+  isAdmin = false;
 
-  constructor(private apiService: ApiService, private dialog: MatDialog, private snackBar: MatSnackBar) {}
+  constructor(private apiService: ApiService, private authService: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {}
 
   ngOnInit(): void {
     this.loadEvents();
     this.typeControl.valueChanges.pipe(startWith('ALL')).subscribe(() => this.loadEvents());
     this.apiService.checkChoirAdminStatus().subscribe(s => this.isChoirAdmin = s.isChoirAdmin);
+    this.authService.isAdmin$.subscribe(isAdmin => this.isAdmin = isAdmin);
   }
 
   private loadEvents(): void {


### PR DESCRIPTION
## Summary
- include director info when creating and fetching events
- update event listing to show last editor and timestamps
- allow global admins to delete events in the UI

## Testing
- `npm test` *(fails: Missing test script)*
- `npm test --silent` in frontend *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d46f358b08320bbbb6a06f4b1f15f