### PR TITLE
Fix hue in menu style

### DIFF
--- a/choir-app-frontend/src/app/shared/components/menu-list-item/menu-list-item.component.scss
+++ b/choir-app-frontend/src/app/shared/components/menu-list-item/menu-list-item.component.scss
@@ -23,16 +23,16 @@
   }
 
   .mat-list-item.active {
-    background-color: mat.get-color-from-palette(nak.$choir-app-primary) !important;
-    color: mat.get-contrast-color-from-palette(nak.$choir-app-primary) !important;
+    background-color: mat.m2-get-color-from-palette(nak.$choir-app-primary, default) !important;
+    color: mat.m2-get-contrast-color-from-palette(nak.$choir-app-primary, default) !important;
   }
 
   &:active,
   &:hover,
   &:focus {
     >a:not(.expanded) {
-      background-color: mat.get-color-from-palette(nak.$choir-app-primary) !important;
-      color: mat.get-contrast-color-from-palette(nak.$choir-app-primary) !important;
+      background-color: mat.m2-get-color-from-palette(nak.$choir-app-primary, default) !important;
+      color: mat.m2-get-contrast-color-from-palette(nak.$choir-app-primary, default) !important;
     }
   }
 


### PR DESCRIPTION
## Summary
- specify palette hue for menu highlight styles

## Testing
- `npm test --silent --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ee222048320821dd68ef0db53c4