### PR TITLE
Add missing repertoire route

### DIFF
--- a/choir-app-backend/src/routes/repertoire.routes.js
+++ b/choir-app-backend/src/routes/repertoire.routes.js
@@ -6,6 +6,7 @@ router.use(authJwt.verifyToken);
 
 router.get("/", controller.findMyRepertoire);
 router.put("/status", controller.updateStatus);
+router.post("/add-piece", controller.addPieceToRepertoire);
 router.get("/lookup", controller.lookup);
 router.get("/:id", controller.findOne);
 


### PR DESCRIPTION
## Summary
- expose `addPieceToRepertoire` in repertoire routes

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef3dfed80832084060d9b558726f4