### PR TITLE
Fix piece lookup search across spaces

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -100,7 +100,8 @@ export class EventDialogComponent implements OnInit {
 
   // --- DIE ERWEITERTE FILTERFUNKTION ---
   private _filter(search: string): LookupPiece[] {
-    const filterValue = search.toLowerCase().replace(/\s/g, '');
+    const filterValue = search.toLowerCase();
+    const filterValueNoSpace = filterValue.replace(/\s/g, '');
     const selectedIds = new Set(this.selectedPieces.map(p => p.id));
 
     return this.allRepertoirePieces.filter(piece => {
@@ -109,7 +110,7 @@ export class EventDialogComponent implements OnInit {
       // Prüfen, ob der Titel ODER die Referenz passt.
       const titleMatches = piece.title.toLowerCase().includes(filterValue);
       // 'piece.reference' ist jetzt ein einfacher String.
-      const referenceMatches = piece.reference ? piece.reference.toLowerCase().replace(/\s/g, '').includes(filterValue) : false;
+      const referenceMatches = piece.reference ? piece.reference.toLowerCase().replace(/\s/g, '').includes(filterValueNoSpace) : false;
 
       return isNotSelected && (titleMatches || referenceMatches);
     });


### PR DESCRIPTION
## Summary
- improve event piece lookup to match multi-word titles

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685efc031d788320ac0a297f8179cd4e