### PR TITLE
Fix piece author handling

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js"
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -15,7 +15,7 @@ exports.create = async (req, res) => {
      const {
         title, composerId, categoryId, voicing,
         key, timeSignature, lyrics, imageIdentifier, license, opus,
-        authorName, // e.g., "Martin Luther"
+        authorName, authorId,
         arrangerIds, // e.g., [12, 15]
         links        // e.g., [{ description: 'YouTube', url: '...' }]
     } = req.body;
@@ -25,15 +25,15 @@ exports.create = async (req, res) => {
     }
 
     try {
-        let authorId = null;
-        if (authorName) {
+        let resolvedAuthorId = authorId || null;
+        if (!resolvedAuthorId && authorName) {
             const [author] = await db.author.findOrCreate({ where: { name: authorName }, defaults: { name: authorName }});
-            authorId = author.id;
+            resolvedAuthorId = author.id;
         }
 
         const newPiece = await db.piece.create({
             title, composerId, categoryId, voicing, key, timeSignature,
-            lyrics, imageIdentifier, license, opus, authorId
+            lyrics, imageIdentifier, license, opus, authorId: resolvedAuthorId
         });
 
         if (arrangerIds && arrangerIds.length > 0) {

--- a/choir-app-backend/tests/piece.controller.test.js
+++ b/choir-app-backend/tests/piece.controller.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+
+// Use in-memory SQLite for testing
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/piece.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+
+    // create composer and author
+    const composer = await db.composer.create({ name: 'Test Composer' });
+    const author = await db.author.create({ name: 'Test Author' });
+
+    const req = {
+      body: {
+        title: 'Test Piece',
+        composerId: composer.id,
+        authorId: author.id,
+      },
+    };
+
+    let statusCode;
+    const res = {
+      status(code) { statusCode = code; return this; },
+      send(data) { this.data = data; },
+    };
+
+    await controller.create(req, res);
+
+    assert.strictEqual(statusCode, 201, 'should return 201');
+    const created = await db.piece.findByPk(res.data.id);
+    assert.strictEqual(created.composerId, composer.id);
+    assert.strictEqual(created.authorId, author.id);
+
+    console.log('piece.controller create test passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();
+

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -35,7 +35,7 @@
 
           <mat-form-field appearance="outline" class="lyrics-field">
             <mat-label>Text</mat-label>
-            <textarea matInput formControlName="lycris"></textarea>
+            <textarea matInput formControlName="lyrics"></textarea>
           </mat-form-field>
 
           <mat-form-field appearance="outline">

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -65,7 +65,7 @@ export class PieceDialogComponent implements OnInit {
         this.pieceForm = this.fb.group({
             title: ['', Validators.required],
             voicing: [''],
-            lycris: [''],
+            lyrics: [''],
             links: this.fb.array([]),
             opus: [''],
             key: [''],
@@ -205,7 +205,7 @@ export class PieceDialogComponent implements OnInit {
             authorId: piece.author?.id,
             categoryId: piece.category?.id,
             arrangerIds: piece.arrangers?.map((a) => a.id) || [],
-            lycris: piece.lyrics,
+            lyrics: piece.lyrics,
         });
 
         // Populate the links FormArray


### PR DESCRIPTION
## Summary
- allow `authorId` when creating a piece in the backend
- adapt frontend piece dialog to use `lyrics` field
- update backend test script and add a test for piece creation with composer and author

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685f02d24c40832087cdaf9713d86694