### PR TITLE
Enable gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ npm test --prefix choir-app-backend
 
 These tests load all Sequelize models using an in-memory SQLite database and
 verify required fields and associations.
+
+## Compression
+
+The backend enables gzip compression by including the
+[`compression`](https://www.npmjs.com/package/compression) middleware. Running
+`npm install` inside `choir-app-backend` installs this dependency automatically.
+
+For the Angular frontend you can pre-compress build artifacts using
+`compression-webpack-plugin` together with a custom webpack configuration:
+
+```bash
+npm install --save-dev compression-webpack-plugin @angular-builders/custom-webpack
+```
+
+The generated `.gz` or `.br` files can then be served by a web server that
+supports content negotiation for pre-compressed assets.

--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const cors = require("cors");
 const app = express();
 const helmet = require("helmet");
+const compression = require("compression");
 const RateLimit = require("express-rate-limit");
 const path = require('path');
 
@@ -11,6 +12,7 @@ app.set("trust proxy", 1);
 
 app.use(cors());
 app.use(helmet());
+app.use(compression());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));


### PR DESCRIPTION
## Summary
- enable gzip compression in backend Express app
- add README notes about compression and useful packages

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685f09a59180832088724837d4c3ff29