### PR TITLE
Add filtering and pagination for ManageComposers

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
@@ -2,6 +2,12 @@
   <button mat-flat-button color="primary" (click)="addComposer()">Add Composer</button>
 </div>
 
+<div class="letter-filter">
+  <button mat-button *ngFor="let l of letters" (click)="onLetterSelect(l)" [color]="selectedLetter === l ? 'primary' : undefined">
+    {{ l }}
+  </button>
+</div>
+
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
@@ -33,3 +39,5 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
+
+<mat-paginator [length]="totalComposers" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons></mat-paginator>

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.scss
@@ -5,3 +5,10 @@ table {
 .toolbar {
   margin-bottom: 1rem;
 }
+
+.letter-filter {
+  margin-bottom: 1rem;
+  button {
+    min-width: 32px;
+  }
+}


### PR DESCRIPTION
## Summary
- add paginator and alpha filter to ManageComposers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4f063f908320afac05cc5ccf7881