### PR TITLE
Add hover state for events table rows

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.scss
@@ -14,3 +14,17 @@
 .actions-cell {
   text-align: right;
 }
+
+.event-table .mat-row {
+  cursor: pointer;
+}
+
+.event-table .mat-row:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+  .event-table .mat-row:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+}


### PR DESCRIPTION
## Summary
- show pointer cursor and highlight Event row on hover

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5a87350083208ec7e39b97fe9ec3