### PR TITLE
Fix event edit dialog not showing selected pieces

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -64,14 +64,16 @@ export class EventListComponent implements OnInit {
   }
 
   editEvent(event: Event): void {
-    const dialogRef = this.dialog.open(EventDialogComponent, { width: '600px', data: { event } });
-    dialogRef.afterClosed().subscribe(result => {
-      if (result && result.id) {
-        this.apiService.updateEvent(result.id, result).subscribe({
-          next: () => { this.snackBar.open('Event updated.', 'OK', { duration: 3000 }); this.loadEvents(); },
-          error: () => this.snackBar.open('Error updating event.', 'Close', { duration: 4000 })
-        });
-      }
+    this.apiService.getEventById(event.id).subscribe(fullEvent => {
+      const dialogRef = this.dialog.open(EventDialogComponent, { width: '600px', data: { event: fullEvent } });
+      dialogRef.afterClosed().subscribe(result => {
+        if (result && result.id) {
+          this.apiService.updateEvent(result.id, result).subscribe({
+            next: () => { this.snackBar.open('Event updated.', 'OK', { duration: 3000 }); this.loadEvents(); },
+            error: () => this.snackBar.open('Error updating event.', 'Close', { duration: 4000 })
+          });
+        }
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- fetch full event details when editing an event so previously sung pieces load correctly

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efce67ca0832080d443fe136a405c