### PR TITLE
Add choir statistics page

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -52,6 +52,7 @@ const authorRoutes = require("./routes/author.routes");
 const adminRoutes = require("./routes/admin.routes");
 const choirManagementRoutes = require("./routes/choir-management.routes");
 const invitationRoutes = require("./routes/invitation.routes");
+const statsRoutes = require("./routes/stats.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -66,6 +67,7 @@ app.use("/api/authors", authorRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/choir-management", choirManagementRoutes);
 app.use("/api/invitations", invitationRoutes);
+app.use("/api/stats", statsRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/stats.controller.js
+++ b/choir-app-backend/src/controllers/stats.controller.js
@@ -1,0 +1,56 @@
+const db = require("../models");
+const { Sequelize } = require("sequelize");
+
+exports.overview = async (req, res) => {
+    const choirId = req.activeChoirId;
+    try {
+        // Top pieces in services
+        const topServicePieces = await db.piece.findAll({
+            attributes: [
+                'id',
+                'title',
+                [Sequelize.fn('COUNT', Sequelize.col('events.id')), 'count']
+            ],
+            include: [{
+                model: db.event,
+                attributes: [],
+                where: { choirId, type: 'SERVICE' },
+                through: { attributes: [] }
+            }],
+            group: ['piece.id'],
+            order: [[Sequelize.literal('count'), 'DESC']],
+            limit: 3
+        });
+
+        // Top pieces rehearsed
+        const topRehearsalPieces = await db.piece.findAll({
+            attributes: [
+                'id',
+                'title',
+                [Sequelize.fn('COUNT', Sequelize.col('events.id')), 'count']
+            ],
+            include: [{
+                model: db.event,
+                attributes: [],
+                where: { choirId, type: 'REHEARSAL' },
+                through: { attributes: [] }
+            }],
+            group: ['piece.id'],
+            order: [[Sequelize.literal('count'), 'DESC']],
+            limit: 3
+        });
+
+        // Count singable pieces
+        const singableCount = await db.choir_repertoire.count({
+            where: { choirId, status: 'CAN_BE_SUNG' }
+        });
+
+        res.status(200).send({
+            topServicePieces,
+            topRehearsalPieces,
+            singableCount
+        });
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Error generating statistics.' });
+    }
+};

--- a/choir-app-backend/src/routes/stats.routes.js
+++ b/choir-app-backend/src/routes/stats.routes.js
@@ -1,0 +1,9 @@
+const authJwt = require("../middleware/auth.middleware");
+const controller = require("../controllers/stats.controller");
+const router = require("express").Router();
+
+router.use(authJwt.verifyToken);
+
+router.get('/', controller.overview);
+
+module.exports = router;

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -22,6 +22,7 @@ import { ManageChoirComponent } from '@features/choir-management/manage-choir/ma
 import { ManageChoirResolver } from '@features/choir-management/manage-choir-resolver';
 import { EventListComponent } from '@features/events/event-list/event-list.component';
 import { InviteRegistrationComponent } from '@features/registration/invite-registration.component';
+import { StatisticsComponent } from '@features/stats/statistics.component';
 
 export const routes: Routes = [
     // Die MainLayoutComponent ist jetzt die Wurzel und hat keine Guards
@@ -75,6 +76,11 @@ export const routes: Routes = [
             {
                 path: 'events',
                 component: EventListComponent,
+                canActivate: [AuthGuard]
+            },
+            {
+                path: 'stats',
+                component: StatisticsComponent,
                 canActivate: [AuthGuard]
             },
             {

--- a/choir-app-frontend/src/app/core/models/stats-summary.ts
+++ b/choir-app-frontend/src/app/core/models/stats-summary.ts
@@ -1,0 +1,11 @@
+export interface PieceStat {
+  id: number;
+  title: string;
+  count: number;
+}
+
+export interface StatsSummary {
+  topServicePieces: PieceStat[];
+  topRehearsalPieces: PieceStat[];
+  singableCount: number;
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -14,6 +14,7 @@ import { LookupPiece } from '@core/models/lookup-piece';
 import { Author } from '@core/models/author';
 import { Choir } from '@core/models/choir';
 import { PieceService } from './piece.service';
+import { StatsSummary } from '../models/stats-summary';
 
 @Injectable({
   providedIn: 'root'
@@ -317,6 +318,10 @@ export class ApiService {
 
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {
     return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
+  }
+
+  getStatistics(): Observable<StatsSummary> {
+    return this.http.get<StatsSummary>(`${this.apiUrl}/stats`);
   }
 
   pingBackend(): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/stats/statistics.component.html
@@ -1,0 +1,26 @@
+<div class="stats-page" *ngIf="stats">
+  <h2>Statistik</h2>
+
+  <mat-card>
+    <h3>Top 3 Gottesdienst-Stücke</h3>
+    <ol>
+      <li *ngFor="let item of stats.topServicePieces">
+        {{item.title}} ({{item.count}}x)
+      </li>
+    </ol>
+  </mat-card>
+
+  <mat-card>
+    <h3>Top-geprobte Stücke</h3>
+    <ol>
+      <li *ngFor="let item of stats.topRehearsalPieces">
+        {{item.title}} ({{item.count}}x)
+      </li>
+    </ol>
+  </mat-card>
+
+  <mat-card>
+    <h3>Singfähige Stücke im Repertoire</h3>
+    <p>{{stats.singableCount}}</p>
+  </mat-card>
+</div>

--- a/choir-app-frontend/src/app/features/stats/statistics.component.scss
+++ b/choir-app-frontend/src/app/features/stats/statistics.component.scss
@@ -1,0 +1,5 @@
+.stats-page {
+  mat-card {
+    margin-bottom: 1rem;
+  }
+}

--- a/choir-app-frontend/src/app/features/stats/statistics.component.ts
+++ b/choir-app-frontend/src/app/features/stats/statistics.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { StatsSummary } from '@core/models/stats-summary';
+
+@Component({
+  selector: 'app-statistics',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './statistics.component.html',
+  styleUrls: ['./statistics.component.scss']
+})
+export class StatisticsComponent implements OnInit {
+  stats?: StatsSummary;
+
+  constructor(private apiService: ApiService) {}
+
+  ngOnInit(): void {
+    this.apiService.getStatistics().subscribe(s => this.stats = s);
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -97,6 +97,11 @@ export class MainLayoutComponent implements OnInit{
           visibleSubject: this.isLoggedIn$,
       },
       {
+        displayName: 'Statistik',
+        route: '/stats',
+        visibleSubject: this.isLoggedIn$,
+      },
+      {
         displayName: 'Mein Chor',
         //svgIconName: 's-lens-display',
         route: '/manage-choir',


### PR DESCRIPTION
## Summary
- add backend stats controller and route
- expose `/api/stats` in backend
- create `StatsSummary` model
- implement `getStatistics` in ApiService
- build StatisticsComponent and route `/stats`
- add navigation item for statistics

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ff4e4cc832085d41142f3858e57