### PR TITLE
Implement password reset workflow

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -53,6 +53,7 @@ const adminRoutes = require("./routes/admin.routes");
 const choirManagementRoutes = require("./routes/choir-management.routes");
 const invitationRoutes = require("./routes/invitation.routes");
 const statsRoutes = require("./routes/stats.routes");
+const passwordResetRoutes = require("./routes/password-reset.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -68,6 +69,7 @@ app.use("/api/admin", adminRoutes);
 app.use("/api/choir-management", choirManagementRoutes);
 app.use("/api/invitations", invitationRoutes);
 app.use("/api/stats", statsRoutes);
+app.use("/api/password-reset", passwordResetRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -121,3 +121,22 @@ exports.deleteUser = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+const crypto = require('crypto');
+const emailService = require('../services/email.service');
+
+exports.sendPasswordReset = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const user = await db.user.findByPk(id);
+        if (user) {
+            const token = crypto.randomBytes(32).toString('hex');
+            const expiry = new Date(Date.now() + 60 * 60 * 1000);
+            await user.update({ resetToken: token, resetTokenExpiry: expiry });
+            await emailService.sendPasswordResetMail(user.email, token);
+        }
+        res.status(200).send({ message: 'Reset email sent if user exists.' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/controllers/password-reset.controller.js
+++ b/choir-app-backend/src/controllers/password-reset.controller.js
@@ -1,0 +1,51 @@
+const db = require('../models');
+const { Op } = require('sequelize');
+const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
+const emailService = require('../services/email.service');
+
+exports.requestPasswordReset = async (req, res) => {
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).send({ message: 'Email is required.' });
+  }
+  try {
+    const user = await db.user.findOne({ where: { email } });
+    if (user) {
+      const token = crypto.randomBytes(32).toString('hex');
+      const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+      await user.update({ resetToken: token, resetTokenExpiry: expiry });
+      await emailService.sendPasswordResetMail(email, token);
+    }
+    res.status(200).send({ message: 'If registered, you will receive an email with a reset link.' });
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.resetPassword = async (req, res) => {
+  const { token } = req.params;
+  const { password } = req.body;
+  if (!password) {
+    return res.status(400).send({ message: 'Password is required.' });
+  }
+  try {
+    const user = await db.user.findOne({
+      where: {
+        resetToken: token,
+        resetTokenExpiry: { [Op.gt]: new Date() }
+      }
+    });
+    if (!user) {
+      return res.status(400).send({ message: 'Invalid or expired token.' });
+    }
+    await user.update({
+      password: bcrypt.hashSync(password, 8),
+      resetToken: null,
+      resetTokenExpiry: null
+    });
+    res.status(200).send({ message: 'Password updated.' });
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -12,6 +12,14 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: true
       },
+      resetToken: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      resetTokenExpiry: {
+        type: DataTypes.DATE,
+        allowNull: true
+      },
       role: {
         type: DataTypes.ENUM('director', 'choir_admin', 'admin'),
         defaultValue: 'director'

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -25,5 +25,6 @@ router.get("/users", controller.getAllUsers);
 router.post("/users", controller.createUser);
 router.put("/users/:id", controller.updateUser);
 router.delete("/users/:id", controller.deleteUser);
+router.post("/users/:id/send-password-reset", controller.sendPasswordReset);
 
 module.exports = router;

--- a/choir-app-backend/src/routes/password-reset.routes.js
+++ b/choir-app-backend/src/routes/password-reset.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const controller = require('../controllers/password-reset.controller');
+
+router.post('/request', controller.requestPasswordReset);
+router.post('/reset/:token', controller.resetPassword);
+
+module.exports = router;

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -20,3 +20,14 @@ exports.sendInvitationMail = async (to, token, choirName, expiry) => {
     html: `<p>You have been invited to join <b>${choirName}</b>.<br>Click <a href="${link}">here</a> to complete your registration. This link is valid until ${expiry.toLocaleString()}.</p>`
   });
 };
+
+exports.sendPasswordResetMail = async (to, token) => {
+  const linkBase = process.env.FRONTEND_URL || 'http://localhost:4200';
+  const link = `${linkBase}/reset-password/${token}`;
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || 'no-reply@example.com',
+    to,
+    subject: 'Password Reset',
+    html: `<p>Click <a href="${link}">here</a> to set a new password.</p>`
+  });
+};

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -23,6 +23,8 @@ import { ManageChoirResolver } from '@features/choir-management/manage-choir-res
 import { EventListComponent } from '@features/events/event-list/event-list.component';
 import { InviteRegistrationComponent } from '@features/registration/invite-registration.component';
 import { StatisticsComponent } from '@features/stats/statistics.component';
+import { PasswordResetRequestComponent } from '@features/password-reset/password-reset-request.component';
+import { PasswordResetComponent } from '@features/password-reset/password-reset.component';
 
 export const routes: Routes = [
     // Die MainLayoutComponent ist jetzt die Wurzel und hat keine Guards
@@ -43,6 +45,14 @@ export const routes: Routes = [
             {
                 path: 'register/:token',
                 component: InviteRegistrationComponent
+            },
+            {
+                path: 'forgot-password',
+                component: PasswordResetRequestComponent
+            },
+            {
+                path: 'reset-password/:token',
+                component: PasswordResetComponent
             },
             { path: 'imprint', component: ImprintComponent },
             { path: 'privacy', component: PrivacyComponent },

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -272,6 +272,14 @@ export class ApiService {
     return this.http.get(`${this.apiUrl}/invitations/${token}`);
   }
 
+  requestPasswordReset(email: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/password-reset/request`, { email });
+  }
+
+  resetPassword(token: string, password: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/password-reset/reset/${token}`, { password });
+  }
+
   completeRegistration(token: string, data: { name: string; password: string }): Observable<any> {
     return this.http.post(`${this.apiUrl}/invitations/${token}`, data);
   }
@@ -314,6 +322,10 @@ export class ApiService {
 
   deleteUser(id: number): Observable<any> {
     return this.http.delete(`${this.apiUrl}/admin/users/${id}`);
+  }
+
+  sendPasswordReset(id: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/admin/users/${id}/send-password-reset`, {});
   }
 
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -29,6 +29,9 @@
       <button mat-icon-button color="primary" (click)="editUser(element)">
         <mat-icon>edit</mat-icon>
       </button>
+      <button mat-icon-button (click)="sendReset(element)">
+        <mat-icon>mail</mat-icon>
+      </button>
       <button mat-icon-button color="warn" (click)="deleteUser(element)">
         <mat-icon>delete</mat-icon>
       </button>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -5,6 +5,7 @@ import { ApiService } from 'src/app/core/services/api.service';
 import { User } from 'src/app/core/models/user';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserDialogComponent } from './user-dialog/user-dialog.component';
 
 @Component({
@@ -19,7 +20,7 @@ export class ManageUsersComponent implements OnInit {
   displayedColumns = ['name', 'email', 'role', 'choirs', 'actions'];
   dataSource = new MatTableDataSource<User>();
 
-  constructor(private api: ApiService, private dialog: MatDialog) {}
+  constructor(private api: ApiService, private dialog: MatDialog, private snack: MatSnackBar) {}
 
   ngOnInit(): void {
     this.loadUsers();
@@ -53,6 +54,14 @@ export class ManageUsersComponent implements OnInit {
   deleteUser(user: User): void {
     if (confirm('Delete user?')) {
       this.api.deleteUser(user.id).subscribe(() => this.loadUsers());
+    }
+  }
+
+  sendReset(user: User): void {
+    if (confirm('Send password reset email?')) {
+      this.api.sendPasswordReset(user.id).subscribe(() => {
+        this.snack.open('Email sent if user exists.', 'OK', { duration: 3000 });
+      });
     }
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -17,10 +17,6 @@
         <mat-option value="admin">admin</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field appearance="outline">
-      <mat-label>Password</mat-label>
-      <input matInput formControlName="password" type="password">
-    </mat-form-field>
   </form>
 </div>
 <div mat-dialog-actions align="end">

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -25,8 +25,7 @@ export class UserDialogComponent {
     this.form = this.fb.group({
       name: [data?.name || '', Validators.required],
       email: [data?.email || '', [Validators.required, Validators.email]],
-      role: [data?.role || 'director', Validators.required],
-      password: ['']
+      role: [data?.role || 'director', Validators.required]
     });
   }
 
@@ -36,11 +35,7 @@ export class UserDialogComponent {
 
   onSave(): void {
     if (this.form.valid) {
-      const value = { ...this.form.value };
-      if (!value.password) {
-        delete value.password;
-      }
-      this.dialogRef.close(value);
+      this.dialogRef.close(this.form.value);
     }
   }
 }

--- a/choir-app-frontend/src/app/features/login/login.component.html
+++ b/choir-app-frontend/src/app/features/login/login.component.html
@@ -27,6 +27,7 @@
           </button>
         </mat-card-actions>
       </form>
+      <p class="reset-link"><a routerLink="/forgot-password">Passwort vergessen?</a></p>
     </mat-card-content>
   </mat-card>
 </div>

--- a/choir-app-frontend/src/app/features/login/login.component.scss
+++ b/choir-app-frontend/src/app/features/login/login.component.scss
@@ -20,6 +20,10 @@ mat-form-field {
   width: 100%;
 }
 
+.reset-link {
+  margin-top: 1rem;
+}
+
 .in-button-spinner {
   display: inline-block;
   margin: 0 12px;

--- a/choir-app-frontend/src/app/features/password-reset/password-reset-request.component.html
+++ b/choir-app-frontend/src/app/features/password-reset/password-reset-request.component.html
@@ -1,0 +1,20 @@
+<div class="reset-container">
+  <mat-card>
+    <mat-card-title>Passwort vergessen</mat-card-title>
+    <mat-card-content>
+      <form [formGroup]="form" (ngSubmit)="submit()">
+        <mat-form-field appearance="outline">
+          <mat-label>Email</mat-label>
+          <input matInput type="email" formControlName="email">
+        </mat-form-field>
+        <mat-card-actions align="end">
+          <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid || isLoading">
+            <span *ngIf="!isLoading">Absenden</span>
+            <mat-spinner *ngIf="isLoading" diameter="24"></mat-spinner>
+          </button>
+        </mat-card-actions>
+      </form>
+      <p *ngIf="message">{{ message }}</p>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/choir-app-frontend/src/app/features/password-reset/password-reset-request.component.scss
+++ b/choir-app-frontend/src/app/features/password-reset/password-reset-request.component.scss
@@ -1,0 +1,1 @@
+.reset-container { display: flex; justify-content: center; margin-top: 2rem; }

--- a/choir-app-frontend/src/app/features/password-reset/password-reset-request.component.ts
+++ b/choir-app-frontend/src/app/features/password-reset/password-reset-request.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+
+@Component({
+  selector: 'app-password-reset-request',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './password-reset-request.component.html',
+  styleUrls: ['./password-reset-request.component.scss']
+})
+export class PasswordResetRequestComponent {
+  form = this.fb.group({
+    email: ['', [Validators.required, Validators.email]]
+  });
+  isLoading = false;
+  message = '';
+
+  constructor(private fb: FormBuilder, private api: ApiService) {}
+
+  submit(): void {
+    if (this.form.invalid) return;
+    this.isLoading = true;
+    this.api.requestPasswordReset(this.form.value.email || '').subscribe({
+      next: () => {
+        this.message = 'Wenn du registriert bist, erhältst du eine E-Mail mit einem Link zum Erstellen eines neuen Passworts.';
+        this.isLoading = false;
+      },
+      error: () => {
+        this.message = 'Wenn du registriert bist, erhältst du eine E-Mail mit einem Link zum Erstellen eines neuen Passworts.';
+        this.isLoading = false;
+      }
+    });
+  }
+}

--- a/choir-app-frontend/src/app/features/password-reset/password-reset.component.html
+++ b/choir-app-frontend/src/app/features/password-reset/password-reset.component.html
@@ -1,0 +1,20 @@
+<div class="reset-container">
+  <mat-card>
+    <mat-card-title>Neues Passwort</mat-card-title>
+    <mat-card-content>
+      <form [formGroup]="form" (ngSubmit)="submit()">
+        <mat-form-field appearance="outline">
+          <mat-label>Neues Passwort</mat-label>
+          <input matInput type="password" formControlName="password">
+        </mat-form-field>
+        <mat-card-actions align="end">
+          <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid || isLoading">
+            <span *ngIf="!isLoading">Speichern</span>
+            <mat-spinner *ngIf="isLoading" diameter="24"></mat-spinner>
+          </button>
+        </mat-card-actions>
+      </form>
+      <p *ngIf="message">{{ message }}</p>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/choir-app-frontend/src/app/features/password-reset/password-reset.component.scss
+++ b/choir-app-frontend/src/app/features/password-reset/password-reset.component.scss
@@ -1,0 +1,1 @@
+.reset-container { display: flex; justify-content: center; margin-top: 2rem; }

--- a/choir-app-frontend/src/app/features/password-reset/password-reset.component.ts
+++ b/choir-app-frontend/src/app/features/password-reset/password-reset.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+
+@Component({
+  selector: 'app-password-reset',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './password-reset.component.html',
+  styleUrls: ['./password-reset.component.scss']
+})
+export class PasswordResetComponent {
+  form = this.fb.group({
+    password: ['', Validators.required]
+  });
+  isLoading = false;
+  message = '';
+  token: string;
+
+  constructor(private fb: FormBuilder, private route: ActivatedRoute, private api: ApiService) {
+    this.token = this.route.snapshot.params['token'];
+  }
+
+  submit(): void {
+    if (this.form.invalid) return;
+    this.isLoading = true;
+    this.api.resetPassword(this.token, this.form.value.password || '').subscribe({
+      next: () => {
+        this.message = 'Dein Passwort wurde aktualisiert. Du kannst dich jetzt anmelden.';
+        this.isLoading = false;
+      },
+      error: err => {
+        this.message = err.error?.message || 'Link ungültig oder abgelaufen.';
+        this.isLoading = false;
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- extend user model with password reset fields
- allow server to send password reset emails and update passwords
- add admin API to send password reset for users
- expose reset endpoints in frontend API service
- add request/reset components and routes
- link to password reset from login page
- update admin user dialog and table with reset option

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e71d6b0488320bf7861ac9d31c966