### PR TITLE
Add backend model tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ npm test
 ```
 
 This command uses the Angular CLI to execute Karma tests from the `choir-app-frontend` project.
+
+Run backend model tests with:
+
+```bash
+npm test --prefix choir-app-backend
+```
+
+These tests load all Sequelize models using an in-memory SQLite database and
+verify required fields and associations.

--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "node tests/models.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+
+// Set up in-memory SQLite for testing
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+
+    function checkFields(model, fields) {
+      const attrs = Object.keys(model.rawAttributes);
+      for (const field of fields) {
+        assert(attrs.includes(field), `${model.name} missing field ${field}`);
+      }
+    }
+
+    checkFields(db.user, ['email', 'role']);
+    checkFields(db.choir, ['name']);
+    checkFields(db.piece, ['title']);
+    checkFields(db.event, ['date', 'type']);
+    checkFields(db.composer, ['name']);
+    checkFields(db.category, ['name']);
+    checkFields(db.collection_piece, ['numberInCollection']);
+    checkFields(db.user_choir, ['roleInChoir', 'registrationStatus']);
+    checkFields(db.piece_change, ['data']);
+
+    // Basic association checks
+    assert(db.user.associations.choirs, 'User should have choirs association');
+    assert(db.piece.associations.composer, 'Piece should have composer association');
+    assert(db.choir.associations.events, 'Choir should have events association');
+
+    console.log('All model tests passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- create test for Sequelize models using in-memory SQLite
- add backend test script
- document backend tests in README

## Testing
- `npm --prefix choir-app-backend test` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efb0f6c1c8320823a37395322dd47