### PR TITLE
Add backend ping route and initial frontend check

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -34,7 +34,7 @@ app.use(limiter);
 app.get("/", (req, res) => {
     res.json({ message: "Welcome to the Choir App API." });
 });
-app.get("/ping", (req, res) => {
+app.get(["/ping", "/api/ping"], (req, res) => {
     res.json({ message: "PONG" });
 });
 

--- a/choir-app-frontend/src/app/app.component.spec.ts
+++ b/choir-app-frontend/src/app/app.component.spec.ts
@@ -1,23 +1,31 @@
 import { TestBed } from '@angular/core/testing';
-import { App } from './app.component';
+import { of } from 'rxjs';
+import { AppComponent } from './app.component';
+import { ApiService } from '@core/services/api.service';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-describe('App', () => {
+class ApiServiceStub {
+  pingBackend() { return of({ message: 'PONG' }); }
+}
+
+describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      imports: [AppComponent, MatSnackBarModule],
+      providers: [{ provide: ApiService, useClass: ApiServiceStub }]
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(App);
+    const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(App);
+    const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, choir-app-frontend');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/choir-app-frontend/src/app/app.component.ts
+++ b/choir-app-frontend/src/app/app.component.ts
@@ -1,17 +1,28 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { ThemeService } from '@core/services/theme.service';
+import { ApiService } from '@core/services/api.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterModule],
+  imports: [RouterModule, MatSnackBarModule],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  constructor(private themeService: ThemeService) {
+  constructor(private themeService: ThemeService,
+              private api: ApiService,
+              private snackBar: MatSnackBar) {
     // Rufen Sie die Initialisierungsmethode auf, wenn die App startet.
     this.themeService.initializeTheme();
+
+    this.api.pingBackend().subscribe({
+      error: () => this.snackBar.open('Backend nicht erreichbar', 'Close', {
+        duration: 5000,
+        verticalPosition: 'top'
+      })
+    });
   }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -22,6 +22,10 @@ export class ApiService {
 
   constructor(private http: HttpClient) { }
 
+  pingBackend(): Observable<{ message: string }> {
+    return this.http.get<{ message: string }>(`${this.apiUrl}/ping`);
+  }
+
   // --- Repertoire Methods (Choir-Specific) ---
 
   /**


### PR DESCRIPTION
## Summary
- add `/api/ping` route in backend
- expose `pingBackend()` in API service
- call `pingBackend()` when the Angular app starts and show a snackbar if it fails
- update unit test

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f01a71c8320bca3d762877e0e02