### PR TITLE
Add piece details view

### DIFF
--- a/choir-app-backend/src/routes/repertoire.routes.js
+++ b/choir-app-backend/src/routes/repertoire.routes.js
@@ -7,5 +7,6 @@ router.use(authJwt.verifyToken);
 router.get("/", controller.findMyRepertoire);
 router.put("/status", controller.updateStatus);
 router.get("/lookup", controller.lookup);
+router.get("/:id", controller.findOne);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -25,6 +25,7 @@ import { InviteRegistrationComponent } from '@features/user/registration/invite-
 import { StatisticsComponent } from '@features/dashboard/stats/statistics.component';
 import { PasswordResetRequestComponent } from '@features/user/password-reset/password-reset-request.component';
 import { PasswordResetComponent } from '@features/user/password-reset/password-reset.component';
+import { PieceDetailComponent } from '@features/literature/piece-detail/piece-detail.component';
 
 export const routes: Routes = [
     // Die MainLayoutComponent ist jetzt die Wurzel und hat keine Guards
@@ -91,6 +92,11 @@ export const routes: Routes = [
             {
                 path: 'stats',
                 component: StatisticsComponent,
+                canActivate: [AuthGuard]
+            },
+            {
+                path: 'pieces/:id',
+                component: PieceDetailComponent,
                 canActivate: [AuthGuard]
             },
             {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -269,6 +269,10 @@ export class ApiService {
     return this.pieceService.getPieceById(id);
   }
 
+  getRepertoirePiece(id: number): Observable<Piece> {
+    return this.http.get<Piece>(`${this.apiUrl}/repertoire/${id}`);
+  }
+
   getMyChoirDetails(): Observable<Choir> {
     return this.http.get<Choir>(`${this.apiUrl}/choir-management`);
   }

--- a/choir-app-frontend/src/app/features/dashboard/event-card/event-card.component.html
+++ b/choir-app-frontend/src/app/features/dashboard/event-card/event-card.component.html
@@ -8,7 +8,11 @@
       <h3>{{ event.date | date:'fullDate' }}</h3>
       <mat-list>
         <mat-list-item *ngFor="let piece of event.pieces">
-          <div matListItemTitle>{{getPieceReference(piece)}} {{ piece.title }}</div>
+          <div matListItemTitle>
+            <a [routerLink]="['/pieces', piece.id]" class="piece-link">
+              {{getPieceReference(piece)}} {{ piece.title }}
+            </a>
+          </div>
           <div matListItemLine>
               <span>{{ getPieceSubtitle(piece) }}</span>
           </div>

--- a/choir-app-frontend/src/app/features/dashboard/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/dashboard/stats/statistics.component.html
@@ -5,7 +5,7 @@
     <h3>Top 3 Gottesdienst-Stücke</h3>
     <ol>
       <li *ngFor="let item of stats.topServicePieces">
-        {{item.title}} ({{item.count}}x)
+        <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
       </li>
     </ol>
   </mat-card>
@@ -14,7 +14,7 @@
     <h3>Top-geprobte Stücke</h3>
     <ol>
       <li *ngFor="let item of stats.topRehearsalPieces">
-        {{item.title}} ({{item.count}}x)
+        <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
       </li>
     </ol>
   </mat-card>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -1,0 +1,17 @@
+<div class="piece-detail" *ngIf="piece">
+  <h2>{{ piece.title }}</h2>
+  <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
+  <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
+  <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status }}</p>
+
+  <h3>Geprobt bei</h3>
+  <mat-list *ngIf="piece.events?.length; else noEvents">
+    <mat-list-item *ngFor="let ev of piece.events">
+      <div matLine>{{ ev.date | date:'mediumDate' }} - {{ ev.type }}</div>
+      <div matLine>{{ ev.notes }}</div>
+    </mat-list-item>
+  </mat-list>
+  <ng-template #noEvents>
+    <p>Keine Einträge</p>
+  </ng-template>
+</div>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
@@ -1,0 +1,4 @@
+.piece-detail {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+import { PieceDetailComponent } from './piece-detail.component';
+import { ApiService } from '@core/services/api.service';
+
+describe('PieceDetailComponent', () => {
+  let component: PieceDetailComponent;
+  let fixture: ComponentFixture<PieceDetailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PieceDetailComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } },
+        { provide: ApiService, useValue: { getRepertoirePiece: () => of(null) } }
+      ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PieceDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Piece } from '@core/models/piece';
+
+@Component({
+  selector: 'app-piece-detail',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './piece-detail.component.html',
+  styleUrls: ['./piece-detail.component.scss']
+})
+export class PieceDetailComponent implements OnInit {
+  piece?: Piece;
+
+  constructor(private route: ActivatedRoute, private apiService: ApiService) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.apiService.getRepertoirePiece(id).subscribe(p => this.piece = p);
+  }
+}


### PR DESCRIPTION
## Summary
- expose API route `/repertoire/:id` returning piece details with choir status and events
- link piece titles on dashboard and statistics to the new detail page
- add `PieceDetailComponent` and routing
- extend `ApiService` with `getRepertoirePiece`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a7ce30883208a7177f09da105ae