### PR TITLE
Fix cover image endpoint location

### DIFF
--- a/choir-app-backend/src/routes/collection.routes.js
+++ b/choir-app-backend/src/routes/collection.routes.js
@@ -15,12 +15,14 @@ const storage = multer.diskStorage({
 });
 const upload = multer({ storage });
 
+// Public endpoint to fetch a collection's cover image without authentication
+router.get("/:id/cover", controller.getCover);
+
 router.use(authJwt.verifyToken);
 router.post("/", controller.create);
 router.get("/", controller.findAll);
 router.get("/:id", controller.findOne);
 router.put("/:id", controller.update);
 router.post("/:id/cover", upload.single('cover'), controller.uploadCover);
-router.get("/:id/cover", controller.getCover);
 router.post("/:id/addToChoir", controller.addToChoir); // Crucial endpoint
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose collection cover images under `/api` before auth middleware
- add missing newline

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efdc2ae808320b1f321957595e7b1