### PR TITLE
Add Angular test example and root npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Chorleiter
+
 Management of choirs for directors
+
+## Tests
+
+Run frontend unit tests with:
+
+```bash
+npm test
+```
+
+This command uses the Angular CLI to execute Karma tests from the `choir-app-frontend` project.

--- a/choir-app-frontend/src/app/features/registration/invite-registration.component.spec.ts
+++ b/choir-app-frontend/src/app/features/registration/invite-registration.component.spec.ts
@@ -1,0 +1,62 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InviteRegistrationComponent } from './invite-registration.component';
+import { ApiService } from '@core/services/api.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+class SnackBarStub {
+  open = jasmine.createSpy('open');
+}
+
+describe('InviteRegistrationComponent', () => {
+  let component: InviteRegistrationComponent;
+  let fixture: ComponentFixture<InviteRegistrationComponent>;
+  let api: jasmine.SpyObj<ApiService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj('ApiService', ['getInvitation', 'completeRegistration']);
+
+    await TestBed.configureTestingModule({
+      imports: [InviteRegistrationComponent, RouterTestingModule],
+      providers: [
+        { provide: ApiService, useValue: api },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { token: 'abc' } } } },
+        { provide: MatSnackBar, useClass: SnackBarStub }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InviteRegistrationComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load invitation details on init', () => {
+    api.getInvitation.and.returnValue(of({ email: 'e@mail.com', choirName: 'Choir' }));
+
+    component.ngOnInit();
+
+    expect(api.getInvitation).toHaveBeenCalledWith('abc');
+    expect(component.email).toBe('e@mail.com');
+    expect(component.choirName).toBe('Choir');
+  });
+
+  it('should submit registration and navigate to login', () => {
+    api.completeRegistration.and.returnValue(of({}));
+    spyOn(router, 'navigate');
+
+    component.token = 'abc';
+    component.form.setValue({ name: 'Test', password: 'secret' });
+
+    component.submit();
+
+    expect(api.completeRegistration).toHaveBeenCalledWith('abc', { name: 'Test', password: 'secret' });
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "chorleiter-root",
+  "private": true,
+  "scripts": {
+    "test": "npm test --prefix choir-app-frontend"
+  }
+}


### PR DESCRIPTION
## Summary
- add root `package.json` with `npm test` that calls frontend tests
- document test command in README
- provide example spec for `InviteRegistrationComponent`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4893391c8320b59e704da083f559