### PR TITLE
Fix Karma launcher configuration

### DIFF
--- a/choir-app-frontend/angular.json
+++ b/choir-app-frontend/angular.json
@@ -105,7 +105,8 @@
             "styles": [
               "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
-            ]
+            ],
+            "karmaConfig": "karma.conf.js"
           }
         }
       }


### PR DESCRIPTION
## Summary
- load custom Karma config from `angular.json` so `ChromeHeadlessCI` is registered

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7305c62c8320bb53329d2558134e