### PR TITLE
Add request timeout and global loading spinner

### DIFF
--- a/choir-app-backend/server.js
+++ b/choir-app-backend/server.js
@@ -63,7 +63,13 @@ db.sequelize.sync({ alter: true }).then(() => {
     // Rufen Sie die Seed-Funktion auf.
     initialSeed();
 
-    app.listen(PORT, ADDRESS, () => {
+    const server = app.listen(PORT, ADDRESS, () => {
         console.log(`Server is running on port ${PORT}, listening ${ADDRESS}.`);
+    });
+    // Close requests that take longer than 20 seconds
+    server.setTimeout(20 * 1000);
+    server.on('timeout', (socket) => {
+        console.warn('Request timed out.');
+        socket.destroy();
     });
 });

--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+
+@Injectable()
+export class ErrorInterceptor implements HttpInterceptor {
+  constructor(private dialog: MatDialog) {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      catchError((error) => {
+        const data: ConfirmDialogData = {
+          title: 'Fehler',
+          message: error.name === 'TimeoutError'
+            ? 'Die Anfrage hat zu lange gedauert.'
+            : (error instanceof HttpErrorResponse ? (error.error?.message || error.message) : 'Unbekannter Fehler'),
+          confirmButtonText: 'Erneut versuchen',
+          cancelButtonText: 'Abbrechen'
+        };
+
+        return this.dialog.open(ConfirmDialogComponent, { data }).afterClosed().pipe(
+          switchMap(retry => {
+            if (retry) {
+              return next.handle(req);
+            }
+            return throwError(() => error);
+          })
+        );
+      })
+    );
+  }
+}

--- a/choir-app-frontend/src/app/core/interceptors/loading-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/loading-interceptor.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoadingService } from '../services/loading.service';
+
+@Injectable()
+export class LoadingInterceptor implements HttpInterceptor {
+  constructor(private loadingService: LoadingService) {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    this.loadingService.show();
+    return next.handle(req).pipe(finalize(() => this.loadingService.hide()));
+  }
+}

--- a/choir-app-frontend/src/app/core/interceptors/timeout-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/timeout-interceptor.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+
+@Injectable()
+export class TimeoutInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(timeout(20000));
+  }
+}

--- a/choir-app-frontend/src/app/core/services/loading.service.ts
+++ b/choir-app-frontend/src/app/core/services/loading.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadingService {
+  private counter = 0;
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+  loading$ = this.loadingSubject.asObservable();
+
+  show(): void {
+    this.counter++;
+    if (this.counter === 1) {
+      this.loadingSubject.next(true);
+    }
+  }
+
+  hide(): void {
+    if (this.counter > 0) {
+      this.counter--;
+      if (this.counter === 0) {
+        this.loadingSubject.next(false);
+      }
+    }
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -62,6 +62,7 @@
   </mat-toolbar>
 
   <app-error-display></app-error-display>
+  <app-loading-indicator></app-loading-indicator>
 
   <main class="main-content">
     <div class="container">

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -10,6 +10,7 @@ import { combineLatest, map, Observable } from 'rxjs';
 import { Theme, ThemeService } from '@core/services/theme.service';
 import { ChoirSwitcherComponent } from '../choir-switcher/choir-switcher.component';
 import { ErrorDisplayComponent } from '@shared/components/error-display/error-display.component';
+import { LoadingIndicatorComponent } from '@shared/components/loading-indicator/loading-indicator.component';
 
 @Component({
   selector: 'app-main-layout',
@@ -22,7 +23,8 @@ import { ErrorDisplayComponent } from '@shared/components/error-display/error-di
     MaterialModule,
     FooterComponent,
     ChoirSwitcherComponent,
-    ErrorDisplayComponent
+    ErrorDisplayComponent,
+    LoadingIndicatorComponent
   ]
 })
 export class MainLayoutComponent {

--- a/choir-app-frontend/src/app/shared/components/loading-indicator/loading-indicator.component.html
+++ b/choir-app-frontend/src/app/shared/components/loading-indicator/loading-indicator.component.html
@@ -1,0 +1,3 @@
+<div class="global-loading-overlay" *ngIf="loading$ | async">
+  <mat-spinner></mat-spinner>
+</div>

--- a/choir-app-frontend/src/app/shared/components/loading-indicator/loading-indicator.component.scss
+++ b/choir-app-frontend/src/app/shared/components/loading-indicator/loading-indicator.component.scss
@@ -1,0 +1,12 @@
+.global-loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 1500;
+}

--- a/choir-app-frontend/src/app/shared/components/loading-indicator/loading-indicator.component.ts
+++ b/choir-app-frontend/src/app/shared/components/loading-indicator/loading-indicator.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { LoadingService } from '@core/services/loading.service';
+
+@Component({
+  selector: 'app-loading-indicator',
+  standalone: true,
+  imports: [CommonModule, MatProgressSpinnerModule],
+  templateUrl: './loading-indicator.component.html',
+  styleUrls: ['./loading-indicator.component.scss']
+})
+export class LoadingIndicatorComponent {
+  loading$ = this.loadingService.loading$;
+  constructor(private loadingService: LoadingService) {}
+}

--- a/choir-app-frontend/src/main.ts
+++ b/choir-app-frontend/src/main.ts
@@ -8,6 +8,9 @@ import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material/snack-bar';
 import { AppComponent } from './app/app.component';
 import { AppRoutingModule } from './app/app-routing.module';
 import { AuthInterceptor } from '@core/interceptors/auth-interceptor';
+import { TimeoutInterceptor } from '@core/interceptors/timeout-interceptor';
+import { LoadingInterceptor } from '@core/interceptors/loading-interceptor';
+import { ErrorInterceptor } from '@core/interceptors/error-interceptor';
 import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de'; // Importieren Sie das deutsche Sprachpaket
 import localeDeExtra from '@angular/common/locales/extra/de'; // Optionale extra Daten
@@ -21,7 +24,10 @@ bootstrapApplication(AppComponent, {
     provideRouter(AppRoutingModule.routes), // Provide routes from your routing file
     provideAnimations(), // Provides BrowserAnimationsModule
     provideHttpClient(withInterceptorsFromDi()), // Provides HttpClient and interceptor logic
-    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }, // Provide your interceptor
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: TimeoutInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
     { provide: LOCALE_ID, useValue: 'de-DE' },
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { verticalPosition: 'top' } }
   ]


### PR DESCRIPTION
## Summary
- close slow connections in backend after 20s
- show a spinner while HTTP requests are pending
- timeout HTTP requests in the frontend after 20s
- prompt for retry when requests fail

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dab12f0408320a45b7e9f52149210