### PR TITLE
Fix Karma plugin path for Angular 20 build

### DIFF
--- a/choir-app-frontend/karma.conf.js
+++ b/choir-app-frontend/karma.conf.js
@@ -1,13 +1,13 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    frameworks: ['jasmine', '@angular/build'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage'),
-      require('@angular-devkit/build-angular/plugins/karma')
+      require('@angular/build/karma')
     ],
     client: {
       clearContext: false


### PR DESCRIPTION
## Summary
- update Karma config to use `@angular/build/karma`

## Testing
- `npm install --prefix choir-app-frontend` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_685e7a0faf4c83209973eff0a3bd4115