### PR TITLE
Automate piece status updates and German labels

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -23,7 +23,7 @@
         </mat-select>
       </mat-form-field>
       <mat-checkbox [checked]="onlySingable$.value" (change)="onSingableToggle($event.checked)">
-        Only singable
+        Nur aufführbare
       </mat-checkbox>
       <button mat-button (click)="clearFilters()">Clear Filters</button>
     </div>
@@ -82,9 +82,9 @@
               <td mat-cell *matCellDef="let piece">
                 <mat-select [value]="piece.choir_repertoire?.status"
                   (selectionChange)="onStatusChange($event.value, piece.id)" (click)="$event.stopPropagation()">
-                  <mat-option value="CAN_BE_SUNG">Can be Sung</mat-option>
-                  <mat-option value="IN_REHEARSAL">In Rehearsal</mat-option>
-                  <mat-option value="NOT_READY">Not Ready</mat-option>
+                  <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>
+                  <mat-option value="IN_REHEARSAL">Wird geprobt</mat-option>
+                  <mat-option value="NOT_READY">Nicht im Repertoire</mat-option>
                 </mat-select>
               </td>
             </ng-container>


### PR DESCRIPTION
## Summary
- update event controller to change piece status automatically when events are created or updated
- show repertoire status labels in German
- translate checkbox label for singable pieces

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b328028832095ac4533bb10f1bc