### PR TITLE
Enable sorting for collection list

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -10,8 +10,8 @@
   </button>
 </div>
 
-<div class="table-container mat-elevation-z8" *ngIf="(collections$ | async) as collections; else loading">
-  <table mat-table [dataSource]="collections">
+<div class="table-container mat-elevation-z8" *ngIf="!isLoading; else loading">
+  <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
 
     <!-- Cover Column -->
     <ng-container matColumnDef="cover">
@@ -23,7 +23,7 @@
 
     <!-- Status Column -->
     <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef> Status </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header="status"> Status </th>
       <td mat-cell *matCellDef="let collection">
         <mat-icon
           class="status-icon"
@@ -36,7 +36,7 @@
 
     <!-- Title Column -->
     <ng-container matColumnDef="title">
-      <th mat-header-cell *matHeaderCellDef> Titel </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
       <td mat-cell *matCellDef="let collection">
         <strong>{{ collection.title }}</strong>
         <div class="prefix-hint" *ngIf="collection.prefix">Prefix: {{ collection.prefix }}</div>
@@ -44,7 +44,7 @@
     </ng-container>
 
     <ng-container matColumnDef="titles">
-      <th mat-header-cell *matHeaderCellDef> Stücke </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header="titles"> Stücke </th>
       <td mat-cell *matCellDef="let collection" class="titles-cell">
         {{ collection.pieceCount || 0 }}
       </td>
@@ -52,7 +52,7 @@
 
     <!-- Publisher Column -->
     <ng-container matColumnDef="publisher">
-      <th mat-header-cell *matHeaderCellDef> Verlag </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header="publisher"> Verlag </th>
       <td mat-cell *matCellDef="let collection"> {{ collection.publisher || '-' }} </td>
     </ng-container>
 
@@ -78,7 +78,7 @@
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
 
-  <div *ngIf="collections.length === 0" class="empty-state">
+  <div *ngIf="dataSource.data.length === 0" class="empty-state">
       <p>No collections have been created yet.</p>
   </div>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Observable, BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { MaterialModule } from '@modules/material.module';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
 import { ApiService } from '@core/services/api.service';
 import { Collection } from '@core/models/collection';
 import { RouterLink } from '@angular/router'; // Import RouterLink for the template
@@ -20,11 +20,16 @@ import { RouterLink } from '@angular/router'; // Import RouterLink for the templ
   styleUrls: ['./collection-list.component.scss']
 })
 export class CollectionListComponent implements OnInit {
-  // Use a BehaviorSubject to hold the data, allowing us to update it.
-  private collectionsSubject = new BehaviorSubject<Collection[]>([]);
-  public collections$ = this.collectionsSubject.asObservable();
+  public dataSource = new MatTableDataSource<Collection>();
+  public isLoading = true;
+  private _sort!: MatSort;
+  @ViewChild(MatSort) set sort(sort: MatSort) {
+    if (sort) {
+      this._sort = sort;
+      this.dataSource.sort = this._sort;
+    }
+  }
 
-  // Define the columns for the mat-table
   public displayedColumns: string[] = ['cover', 'status', 'title', 'titles', 'publisher', 'actions'];
 
   constructor(
@@ -37,8 +42,10 @@ export class CollectionListComponent implements OnInit {
   }
 
   loadCollections(): void {
+    this.isLoading = true;
     this.apiService.getCollections().subscribe(collections => {
-      this.collectionsSubject.next(collections);
+      this.dataSource.data = collections;
+      this.isLoading = false;
     });
   }
 


### PR DESCRIPTION
## Summary
- add Angular Material sorting to the collection list
- show loading state while collections load

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efbaf06348320874a334a3dcef4db