### PR TITLE
Add timestamped output for ng serve

### DIFF
--- a/choir-app-frontend/README.md
+++ b/choir-app-frontend/README.md
@@ -4,11 +4,13 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## Development server
 
-To start a local development server, run:
+To start a local development server with timestamped output, run:
 
 ```bash
-ng serve
+npm start
 ```
+
+This command runs `ng serve` and prefixes build output with the current time.
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
 

--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "node ./scripts/serve-with-timestamp.js",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/choir-app-frontend/scripts/serve-with-timestamp.js
+++ b/choir-app-frontend/scripts/serve-with-timestamp.js
@@ -1,0 +1,20 @@
+const { spawn } = require('child_process');
+
+const child = spawn('npx', ['ng', 'serve'], { stdio: ['inherit', 'pipe', 'pipe'] });
+
+function logWithTimestamp(prefix) {
+  return data => {
+    data.toString().split(/\r?\n/).forEach(line => {
+      if (line.trim() !== '') {
+        console.log(`[${new Date().toLocaleTimeString()}] ${prefix}${line}`);
+      }
+    });
+  };
+}
+
+child.stdout.on('data', logWithTimestamp(''));
+child.stderr.on('data', logWithTimestamp('ERR: '));
+
+child.on('close', code => {
+  console.log(`ng serve exited with code ${code}`);
+});


### PR DESCRIPTION
## Summary
- add a script to prefix `ng serve` output with a timestamp
- run this script via `npm start`
- document how to use the new server in the frontend README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec561d6bc8320830ea68ac77f1d41