### PR TITLE
Enable admin access for choir management

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -4,6 +4,7 @@ import { Observable, forkJoin, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { ApiService } from 'src/app/core/services/api.service';
 import { ErrorService } from 'src/app/core/services/error.service';
+import { AuthService } from 'src/app/core/services/auth.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,29 +13,41 @@ export class ManageChoirResolver implements Resolve<any> {
   constructor(
     private apiService: ApiService,
     private errorService: ErrorService,
-    private router: Router
+    private router: Router,
+    private authService: AuthService
   ) {}
 
   resolve(): Observable<any> {
     // Leeren Sie alte Fehler, bevor Sie eine neue Seite laden
     this.errorService.clearError();
 
-    return this.apiService.checkChoirAdminStatus().pipe(
-      switchMap(status => {
+    return this.authService.isAdmin$.pipe(
+      switchMap(isAdmin => {
         const choirDetails$ = this.apiService.getMyChoirDetails();
-        if (status.isChoirAdmin) {
+        if (isAdmin) {
           return forkJoin({
             choirDetails: choirDetails$,
             members: this.apiService.getChoirMembers(),
             isChoirAdmin: of(true)
           });
-        } else {
-          return forkJoin({
-            choirDetails: choirDetails$,
-            members: of([]),
-            isChoirAdmin: of(false)
-          });
         }
+        return this.apiService.checkChoirAdminStatus().pipe(
+          switchMap(status => {
+            if (status.isChoirAdmin) {
+              return forkJoin({
+                choirDetails: choirDetails$,
+                members: this.apiService.getChoirMembers(),
+                isChoirAdmin: of(true)
+              });
+            } else {
+              return forkJoin({
+                choirDetails: choirDetails$,
+                members: of([]),
+                isChoirAdmin: of(false)
+              });
+            }
+          })
+        );
       }),
       catchError((error) => {
         const errorMessage = error.error?.message || 'Could not load data for choir management.';


### PR DESCRIPTION
## Summary
- give `ManageChoirResolver` access to `AuthService`
- treat global admins the same as choir admins so they can manage choirs

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5cb28ecc83209a16ec68a9173f7e