### PR TITLE
Add global margin for material card headers

### DIFF
--- a/choir-app-frontend/src/styles.scss
+++ b/choir-app-frontend/src/styles.scss
@@ -14,6 +14,11 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
     padding: 2rem;
 }
 
+// Add space below all Material card headers
+mat-card-header {
+  margin-bottom: 1rem;
+}
+
 // Wenden Sie das helle Theme standardmäßig auf den body an.
 // Dies ist wichtig, damit immer ein Theme vorhanden ist.
 // Das Theme wird bereits weiter oben eingebunden, daher genügt


### PR DESCRIPTION
## Summary
- add 1rem bottom margin for `mat-card-header`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3696b5f483208b2cfeb6c98c0b83