### PR TITLE
Fix choir select styling

### DIFF
--- a/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.html
+++ b/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.html
@@ -1,11 +1,13 @@
 <ng-container *ngIf="availableChoirs$ | async as choirs">
-  <!-- Zeigen Sie die Box nur an, wenn mehr als ein Chor vorhanden ist -->
-  <mat-form-field *ngIf="choirs.length > 1" appearance="outline" class="choir-select">
-    <mat-label>Chor</mat-label>
-    <mat-select [value]="(activeChoir$ | async)?.id" (selectionChange)="onChoirChange($event.value)">
-      <mat-option *ngFor="let choir of choirs" [value]="choir.id">
-        {{ choir.name }}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
+  <!-- Anzeige nur bei mehreren verfügbaren Chören -->
+  <mat-select
+    *ngIf="choirs.length > 1"
+    class="choir-select"
+    [value]="(activeChoir$ | async)?.id"
+    (selectionChange)="onChoirChange($event.value)"
+  >
+    <mat-option *ngFor="let choir of choirs" [value]="choir.id">
+      {{ choir.name }}
+    </mat-option>
+  </mat-select>
 </ng-container>

--- a/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.scss
+++ b/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.scss
@@ -1,14 +1,9 @@
 .choir-select {
   margin: 0 16px;
-  // Passen Sie die Größe an, damit es gut in die Toolbar passt
-  ::ng-deep .mat-mdc-form-field-flex {
-    height: 40px;
-    align-items: center;
-  }
+  height: 40px;
+  display: flex;
+  align-items: center;
   ::ng-deep .mat-mdc-select-value {
-    color: white;
-  }
-  ::ng-deep .mat-mdc-floating-label {
-    top: -12px !important;
+    color: currentColor;
   }
 }


### PR DESCRIPTION
## Summary
- use bare `mat-select` in `ChoirSwitcherComponent`
- clean up CSS for the select

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8bdf1da083208fa1f38d8f119934