### PR TITLE
Show events in table with pagination

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -9,18 +9,49 @@
   </mat-form-field>
 </div>
 
-<mat-list>
-  <mat-list-item *ngFor="let ev of events$ | async" (click)="selectEvent(ev)">
-    <div matListItemTitle>{{ ev.date | date:'shortDate' }} - {{ ev.type }}</div>
-    <div matListItemLine class="meta-info">Zuletzt geändert am {{ ev.updatedAt | date:'short' }} von {{ ev.director?.name }}</div>
-    <span class="spacer"></span>
-    <button mat-icon-button (click)="editEvent(ev); $event.stopPropagation()">
-      <mat-icon>edit</mat-icon>
-    </button>
-    <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button color="warn" (click)="deleteEvent(ev); $event.stopPropagation()">
-      <mat-icon>delete</mat-icon>
-    </button>
-  </mat-list-item>
-</mat-list>
+
+<div class="table-wrapper mat-elevation-z4">
+  <table mat-table [dataSource]="dataSource" class="event-table">
+    <ng-container matColumnDef="date">
+      <th mat-header-cell *matHeaderCellDef>Datum</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef>Typ</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.type }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="updatedAt">
+      <th mat-header-cell *matHeaderCellDef>Geändert</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.updatedAt | date:'short' }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="director">
+      <th mat-header-cell *matHeaderCellDef>Leiter</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.director?.name }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let ev" class="actions-cell">
+        <button mat-icon-button (click)="editEvent(ev); $event.stopPropagation()">
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button color="warn" (click)="deleteEvent(ev); $event.stopPropagation()">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectEvent(row)"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Events gefunden.</td>
+    </tr>
+  </table>
+
+  <mat-paginator [pageSizeOptions]="[5, 10, 25]" showFirstLastButtons></mat-paginator>
+</div>
 
 <app-event-card *ngIf="selectedEvent" cardTitle="Gesungene Literatur" [event]="selectedEvent"></app-event-card>

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.scss
@@ -5,3 +5,12 @@
 .spacer {
   flex: 1 1 auto;
 }
+
+.table-wrapper {
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.actions-cell {
+  text-align: right;
+}

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -7,7 +7,8 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { Event } from '@core/models/event';
-import { Observable, switchMap } from 'rxjs';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
 import { startWith } from 'rxjs/operators';
 import { EventDialogComponent } from '../event-dialog/event-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
@@ -22,10 +23,13 @@ import { EventCardComponent } from '../../dashboard/event-card/event-card.compon
 })
 export class EventListComponent implements OnInit {
   typeControl = new FormControl('ALL');
-  events$!: Observable<Event[]>;
+  displayedColumns: string[] = ['date', 'type', 'updatedAt', 'director', 'actions'];
+  dataSource = new MatTableDataSource<Event>();
   selectedEvent: Event | null = null;
   isChoirAdmin = false;
   isAdmin = false;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
 
   constructor(private apiService: ApiService, private authService: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {}
 
@@ -38,8 +42,14 @@ export class EventListComponent implements OnInit {
 
   private loadEvents(): void {
     const type = this.typeControl.value;
-    this.events$ = this.apiService.getEvents(type === 'ALL' ? undefined : (type as any));
-    this.selectedEvent = null;
+    this.apiService.getEvents(type === 'ALL' ? undefined : (type as any))
+      .subscribe(events => {
+        this.dataSource.data = events;
+        if (this.paginator) {
+          this.dataSource.paginator = this.paginator;
+        }
+        this.selectedEvent = null;
+      });
   }
 
   selectEvent(event: Event): void {


### PR DESCRIPTION
## Summary
- switch event list to Material table
- add paginator support
- adjust event list styles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e56f2bbe4832086078eaf0ee51e1e