### PR TITLE
Fix piece events type

### DIFF
--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -2,6 +2,7 @@ import { Composer } from './composer';
 import { Category } from './category';
 import { Author } from './author';
 import { PieceLink } from './piece-link';
+import { Event } from './event';
 
 export interface CollectionReference {
   prefix: string;
@@ -30,4 +31,5 @@ export interface Piece {
   author?: Author;
   arrangers?: Composer[];
   links?: PieceLink[];
+  events?: Event[];
 }


### PR DESCRIPTION
## Summary
- add event import and events field in Piece model interface

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb66074c48320a92ae0c019693da4