### PR TITLE
Introduce generic services and use them in literature features

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -2,6 +2,8 @@ const db = require("../models");
 const Piece = db.piece;
 const Composer = db.composer;
 const Category = db.category;
+const CrudService = require("../services/crud.service");
+const pieceService = new CrudService(Piece);
 
 /**
  * @description Create a new global piece.
@@ -64,7 +66,7 @@ exports.create = async (req, res) => {
  */
 exports.findAll = async (req, res) => {
     try {
-        const pieces = await Piece.findAll({
+        const pieces = await pieceService.findAll({
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] }
@@ -85,7 +87,7 @@ exports.findOne = async (req, res) => {
     const id = req.params.id;
 
     try {
-        const piece = await Piece.findByPk(id, {
+        const piece = await pieceService.findById(id, {
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] }
@@ -113,9 +115,7 @@ exports.update = async (req, res) => {
     const id = req.params.id;
 
     try {
-        const num = await Piece.update(req.body, {
-            where: { id: id }
-        });
+        const num = await pieceService.update(id, req.body);
 
         if (num == 1) {
             res.send({
@@ -141,9 +141,7 @@ exports.delete = async (req, res) => {
     const id = req.params.id;
 
     try {
-        const num = await Piece.destroy({
-            where: { id: id }
-        });
+        const num = await pieceService.delete(id);
 
         if (num == 1) {
             res.send({

--- a/choir-app-backend/src/services/crud.service.js
+++ b/choir-app-backend/src/services/crud.service.js
@@ -1,0 +1,28 @@
+class CrudService {
+  constructor(model) {
+    this.model = model;
+  }
+
+  async create(data, options = {}) {
+    return await this.model.create(data, options);
+  }
+
+  async findAll(options = {}) {
+    return await this.model.findAll(options);
+  }
+
+  async findById(id, options = {}) {
+    return await this.model.findByPk(id, options);
+  }
+
+  async update(id, data, options = {}) {
+    const [num] = await this.model.update(data, { where: { id }, ...options });
+    return num;
+  }
+
+  async delete(id, options = {}) {
+    return await this.model.destroy({ where: { id }, ...options });
+  }
+}
+
+module.exports = CrudService;

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -1,0 +1,66 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { Piece } from '../models/piece';
+import { LookupPiece } from '../models/lookup-piece';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PieceService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getMyRepertoire(
+    categoryId?: number,
+    collectionId?: number,
+    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection',
+    page = 1,
+    limit = 25,
+    status?: string,
+    sortDir: 'ASC' | 'DESC' = 'ASC',
+    search?: string
+  ): Observable<{ data: Piece[]; total: number }> {
+    let params = new HttpParams();
+    if (categoryId) params = params.set('categoryId', categoryId.toString());
+    if (collectionId) params = params.set('collectionId', collectionId.toString());
+    if (sortBy) params = params.set('sortBy', sortBy);
+    params = params.set('page', page);
+    params = params.set('limit', limit);
+    params = params.set('sortDir', sortDir);
+    if (status) params = params.set('status', status);
+    if (search) params = params.set('search', search);
+
+    return this.http.get<{ data: Piece[]; total: number }>(`${this.apiUrl}/repertoire`, { params });
+  }
+
+  updatePieceStatus(pieceId: number, status: string): Observable<any> {
+    return this.http.put(`${this.apiUrl}/repertoire/status`, { pieceId, status });
+  }
+
+  getGlobalPieces(): Observable<Piece[]> {
+    return this.http.get<Piece[]>(`${this.apiUrl}/pieces`);
+  }
+
+  createGlobalPiece(pieceData: any): Observable<Piece> {
+    return this.http.post<Piece>(`${this.apiUrl}/pieces`, pieceData);
+  }
+
+  updateGlobalPiece(id: number, pieceData: any): Observable<Piece> {
+    return this.http.put<Piece>(`${this.apiUrl}/pieces/${id}`, pieceData);
+  }
+
+  getPieceById(id: number): Observable<Piece> {
+    return this.http.get<Piece>(`${this.apiUrl}/pieces/${id}`);
+  }
+
+  addPieceToMyRepertoire(pieceId: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/repertoire/add-piece`, { pieceId });
+  }
+
+  getRepertoireForLookup(): Observable<LookupPiece[]> {
+    return this.http.get<LookupPiece[]>(`${this.apiUrl}/repertoire/lookup`);
+  }
+}

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -11,6 +11,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from 'src/app/core/services/api.service';
+import { PieceService } from 'src/app/core/services/piece.service';
 import { Piece } from 'src/app/core/models/piece';
 import { Collection } from 'src/app/core/models/collection';
 import { Category } from 'src/app/core/models/category';
@@ -65,6 +66,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
 
   constructor(
     private apiService: ApiService,
+    private pieceService: PieceService,
     public dialog: MatDialog,
     private snackBar: MatSnackBar // Inject MatSnackBar for feedback
   ) {}
@@ -112,8 +114,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
           if (cached) {
             return of({ data: cached, total: this.totalPieces });
           }
-          return this.apiService.getMyRepertoire(
-            undefined,
+          return this.pieceService.getMyRepertoire(
             this.filterByCategoryId$.value ?? undefined,
             this.filterByCollectionId$.value ?? undefined,
             this._sort.active as any,
@@ -159,8 +160,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     const nextIndex = this._paginator.pageIndex + 1;
     if (nextIndex * this._paginator.pageSize >= this.totalPieces) return;
     if (this.pageCache.has(nextIndex)) return;
-    this.apiService.getMyRepertoire(
-      undefined,
+    this.pieceService.getMyRepertoire(
       this.filterByCategoryId$.value ?? undefined,
       this.filterByCollectionId$.value ?? undefined,
       this._sort.active as any,
@@ -289,7 +289,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
    * Called when a user changes the status of a piece from the dropdown in the table.
    */
   onStatusChange(newStatus: string, pieceId: number): void {
-    this.apiService.updatePieceStatus(pieceId, newStatus).subscribe({
+    this.pieceService.updatePieceStatus(pieceId, newStatus).subscribe({
       next: () => {
         // Log to console for debugging, a snackbar is optional here as the change is visual.
         console.log(`Status for piece ${pieceId} updated to ${newStatus}`);

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -16,6 +16,7 @@ import { MaterialModule } from '@modules/material.module';
 import { Composer } from '@core/models/composer';
 import { BehaviorSubject, Observable, switchMap } from 'rxjs';
 import { ApiService } from '@core/services/api.service';
+import { PieceService } from '@core/services/piece.service';
 import { ComposerDialogComponent } from '../../composers/composer-dialog/composer-dialog.component';
 import { Category } from '@core/models/category';
 import { CategoryDialogComponent } from '../../categories/category-dialog/category-dialog.component';
@@ -51,6 +52,7 @@ export class PieceDialogComponent implements OnInit {
     constructor(
         private fb: FormBuilder,
         private apiService: ApiService,
+        private pieceService: PieceService,
         public dialog: MatDialog,
         public dialogRef: MatDialogRef<PieceDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: { pieceId: number | null }
@@ -102,7 +104,7 @@ export class PieceDialogComponent implements OnInit {
         });
 
         if (this.isEditMode && this.data.pieceId) {
-            this.apiService
+            this.pieceService
                 .getPieceById(this.data.pieceId)
                 .subscribe((piece) => {
                     this.populateForm(piece);
@@ -225,7 +227,7 @@ export class PieceDialogComponent implements OnInit {
         }
 
         if (this.isEditMode && this.data.pieceId) {
-            this.apiService
+            this.pieceService
                 .updateGlobalPiece(this.data.pieceId, this.pieceForm.value)
                 .subscribe({
                     next: () => this.dialogRef.close(true),
@@ -234,11 +236,11 @@ export class PieceDialogComponent implements OnInit {
                     },
                 });
         } else {
-            this.apiService
+            this.pieceService
                 .createGlobalPiece(this.pieceForm.value)
                 .pipe(
                     switchMap((newlyCreatedPiece) =>
-                        this.apiService.addPieceToMyRepertoire(newlyCreatedPiece.id)
+                        this.pieceService.addPieceToMyRepertoire(newlyCreatedPiece.id)
                     )
                 )
                 .subscribe({


### PR DESCRIPTION
## Summary
- add generic `CrudService` for backend CRUD operations
- refactor `piece.controller` to use `CrudService`
- split piece-related calls out of `ApiService` via new `PieceService`
- use `PieceService` in literature list and piece dialog components

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db075378c83208477b15baa6ca57a