### PR TITLE
Translate event type labels

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -19,7 +19,7 @@
 
     <ng-container matColumnDef="type">
       <th mat-header-cell *matHeaderCellDef>Typ</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.type }}</td>
+      <td mat-cell *matCellDef="let ev">{{ ev.type | eventTypeLabel }}</td>
     </ng-container>
 
     <ng-container matColumnDef="updatedAt">

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -12,12 +12,19 @@ import { MatPaginator } from '@angular/material/paginator';
 import { startWith } from 'rxjs/operators';
 import { EventDialogComponent } from '../event-dialog/event-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
 import { EventCardComponent } from '../../dashboard/event-card/event-card.component';
 
 @Component({
   selector: 'app-event-list',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MaterialModule, EventCardComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MaterialModule,
+    EventCardComponent,
+    EventTypeLabelPipe
+  ],
   templateUrl: './event-list.component.html',
   styleUrls: ['./event-list.component.scss']
 })

--- a/choir-app-frontend/src/app/shared/pipes/event-type-label.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/event-type-label.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Wandelt die Event-Typen "SERVICE" und "REHEARSAL" in ihre deutschen
+ * Bezeichnungen um.
+ */
+@Pipe({
+  name: 'eventTypeLabel',
+  standalone: true
+})
+export class EventTypeLabelPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+    switch (value) {
+      case 'SERVICE':
+        return 'Gottesdienst';
+      case 'REHEARSAL':
+        return 'Probe';
+      default:
+        return value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- show German terms for event types using EventTypeLabelPipe
- use the pipe in the event list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5a51c82c83208fb191a9e8730668