### PR TITLE
Add event creation from events list

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -1,12 +1,19 @@
-<div class="filter-row">
-  <mat-form-field appearance="outline">
-    <mat-label>Typ</mat-label>
-    <mat-select [formControl]="typeControl">
-      <mat-option value="ALL">Alle</mat-option>
-      <mat-option value="SERVICE">Gottesdienste</mat-option>
-      <mat-option value="REHEARSAL">Proben</mat-option>
-    </mat-select>
-  </mat-form-field>
+<div class="header-row">
+  <div class="filter-row">
+    <mat-form-field appearance="outline">
+      <mat-label>Typ</mat-label>
+      <mat-select [formControl]="typeControl">
+        <mat-option value="ALL">Alle</mat-option>
+        <mat-option value="SERVICE">Gottesdienste</mat-option>
+        <mat-option value="REHEARSAL">Proben</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+  <span class="spacer"></span>
+  <button mat-flat-button color="primary" (click)="openAddEventDialog()">
+    <mat-icon>add</mat-icon>
+    <span>Neues Ereignis</span>
+  </button>
 </div>
 
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.scss
@@ -1,4 +1,11 @@
+
 .filter-row {
+  margin-bottom: 0;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
   margin-bottom: 1rem;
 }
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -6,7 +6,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
-import { Event } from '@core/models/event';
+import { CreateEventResponse, Event } from '@core/models/event';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { startWith } from 'rxjs/operators';
@@ -76,6 +76,24 @@ export class EventListComponent implements OnInit {
         this.apiService.deleteEvent(event.id).subscribe({
           next: () => { this.snackBar.open('Event deleted.', 'OK', { duration: 3000 }); this.loadEvents(); },
           error: () => this.snackBar.open('Error deleting event.', 'Close', { duration: 4000 })
+        });
+      }
+    });
+  }
+
+  openAddEventDialog(): void {
+    const dialogRef = this.dialog.open(EventDialogComponent, { width: '600px', disableClose: true });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.apiService.createEvent(result).subscribe({
+          next: (response: CreateEventResponse) => {
+            const message = response.wasUpdated ?
+              'Event für diesen Tag wurde aktualisiert!' :
+              'Event erfolgreich angelegt!';
+            this.snackBar.open(message, 'OK', { duration: 3000 });
+            this.loadEvents();
+          },
+          error: () => this.snackBar.open('Fehler: Das Event konnte nicht gespeichert werden.', 'Schließen', { duration: 5000 })
         });
       }
     });


### PR DESCRIPTION
## Summary
- add header row with create button to event list
- style header
- implement `openAddEventDialog` in event list component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ac2182083208d25eb641ec63c59