### PR TITLE
Add admin pages for choir and user management

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -10,4 +10,114 @@ exports.getAll = (model) => async (req, res) => {
     }
 };
 
-// ... hier würden auch Funktionen für create, update, delete stehen ...
+// Erstellt ein neues Element eines gegebenen Modells
+exports.create = (model) => async (req, res) => {
+    try {
+        const item = await model.create(req.body);
+        res.status(201).send(item);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+// Aktualisiert ein bestehendes Element
+exports.update = (model) => async (req, res) => {
+    const { id } = req.params;
+    try {
+        const [num] = await model.update(req.body, { where: { id } });
+        if (num === 1) {
+            const item = await model.findByPk(id);
+            res.status(200).send(item);
+        } else {
+            res.status(404).send({ message: 'Not found' });
+        }
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+// Löscht ein Element
+exports.remove = (model) => async (req, res) => {
+    const { id } = req.params;
+    try {
+        const num = await model.destroy({ where: { id } });
+        if (num === 1) {
+            res.status(204).send();
+        } else {
+            res.status(404).send({ message: 'Not found' });
+        }
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+// Spezielle Abfrage für Benutzer inklusive Chöre
+exports.getAllUsers = async (req, res) => {
+    try {
+        const users = await db.user.findAll({
+            order: [['name', 'ASC']],
+            include: [{
+                model: db.choir,
+                as: 'choirs',
+                attributes: ['id', 'name'],
+                through: { attributes: ['roleInChoir', 'registrationStatus'] }
+            }]
+        });
+        res.status(200).send(users);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+const bcrypt = require('bcryptjs');
+
+exports.createUser = async (req, res) => {
+    const { name, email, password, role } = req.body;
+    try {
+        const user = await db.user.create({
+            name,
+            email,
+            role: role || 'director',
+            password: password ? bcrypt.hashSync(password, 8) : null
+        });
+        res.status(201).send(user);
+    } catch (err) {
+        if (err.name === 'SequelizeUniqueConstraintError') {
+            res.status(409).send({ message: 'Email already in use.' });
+        } else {
+            res.status(500).send({ message: err.message });
+        }
+    }
+};
+
+exports.updateUser = async (req, res) => {
+    const { id } = req.params;
+    const { name, email, password, role } = req.body;
+    try {
+        const user = await db.user.findByPk(id);
+        if (!user) return res.status(404).send({ message: 'Not found' });
+        await user.update({
+            name: name ?? user.name,
+            email: email ?? user.email,
+            role: role ?? user.role,
+            ...(password ? { password: bcrypt.hashSync(password, 8) } : {})
+        });
+        res.status(200).send(user);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.deleteUser = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const num = await db.user.destroy({ where: { id } });
+        if (num === 1) {
+            res.status(204).send();
+        } else {
+            res.status(404).send({ message: 'Not found' });
+        }
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -16,10 +16,14 @@ router.get("/authors", controller.getAll(db.author));
 
 // Routen für Chöre
 router.get("/choirs", controller.getAll(db.choir));
-// ...
+router.post("/choirs", controller.create(db.choir));
+router.put("/choirs/:id", controller.update(db.choir));
+router.delete("/choirs/:id", controller.remove(db.choir));
 
 // Routen für Benutzer
-router.get("/users", controller.getAll(db.user));
-// ...
+router.get("/users", controller.getAllUsers);
+router.post("/users", controller.createUser);
+router.put("/users/:id", controller.updateUser);
+router.delete("/users/:id", controller.deleteUser);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -14,6 +14,8 @@ import { PrivacyComponent } from '@features/legal/privacy/privacy.component';
 import { AdminGuard } from '@core/guards/admin-guard';
 import { ManageComposersComponent } from '@features/admin/manage-composers/manage-composers.component';
 import { ManageAuthorsComponent } from '@features/admin/manage-authors/manage-authors.component';
+import { ManageChoirsComponent } from '@features/admin/manage-choirs/manage-choirs.component';
+import { ManageUsersComponent } from '@features/admin/manage-users/manage-users.component';
 import { LoginGuard } from '@core/guards/login.guard';
 import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
@@ -96,7 +98,8 @@ export const routes: Routes = [
             { path: '', redirectTo: 'composers', pathMatch: 'full' },
             { path: 'composers', component: ManageComposersComponent },
             { path: 'authors', component: ManageAuthorsComponent },
-            // ... andere Admin-Seiten
+            { path: 'choirs', component: ManageChoirsComponent },
+            { path: 'users', component: ManageUsersComponent },
         ],
     },
 

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -281,6 +281,40 @@ export class ApiService {
     return this.http.delete(`${this.apiUrl}/choir-management/members`, options);
   }
 
+  // --- Admin Methods ---
+
+  getAdminChoirs(): Observable<Choir[]> {
+    return this.http.get<Choir[]>(`${this.apiUrl}/admin/choirs`);
+  }
+
+  createChoir(data: { name: string; description?: string; location?: string }): Observable<Choir> {
+    return this.http.post<Choir>(`${this.apiUrl}/admin/choirs`, data);
+  }
+
+  updateChoir(id: number, data: { name: string; description?: string; location?: string }): Observable<Choir> {
+    return this.http.put<Choir>(`${this.apiUrl}/admin/choirs/${id}`, data);
+  }
+
+  deleteChoir(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/admin/choirs/${id}`);
+  }
+
+  getUsers(): Observable<User[]> {
+    return this.http.get<User[]>(`${this.apiUrl}/admin/users`);
+  }
+
+  createUser(data: any): Observable<User> {
+    return this.http.post<User>(`${this.apiUrl}/admin/users`, data);
+  }
+
+  updateUser(id: number, data: any): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/admin/users/${id}`, data);
+  }
+
+  deleteUser(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/admin/users/${id}`);
+  }
+
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {
     return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
   }

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -1,0 +1,21 @@
+<h1 mat-dialog-title>{{ title }}</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" id="choir-form" (ngSubmit)="onSave()">
+    <mat-form-field appearance="outline">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" cdkFocusInitial>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Description</mat-label>
+      <textarea matInput formControlName="description"></textarea>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Location</mat-label>
+      <input matInput formControlName="location">
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-flat-button color="primary" type="submit" form="choir-form" [disabled]="form.invalid">Save</button>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  display: block;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { Choir } from 'src/app/core/models/choir';
+
+@Component({
+  selector: 'app-choir-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './choir-dialog.component.html',
+  styleUrls: ['./choir-dialog.component.scss']
+})
+export class ChoirDialogComponent {
+  form: FormGroup;
+  title = 'Add Choir';
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<ChoirDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: Choir | null
+  ) {
+    this.title = data ? 'Edit Choir' : 'Add Choir';
+    this.form = this.fb.group({
+      name: [data?.name || '', Validators.required],
+      description: [data?.description || ''],
+      location: [data?.location || '']
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onSave(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
@@ -1,0 +1,30 @@
+<div class="toolbar">
+  <button mat-flat-button color="primary" (click)="addChoir()">Add Choir</button>
+</div>
+
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="location">
+    <th mat-header-cell *matHeaderCellDef>Location</th>
+    <td mat-cell *matCellDef="let element">{{ element.location }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef></th>
+    <td mat-cell *matCellDef="let element">
+      <button mat-icon-button color="primary" (click)="editChoir(element)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button color="warn" (click)="deleteChoir(element)">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.scss
@@ -1,0 +1,7 @@
+.table {
+  width: 100%;
+}
+
+.toolbar {
+  margin-bottom: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from 'src/app/core/services/api.service';
+import { Choir } from 'src/app/core/models/choir';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatDialog } from '@angular/material/dialog';
+import { ChoirDialogComponent } from './choir-dialog/choir-dialog.component';
+
+@Component({
+  selector: 'app-manage-choirs',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, ChoirDialogComponent],
+  templateUrl: './manage-choirs.component.html',
+  styleUrls: ['./manage-choirs.component.scss']
+})
+export class ManageChoirsComponent implements OnInit {
+  choirs: Choir[] = [];
+  displayedColumns = ['name', 'location', 'actions'];
+  dataSource = new MatTableDataSource<Choir>();
+
+  constructor(private api: ApiService, private dialog: MatDialog) {}
+
+  ngOnInit(): void {
+    this.loadChoirs();
+  }
+
+  loadChoirs(): void {
+    this.api.getAdminChoirs().subscribe(data => {
+      this.choirs = data;
+      this.dataSource.data = data;
+    });
+  }
+
+  addChoir(): void {
+    const ref = this.dialog.open(ChoirDialogComponent, { width: '400px' });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.api.createChoir(result).subscribe(() => this.loadChoirs());
+      }
+    });
+  }
+
+  editChoir(choir: Choir): void {
+    const ref = this.dialog.open(ChoirDialogComponent, { width: '400px', data: choir });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.api.updateChoir(choir.id, result).subscribe(() => this.loadChoirs());
+      }
+    });
+  }
+
+  deleteChoir(choir: Choir): void {
+    if (confirm('Delete choir?')) {
+      this.api.deleteChoir(choir.id).subscribe(() => this.loadChoirs());
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -1,0 +1,40 @@
+<div class="toolbar">
+  <button mat-flat-button color="primary" (click)="addUser()">Add User</button>
+</div>
+
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="email">
+    <th mat-header-cell *matHeaderCellDef>Email</th>
+    <td mat-cell *matCellDef="let element">{{ element.email }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="role">
+    <th mat-header-cell *matHeaderCellDef>Role</th>
+    <td mat-cell *matCellDef="let element">{{ element.role }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="choirs">
+    <th mat-header-cell *matHeaderCellDef>Choirs</th>
+    <td mat-cell *matCellDef="let element">{{ choirList(element) }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef></th>
+    <td mat-cell *matCellDef="let element">
+      <button mat-icon-button color="primary" (click)="editUser(element)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button color="warn" (click)="deleteUser(element)">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
@@ -1,0 +1,7 @@
+.table {
+  width: 100%;
+}
+
+.toolbar {
+  margin-bottom: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -1,0 +1,29 @@
+<h1 mat-dialog-title>{{ title }}</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" id="user-form" (ngSubmit)="onSave()">
+    <mat-form-field appearance="outline">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" cdkFocusInitial>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Email</mat-label>
+      <input matInput formControlName="email">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Role</mat-label>
+      <mat-select formControlName="role">
+        <mat-option value="director">director</mat-option>
+        <mat-option value="choir_admin">choir_admin</mat-option>
+        <mat-option value="admin">admin</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Password</mat-label>
+      <input matInput formControlName="password" type="password">
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-flat-button color="primary" type="submit" form="user-form" [disabled]="form.invalid">Save</button>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.scss
@@ -1,0 +1,3 @@
+mat-form-field {
+  display: block;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -1,0 +1,46 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { User } from 'src/app/core/models/user';
+
+@Component({
+  selector: 'app-user-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './user-dialog.component.html',
+  styleUrls: ['./user-dialog.component.scss']
+})
+export class UserDialogComponent {
+  form: FormGroup;
+  title = 'Add User';
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<UserDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: User | null
+  ) {
+    this.title = data ? 'Edit User' : 'Add User';
+    this.form = this.fb.group({
+      name: [data?.name || '', Validators.required],
+      email: [data?.email || '', [Validators.required, Validators.email]],
+      role: [data?.role || 'director', Validators.required],
+      password: ['']
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onSave(): void {
+    if (this.form.valid) {
+      const value = { ...this.form.value };
+      if (!value.password) {
+        delete value.password;
+      }
+      this.dialogRef.close(value);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement generic admin CRUD controller
- expose choir and user CRUD routes
- support admin endpoints in ApiService
- add admin pages to manage choirs and users
- add dialog components for choir and user editing
- wire new admin routes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5cfc3bdc832084f179fb21e86b7e