### PR TITLE
Warn if event date already taken

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js"
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/choir-app-backend/tests/event.controller.test.js
+++ b/choir-app-backend/tests/event.controller.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/event.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+    const choir = await db.choir.create({ name: 'Test Choir' });
+    const user = await db.user.create({ email: 't@example.com', role: 'USER' });
+
+    const baseReq = { activeChoirId: choir.id, userId: user.id };
+    const res = {
+      status(code) { this.statusCode = code; return this; },
+      send(data) { this.data = data; },
+    };
+
+    // First event should succeed
+    await controller.create({ ...baseReq, body: { date: '2024-01-01T10:00:00Z', type: 'SERVICE', pieceIds: [] } }, res);
+    assert.strictEqual(res.statusCode, 201);
+
+    // Same type on same day should be rejected
+    await controller.create({ ...baseReq, body: { date: '2024-01-01T12:00:00Z', type: 'SERVICE', pieceIds: [] } }, res);
+    assert.strictEqual(res.statusCode, 409);
+
+    // Different type on same day should succeed with warning
+    await controller.create({ ...baseReq, body: { date: '2024-01-01T15:00:00Z', type: 'REHEARSAL', pieceIds: [] } }, res);
+    assert.strictEqual(res.statusCode, 201);
+    assert.ok(res.data.warning);
+
+    console.log('event.controller create test passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();

--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -14,5 +14,6 @@ export interface Event {
 export interface CreateEventResponse {
   message: string;
   wasUpdated: boolean;
+  warning?: string;
   event: Event;
 }

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -96,13 +96,19 @@ export class EventListComponent implements OnInit {
       if (result) {
         this.apiService.createEvent(result).subscribe({
           next: (response: CreateEventResponse) => {
-            const message = response.wasUpdated ?
+            const baseMessage = response.wasUpdated ?
               'Event für diesen Tag wurde aktualisiert!' :
               'Event erfolgreich angelegt!';
+            const message = response.warning ? response.warning : baseMessage;
             this.snackBar.open(message, 'OK', { duration: 3000 });
             this.loadEvents();
           },
-          error: () => this.snackBar.open('Fehler: Das Event konnte nicht gespeichert werden.', 'Schließen', { duration: 5000 })
+          error: (err) => {
+            const msg = err.status === 409 && err.error?.message
+              ? err.error.message
+              : 'Fehler: Das Event konnte nicht gespeichert werden.';
+            this.snackBar.open(msg, 'Schließen', { duration: 5000 });
+          }
         });
       }
     });

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -75,24 +75,23 @@ export class DashboardComponent implements OnInit {
       if (result) {
         // Der API-Aufruf bleibt gleich, aber wir erwarten eine andere Antwort.
         this.apiService.createEvent(result).subscribe({
-          // --- DIE NEUE LOGIK IST HIER ---
           next: (response: CreateEventResponse) => {
-            // Wählen Sie die Snackbar-Nachricht basierend auf der Antwort des Servers.
-            const message = response.wasUpdated
+            const baseMessage = response.wasUpdated
               ? 'Event für diesen Tag wurde aktualisiert!'
               : 'Event erfolgreich angelegt!';
-
+            const message = response.warning ? response.warning : baseMessage;
             this.snackBar.open(message, 'OK', {
               duration: 3000,
               verticalPosition: 'top'
             });
-
-            // Das Dashboard wird in beiden Fällen aktualisiert.
             this.refresh$.next();
           },
           error: (err) => {
             console.error('Fehler beim Anlegen/Aktualisieren des Events', err);
-            this.snackBar.open('Fehler: Das Event konnte nicht gespeichert werden.', 'Schließen', {
+            const msg = err.status === 409 && err.error?.message
+              ? err.error.message
+              : 'Fehler: Das Event konnte nicht gespeichert werden.';
+            this.snackBar.open(msg, 'Schließen', {
               duration: 5000,
               verticalPosition: 'top'
             });


### PR DESCRIPTION
## Summary
- ensure event creation checks for existing events on the same day and returns 409 if the same type exists
- send warning when a different event type already exists
- propagate optional warning field to frontend models and display it in event creation dialogs
- add backend test for new event creation rules

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685f10b94e9c83208eb757d5a16d81f9