### PR TITLE
Allow directors to view choir info

### DIFF
--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -2,13 +2,16 @@ const { verifyToken, isChoirAdminOrAdmin } = require("../middleware/auth.middlew
 const controller = require("../controllers/choir-management.controller");
 const router = require("express").Router();
 
-// Alle Routen hier erfordern mindestens "Choir Admin"-Rechte für den aktiven Chor
-router.use(verifyToken, isChoirAdminOrAdmin);
+// Zuerst stellen wir sicher, dass der Benutzer authentifiziert ist
+router.use(verifyToken);
 
+// Chor-Informationen können von allen Mitgliedern gelesen werden
 router.get("/", controller.getMyChoirDetails);
-router.put("/", controller.updateMyChoir);
-router.get("/members", controller.getChoirMembers);
-router.post("/members", controller.inviteUserToChoir);
-router.delete("/members", controller.removeUserFromChoir);
+
+// Alle folgenden Routen erfordern Choir-Admin-Rechte
+router.put("/", isChoirAdminOrAdmin, controller.updateMyChoir);
+router.get("/members", isChoirAdminOrAdmin, controller.getChoirMembers);
+router.post("/members", isChoirAdminOrAdmin, controller.inviteUserToChoir);
+router.delete("/members", isChoirAdminOrAdmin, controller.removeUserFromChoir);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -17,7 +17,6 @@ import { ManageAuthorsComponent } from '@features/admin/manage-authors/manage-au
 import { LoginGuard } from '@core/guards/login.guard';
 import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
-import { ChoirAdminGuard } from '@core/guards/choir-admin-guard';
 import { ManageChoirResolver } from '@features/choir-management/manage-choir-resolver';
 import { EventListComponent } from '@features/events/event-list/event-list.component';
 import { InviteRegistrationComponent } from '@features/registration/invite-registration.component';
@@ -84,7 +83,7 @@ export const routes: Routes = [
             {
                 path: 'manage-choir',
                 component: ManageChoirComponent,
-                canActivate: [AuthGuard, ChoirAdminGuard],
+                canActivate: [AuthGuard],
                 resolve: {pageData: ManageChoirResolver }
             },
         ],

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -22,7 +22,7 @@
           <textarea matInput formControlName="description" rows="4"></textarea>
         </mat-form-field>
         <div class="actions-footer">
-          <button mat-flat-button color="primary" type="submit" [disabled]="choirForm.invalid || choirForm.pristine">
+          <button mat-flat-button color="primary" type="submit" [disabled]="choirForm.invalid || choirForm.pristine || !isChoirAdmin">
             Save Details
           </button>
         </div>
@@ -31,7 +31,7 @@
   </mat-card>
 
   <!-- Card für die Mitglieder-Verwaltung -->
-  <mat-card class="table-card">
+  <mat-card class="table-card" *ngIf="isChoirAdmin">
     <mat-card-header>
       <mat-card-title>Choir Members</mat-card-title>
       <button mat-flat-button color="accent" (click)="openInviteDialog()">

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -25,6 +25,8 @@ import { ActivatedRoute } from '@angular/router';
 export class ManageChoirComponent implements OnInit {
   choirForm: FormGroup;
 
+  isChoirAdmin = false;
+
   // Für die Mitglieder-Tabelle
   displayedColumns: string[] = ['name', 'email', 'role', 'status', 'actions'];
   dataSource = new MatTableDataSource<UserInChoir>();
@@ -49,6 +51,10 @@ export class ManageChoirComponent implements OnInit {
       if (pageData) {
         // Füllen Sie das Formular und die Tabelle
         this.choirForm.patchValue(pageData.choirDetails);
+        this.isChoirAdmin = pageData.isChoirAdmin;
+        if (!this.isChoirAdmin) {
+          this.choirForm.disable();
+        }
         this.dataSource.data = pageData.members;
       }
     });
@@ -57,9 +63,11 @@ export class ManageChoirComponent implements OnInit {
   private reloadData(): void {
     // Sie könnten einen API-Aufruf machen oder, noch besser, zur Seite neu navigieren,
     // um den Resolver erneut auszulösen.
-    this.apiService.getChoirMembers().subscribe(members => {
-        this.dataSource.data = members;
-    });
+    if (this.isChoirAdmin) {
+      this.apiService.getChoirMembers().subscribe(members => {
+          this.dataSource.data = members;
+      });
+    }
   }
 
   onSaveChoirDetails(): void {
@@ -76,6 +84,9 @@ export class ManageChoirComponent implements OnInit {
   }
 
   openInviteDialog(): void {
+    if (!this.isChoirAdmin) {
+      return;
+    }
     const dialogRef = this.dialog.open(InviteUserDialogComponent, {
       width: '450px'
     });
@@ -94,6 +105,9 @@ export class ManageChoirComponent implements OnInit {
   }
 
   removeMember(user: UserInChoir): void {
+    if (!this.isChoirAdmin) {
+      return;
+    }
     const dialogData: ConfirmDialogData = {
       title: 'Remove Member?',
       message: `Are you sure you want to remove ${user.name} (${user.email}) from this choir? This cannot be undone.`


### PR DESCRIPTION
## Summary
- adjust backend choir routes to allow directors to read choir details while keeping other actions restricted
- modify resolver so directors only load choir members when they are choir admins
- update manage-choir component for read-only mode and hide members for directors
- remove choir admin guard from routing

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e3803236c8320a51ea686c0a3f8eb