### PR TITLE
Fix Angular spec names

### DIFF
--- a/choir-app-frontend/src/app/core/services/theme.service.spec.ts
+++ b/choir-app-frontend/src/app/core/services/theme.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Theme } from './theme.service';
+import { ThemeService } from './theme.service';
 
-describe('Theme', () => {
-  let service: Theme;
+describe('ThemeService', () => {
+  let service: ThemeService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(Theme);
+    service = TestBed.inject(ThemeService);
   });
 
   it('should be created', () => {

--- a/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { CategoryDialog } from './category-dialog.component';
+import { CategoryDialogComponent } from './category-dialog.component';
 
-describe('CategoryDialog', () => {
-  let component: CategoryDialog;
-  let fixture: ComponentFixture<CategoryDialog>;
+describe('CategoryDialogComponent', () => {
+  let component: CategoryDialogComponent;
+  let fixture: ComponentFixture<CategoryDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CategoryDialog]
+      imports: [CategoryDialogComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(CategoryDialog);
+    fixture = TestBed.createComponent(CategoryDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { InviteUserDialog } from './invite-user-dialog.component';
+import { InviteUserDialogComponent } from './invite-user-dialog.component';
 
-describe('InviteUserDialog', () => {
-  let component: InviteUserDialog;
-  let fixture: ComponentFixture<InviteUserDialog>;
+describe('InviteUserDialogComponent', () => {
+  let component: InviteUserDialogComponent;
+  let fixture: ComponentFixture<InviteUserDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [InviteUserDialog]
+      imports: [InviteUserDialogComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(InviteUserDialog);
+    fixture = TestBed.createComponent(InviteUserDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.spec.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ManageChoir } from './manage-choir.component';
+import { ManageChoirComponent } from './manage-choir.component';
 
-describe('ManageChoir', () => {
-  let component: ManageChoir;
-  let fixture: ComponentFixture<ManageChoir>;
+describe('ManageChoirComponent', () => {
+  let component: ManageChoirComponent;
+  let fixture: ComponentFixture<ManageChoirComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ManageChoir]
+      imports: [ManageChoirComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(ManageChoir);
+    fixture = TestBed.createComponent(ManageChoirComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { CollectionEdit } from './collection-edit.component';
+import { CollectionEditComponent } from './collection-edit.component';
 
-describe('CollectionEdit', () => {
-  let component: CollectionEdit;
-  let fixture: ComponentFixture<CollectionEdit>;
+describe('CollectionEditComponent', () => {
+  let component: CollectionEditComponent;
+  let fixture: ComponentFixture<CollectionEditComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CollectionEdit]
+      imports: [CollectionEditComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(CollectionEdit);
+    fixture = TestBed.createComponent(CollectionEditComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { CollectionList } from './collection-list.component';
+import { CollectionListComponent } from './collection-list.component';
 
-describe('CollectionList', () => {
-  let component: CollectionList;
-  let fixture: ComponentFixture<CollectionList>;
+describe('CollectionListComponent', () => {
+  let component: CollectionListComponent;
+  let fixture: ComponentFixture<CollectionListComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CollectionList]
+      imports: [CollectionListComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(CollectionList);
+    fixture = TestBed.createComponent(CollectionListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ImportDialog } from './import-dialog.component';
+import { ImportDialogComponent } from './import-dialog.component';
 
-describe('ImportDialog', () => {
-  let component: ImportDialog;
-  let fixture: ComponentFixture<ImportDialog>;
+describe('ImportDialogComponent', () => {
+  let component: ImportDialogComponent;
+  let fixture: ComponentFixture<ImportDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ImportDialog]
+      imports: [ImportDialogComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(ImportDialog);
+    fixture = TestBed.createComponent(ImportDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/choir-app-frontend/src/app/features/dashboard/dashboard.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Dashboard } from './dashboard.component';
+import { DashboardComponent } from './dashboard.component';
 
-describe('Dashboard', () => {
-  let component: Dashboard;
-  let fixture: ComponentFixture<Dashboard>;
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Dashboard]
+      imports: [DashboardComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Dashboard);
+    fixture = TestBed.createComponent(DashboardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/dashboard/event-card/event-card.component.spec.ts
+++ b/choir-app-frontend/src/app/features/dashboard/event-card/event-card.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { EventCard } from './event-card.component';
+import { EventCardComponent } from './event-card.component';
 
-describe('EventCard', () => {
-  let component: EventCard;
-  let fixture: ComponentFixture<EventCard>;
+describe('EventCardComponent', () => {
+  let component: EventCardComponent;
+  let fixture: ComponentFixture<EventCardComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EventCard]
+      imports: [EventCardComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(EventCard);
+    fixture = TestBed.createComponent(EventCardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { EventDialog } from './event-dialog.component';
+import { EventDialogComponent } from './event-dialog.component';
 
-describe('EventDialog', () => {
-  let component: EventDialog;
-  let fixture: ComponentFixture<EventDialog>;
+describe('EventDialogComponent', () => {
+  let component: EventDialogComponent;
+  let fixture: ComponentFixture<EventDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EventDialog]
+      imports: [EventDialogComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(EventDialog);
+    fixture = TestBed.createComponent(EventDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/home/home.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/home.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Home } from './home.component';
+import { HomeComponent } from './home.component';
 
-describe('Home', () => {
-  let component: Home;
-  let fixture: ComponentFixture<Home>;
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Home]
+      imports: [HomeComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Home);
+    fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/legal/imprint/imprint.component.spec.ts
+++ b/choir-app-frontend/src/app/features/legal/imprint/imprint.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Imprint } from './imprint.component';
+import { ImprintComponent } from './imprint.component';
 
-describe('Imprint', () => {
-  let component: Imprint;
-  let fixture: ComponentFixture<Imprint>;
+describe('ImprintComponent', () => {
+  let component: ImprintComponent;
+  let fixture: ComponentFixture<ImprintComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Imprint]
+      imports: [ImprintComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Imprint);
+    fixture = TestBed.createComponent(ImprintComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/legal/privacy/privacy.component.spec.ts
+++ b/choir-app-frontend/src/app/features/legal/privacy/privacy.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Privacy } from './privacy.component';
+import { PrivacyComponent } from './privacy.component';
 
-describe('Privacy', () => {
-  let component: Privacy;
-  let fixture: ComponentFixture<Privacy>;
+describe('PrivacyComponent', () => {
+  let component: PrivacyComponent;
+  let fixture: ComponentFixture<PrivacyComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Privacy]
+      imports: [PrivacyComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Privacy);
+    fixture = TestBed.createComponent(PrivacyComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { LiteratureList } from './literature-list';
+import { LiteratureListComponent } from './literature-list.component';
 
-describe('LiteratureList', () => {
-  let component: LiteratureList;
-  let fixture: ComponentFixture<LiteratureList>;
+describe('LiteratureListComponent', () => {
+  let component: LiteratureListComponent;
+  let fixture: ComponentFixture<LiteratureListComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LiteratureList]
+      imports: [LiteratureListComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(LiteratureList);
+    fixture = TestBed.createComponent(LiteratureListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { PieceDialog } from './piece-dialog.component';
+import { PieceDialogComponent } from './piece-dialog.component';
 
-describe('PieceDialog', () => {
-  let component: PieceDialog;
-  let fixture: ComponentFixture<PieceDialog>;
+describe('PieceDialogComponent', () => {
+  let component: PieceDialogComponent;
+  let fixture: ComponentFixture<PieceDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PieceDialog]
+      imports: [PieceDialogComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(PieceDialog);
+    fixture = TestBed.createComponent(PieceDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/features/login/login.component.spec.ts
+++ b/choir-app-frontend/src/app/features/login/login.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Login } from './login.component.js';
+import { LoginComponent } from './login.component';
 
-describe('Login', () => {
-  let component: Login;
-  let fixture: ComponentFixture<Login>;
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Login]
+      imports: [LoginComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Login);
+    fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/layout/footer/footer.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/footer/footer.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Footer } from './footer.component';
+import { FooterComponent } from './footer.component';
 
-describe('Footer', () => {
-  let component: Footer;
-  let fixture: ComponentFixture<Footer>;
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Footer]
+      imports: [FooterComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Footer);
+    fixture = TestBed.createComponent(FooterComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ConfirmDialog } from './confirm-dialog.component';
+import { ConfirmDialogComponent } from './confirm-dialog.component';
 
-describe('ConfirmDialog', () => {
-  let component: ConfirmDialog;
-  let fixture: ComponentFixture<ConfirmDialog>;
+describe('ConfirmDialogComponent', () => {
+  let component: ConfirmDialogComponent;
+  let fixture: ComponentFixture<ConfirmDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ConfirmDialog]
+      imports: [ConfirmDialogComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(ConfirmDialog);
+    fixture = TestBed.createComponent(ConfirmDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/choir-app-frontend/src/app/shared/components/error-display/error-display.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/error-display/error-display.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ErrorDisplay } from './error-display.component';
+import { ErrorDisplayComponent } from './error-display.component';
 
-describe('ErrorDisplay', () => {
-  let component: ErrorDisplay;
-  let fixture: ComponentFixture<ErrorDisplay>;
+describe('ErrorDisplayComponent', () => {
+  let component: ErrorDisplayComponent;
+  let fixture: ComponentFixture<ErrorDisplayComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ErrorDisplay]
+      imports: [ErrorDisplayComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(ErrorDisplay);
+    fixture = TestBed.createComponent(ErrorDisplayComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
## Summary
- fix component references in Angular unit tests

## Testing
- `ng test --watch=false --progress=false --browsers=ChromeHeadlessCI` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5b66031483208e93f77feb4e70e5