### PR TITLE
Fix Angular test setup

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.spec.ts
+++ b/choir-app-frontend/src/app/core/services/api.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { ApiService } from './api.service';
 
@@ -6,7 +7,9 @@ describe('Api', () => {
   let service: ApiService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(ApiService);
   });
 

--- a/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { ManageAuthorsComponent } from './manage-authors.component';
 
 describe('ManageAuthorsComponent', () => {
@@ -7,7 +11,13 @@ describe('ManageAuthorsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ManageAuthorsComponent]
+      imports: [ManageAuthorsComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ManageAuthorsComponent);

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ManageComposersComponent } from './manage-composers.component';
 
@@ -8,7 +12,13 @@ describe('ManageComposersComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ManageComposersComponent]
+      imports: [ManageComposersComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { CategoryDialogComponent } from './category-dialog.component';
 
@@ -8,7 +12,13 @@ describe('CategoryDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CategoryDialogComponent]
+      imports: [CategoryDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { InviteUserDialogComponent } from './invite-user-dialog.component';
 
@@ -8,7 +12,13 @@ describe('InviteUserDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [InviteUserDialogComponent]
+      imports: [InviteUserDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.spec.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ManageChoirComponent } from './manage-choir.component';
 
@@ -8,7 +12,13 @@ describe('ManageChoirComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ManageChoirComponent]
+      imports: [ManageChoirComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { CollectionEditComponent } from './collection-edit.component';
 
@@ -8,7 +12,13 @@ describe('CollectionEditComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CollectionEditComponent]
+      imports: [CollectionEditComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { CollectionListComponent } from './collection-list.component';
 
@@ -8,7 +12,13 @@ describe('CollectionListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CollectionListComponent]
+      imports: [CollectionListComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ImportDialogComponent } from './import-dialog.component';
 
@@ -8,7 +12,13 @@ describe('ImportDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ImportDialogComponent]
+      imports: [ImportDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ComposerDialogComponent } from './composer-dialog.component';
 
@@ -8,7 +12,13 @@ describe('ComposerDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ComposerDialogComponent]
+      imports: [ComposerDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { EventDialogComponent } from './event-dialog.component';
 
@@ -8,7 +12,13 @@ describe('EventDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EventDialogComponent]
+      imports: [EventDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { DashboardComponent } from './dashboard.component';
 
@@ -8,7 +12,13 @@ describe('DashboardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DashboardComponent]
+      imports: [DashboardComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/home/home.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/home.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { HomeComponent } from './home.component';
 
@@ -8,7 +12,13 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { LiteratureListComponent } from './literature-list.component';
 
@@ -8,7 +12,13 @@ describe('LiteratureListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LiteratureListComponent]
+      imports: [LiteratureListComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { PieceDialogComponent } from './piece-dialog.component';
 
@@ -10,8 +14,14 @@ describe('PieceDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PieceDialogComponent],
-      providers: [{ provide: AuthService, useValue: { isAdmin$: of(true) } }]
+      imports: [PieceDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: { isAdmin$: of(true) } },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/login/login.component.spec.ts
+++ b/choir-app-frontend/src/app/features/login/login.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { LoginComponent } from './login.component';
 
@@ -8,7 +12,13 @@ describe('LoginComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LoginComponent]
+      imports: [LoginComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ProfileComponent } from './profile.component';
 
@@ -8,7 +12,13 @@ describe('ProfileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProfileComponent]
+      imports: [ProfileComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ChoirSwitcherComponent } from './choir-switcher.component';
 
@@ -8,7 +12,13 @@ describe('ChoirSwitcherComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ChoirSwitcherComponent]
+      imports: [ChoirSwitcherComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/layout/footer/footer.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/footer/footer.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { FooterComponent } from './footer.component';
 
@@ -8,7 +12,13 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FooterComponent]
+      imports: [FooterComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { MainLayoutComponent } from './main-layout.component';
 
@@ -8,7 +12,13 @@ describe('MainLayoutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MainLayoutComponent]
+      imports: [MainLayoutComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 

--- a/choir-app-frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ConfirmDialogComponent } from './confirm-dialog.component';
 
@@ -8,7 +12,13 @@ describe('ConfirmDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ConfirmDialogComponent]
+      imports: [ConfirmDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
+      ]
     })
     .compileComponents();
 


### PR DESCRIPTION
## Summary
- add missing Angular testing modules and stub providers in component specs

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef2a0a9bc8320bf2dc77b8434b3b4