### PR TITLE
Fix Add Piece dialog

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -293,6 +293,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
         const pieceDialogRef = this.dialog.open(PieceDialogComponent, {
             width: '500px',
             disableClose: true,
+            data: { pieceId: null },
         });
         pieceDialogRef
             .afterClosed()


### PR DESCRIPTION
## Summary
- ensure `MAT_DIALOG_DATA` is supplied when opening `PieceDialogComponent`

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685eefcfdd80832080b3058c1886dcf1