### PR TITLE
Add Tonart and Takt fields to piece dialog

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -17,6 +17,18 @@
             <input matInput formControlName="voicing">
           </mat-form-field>
 
+          <!-- Key / Tonart -->
+          <mat-form-field appearance="outline">
+            <mat-label>Key (Tonart)</mat-label>
+            <input matInput formControlName="key">
+          </mat-form-field>
+
+          <!-- Time Signature / Takt -->
+          <mat-form-field appearance="outline">
+            <mat-label>Time Signature (Takt)</mat-label>
+            <input matInput formControlName="timeSignature">
+          </mat-form-field>
+
           <!-- Occasion -->
           <mat-form-field appearance="outline">
             <mat-label>Category (Rubrik)</mat-label>

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -69,6 +69,7 @@ export class PieceDialogComponent implements OnInit {
             links: this.fb.array([]),
             opus: [''],
             key: [''],
+            timeSignature: [''],
             license: [''],
             composerId: [null, Validators.required],
             authorId: [null, Validators.required],


### PR DESCRIPTION
## Summary
- extend piece dialog form with `timeSignature` control
- allow editing of key and time signature in the dialog UI

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685f07a40d80832088c60fd67cd650fe