### PR TITLE
Fix stats query

### DIFF
--- a/choir-app-backend/src/controllers/stats.controller.js
+++ b/choir-app-backend/src/controllers/stats.controller.js
@@ -19,7 +19,8 @@ exports.overview = async (req, res) => {
             }],
             group: ['piece.id'],
             order: [[Sequelize.literal('count'), 'DESC']],
-            limit: 3
+            limit: 3,
+            subQuery: false
         });
 
         // Top pieces rehearsed
@@ -37,7 +38,8 @@ exports.overview = async (req, res) => {
             }],
             group: ['piece.id'],
             order: [[Sequelize.literal('count'), 'DESC']],
-            limit: 3
+            limit: 3,
+            subQuery: false
         });
 
         // Count singable pieces


### PR DESCRIPTION
## Summary
- ensure event join is included for stats query

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6932e54c832091040805627a9a24