### PR TITLE
Show table of pieces in event dialog

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -53,18 +53,33 @@
       </mat-autocomplete>
     </mat-form-field>
 
-    <!-- Display Selected Pieces as Chips -->
-    <mat-chip-listbox aria-label="Selected pieces">
-      <mat-chip *ngFor="let piece of selectedPieces" (removed)="remove(piece)">
-        {{ piece.title }}
-        <button matChipRemove>
-          <mat-icon>cancel</mat-icon>
-        </button>
-      </mat-chip>
-    </mat-chip-listbox>
-    <div *ngIf="selectedPieces.length === 0" class="no-pieces-message">
-        No pieces selected for this event yet.
-    </div>
+    <!-- Display Selected Pieces in a Table -->
+    <table mat-table [dataSource]="selectedPieces" class="selected-pieces-table">
+      <ng-container matColumnDef="reference">
+        <th mat-header-cell *matHeaderCellDef>Ref</th>
+        <td mat-cell *matCellDef="let piece">{{ piece.reference }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef>Titel</th>
+        <td mat-cell *matCellDef="let piece">{{ piece.title }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let piece">
+          <button mat-icon-button color="warn" (click)="remove(piece)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="pieceColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: pieceColumns;"></tr>
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="pieceColumns.length">No pieces selected for this event yet.</td>
+      </tr>
+    </table>
 
   </form>
 </div>

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.scss
@@ -28,10 +28,11 @@ h3.mat-subheading-2 {
     color: #888;
 }
 
-// Styling für die Chips
-mat-chip-listbox {
+
+// Styling für die Tabelle der ausgewählten Stücke
+.selected-pieces-table {
+    width: 100%;
     margin-top: 1rem;
-    display: block;
 }
 
 .no-pieces-message {

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -14,7 +14,6 @@ import { MaterialModule } from '@modules/material.module';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { MatChipsModule } from '@angular/material/chips';
 import { LookupPiece } from '@core/models/lookup-piece';
 
 
@@ -26,8 +25,7 @@ import { LookupPiece } from '@core/models/lookup-piece';
     ReactiveFormsModule,
     MaterialModule,
     MatDatepickerModule,
-    MatAutocompleteModule,
-    MatChipsModule
+    MatAutocompleteModule
   ],
   providers: [
     MatDatepickerModule,
@@ -42,6 +40,7 @@ export class EventDialogComponent implements OnInit {
   filteredPieces$!: Observable<LookupPiece[]>;
   allRepertoirePieces: LookupPiece[] = [];
   selectedPieces: LookupPiece[] = [];
+  pieceColumns: string[] = ['reference', 'title', 'actions'];
 
   isEditMode = false;
   private editEventId: number | null = null;
@@ -131,7 +130,7 @@ export class EventDialogComponent implements OnInit {
     this.pieceCtrl.setValue('');
   }
 
-  // Wird aufgerufen, wenn ein Chip entfernt wird
+  // Wird aufgerufen, wenn ein Stück aus der Liste entfernt wird
   remove(piece: LookupPiece): void {
     const index = this.selectedPieces.indexOf(piece);
     if (index >= 0) {


### PR DESCRIPTION
## Summary
- display selected pieces in EventDialogComponent using a table with reference and title
- remove Chip usage and supporting styles/imports

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f072f746483208e8074ad81efee15