### PR TITLE
Add donation link with PayPal integration

### DIFF
--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -6,7 +6,7 @@ const bcrypt = require("bcryptjs");
 exports.getMe = async (req, res) => {
     try {
         const user = await User.findByPk(req.userId, {
-            attributes: ['id', 'name', 'email', 'role'], // Don't send the password hash!
+            attributes: ['id', 'name', 'email', 'role', 'lastDonation'], // Include lastDonation
             include: [{
                 model: Choir,
                 as: 'choirs', // Use the plural alias 'choirs' defined in the association
@@ -66,5 +66,19 @@ exports.updateMe = async (req, res) => {
             return res.status(409).send({ message: "This email address is already in use." });
         }
         res.status(500).send({ message: err.message || "An error occurred while updating the profile." });
+    }
+};
+
+exports.registerDonation = async (req, res) => {
+    try {
+        const user = await User.findByPk(req.userId);
+        if (!user) {
+            return res.status(404).send({ message: "User not found." });
+        }
+        user.lastDonation = new Date();
+        await user.save();
+        res.status(200).send({ message: "Donation recorded." });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
     }
 };

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -23,6 +23,10 @@ module.exports = (sequelize, DataTypes) => {
       role: {
         type: DataTypes.ENUM('director', 'choir_admin', 'admin'),
         defaultValue: 'director'
+      },
+      lastDonation: {
+        type: DataTypes.DATE,
+        allowNull: true
       }
     });
     return User;

--- a/choir-app-backend/src/routes/user.routes.js
+++ b/choir-app-backend/src/routes/user.routes.js
@@ -6,5 +6,6 @@ router.use(authJwt.verifyToken);
 
 router.get("/me", controller.getMe);
 router.put("/me", controller.updateMe);
+router.post("/me/donate", controller.registerDonation);
 
 module.exports = router;

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -17,7 +17,7 @@ const db = require('../src/models');
       }
     }
 
-    checkFields(db.user, ['email', 'role']);
+    checkFields(db.user, ['email', 'role', 'lastDonation']);
     checkFields(db.choir, ['name']);
     checkFields(db.piece, ['title']);
     checkFields(db.event, ['date', 'type']);

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -27,6 +27,9 @@ import { StatisticsComponent } from '@features/home/stats/statistics.component';
 import { PasswordResetRequestComponent } from '@features/user/password-reset/password-reset-request.component';
 import { PasswordResetComponent } from '@features/user/password-reset/password-reset.component';
 import { PieceDetailComponent } from '@features/literature/piece-detail/piece-detail.component';
+import { DonateComponent } from '@features/donations/donate.component';
+import { DonationSuccessComponent } from '@features/donations/donation-success.component';
+import { DonationCancelComponent } from '@features/donations/donation-cancel.component';
 
 export const routes: Routes = [
     // Die MainLayoutComponent ist jetzt die Wurzel und hat keine Guards
@@ -58,6 +61,9 @@ export const routes: Routes = [
             },
             { path: 'imprint', component: ImprintComponent },
             { path: 'privacy', component: PrivacyComponent },
+            { path: 'donate', component: DonateComponent },
+            { path: 'donation-success', component: DonationSuccessComponent },
+            { path: 'donation-cancel', component: DonationCancelComponent },
 
             // --- Geschützte Routen (jede einzelne hat jetzt den Guard) ---
             {

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -32,6 +32,7 @@ export interface User {
 
   activeChoir?: Choir;
   availableChoirs?: Choir[];
+  lastDonation?: string;
 }
 
 export interface UserInChoir extends User {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -387,4 +387,8 @@ export class ApiService {
   pingBackend(): Observable<{ message: string }> {
         return this.http.get<{ message: string }>(`${this.apiUrl}/ping`);
     }
+
+  registerDonation(): Observable<any> {
+        return this.http.post(`${this.apiUrl}/users/me/donate`, {});
+    }
 }

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -84,4 +84,9 @@ export class AuthService {
       })
     );
   }
+
+  setCurrentUser(user: User) {
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+    this.currentUserSubject.next(user);
+  }
 }

--- a/choir-app-frontend/src/app/features/donations/donate.component.html
+++ b/choir-app-frontend/src/app/features/donations/donate.component.html
@@ -1,0 +1,14 @@
+<div class="legal-container">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Unterstütze dieses Projekt</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p>Der Betrieb dieses Servers kostet etwa 120&nbsp;€ pro Jahr. Die Entwicklung dieses Werkzeugs hat viele Stunden Freizeit gekostet und erfolgt ohne Gewinnerzielungsabsicht.</p>
+      <p>Wenn dir diese Anwendung gefällt, freue ich mich über einen Beitrag zu den Betriebs- und Kaffeekosten.</p>
+      <p>Spenden können bequem per Paypal an <strong>michael.free@gmx.de</strong> übermittelt werden.</p>
+      <button mat-raised-button color="accent" (click)="openPaypal()">Jetzt spenden</button>
+    </mat-card-content>
+  </mat-card>
+</div>
+

--- a/choir-app-frontend/src/app/features/donations/donate.component.scss
+++ b/choir-app-frontend/src/app/features/donations/donate.component.scss
@@ -1,0 +1,3 @@
+.legal-container {
+  padding: 1rem;
+}

--- a/choir-app-frontend/src/app/features/donations/donate.component.ts
+++ b/choir-app-frontend/src/app/features/donations/donate.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+
+@Component({
+  selector: 'app-donate',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './donate.component.html',
+  styleUrls: ['./donate.component.scss']
+})
+export class DonateComponent {
+  openPaypal() {
+    const base = window.location.origin;
+    const returnUrl = encodeURIComponent(`${base}/donation-success`);
+    const cancelUrl = encodeURIComponent(`${base}/donation-cancel`);
+    window.location.href = `https://www.paypal.com/donate?business=michael.free%40gmx.de&currency_code=EUR&return=${returnUrl}&cancel_return=${cancelUrl}`;
+  }
+}
+

--- a/choir-app-frontend/src/app/features/donations/donation-cancel.component.html
+++ b/choir-app-frontend/src/app/features/donations/donation-cancel.component.html
@@ -1,0 +1,9 @@
+<div class="legal-container">
+  <mat-card>
+    <mat-card-content>
+      <h2>Spende abgebrochen</h2>
+      <p>Schade, vielleicht ein andermal.</p>
+      <button mat-raised-button color="primary" (click)="back()">Zurück</button>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/choir-app-frontend/src/app/features/donations/donation-cancel.component.scss
+++ b/choir-app-frontend/src/app/features/donations/donation-cancel.component.scss
@@ -1,0 +1,1 @@
+.legal-container { padding: 1rem; }

--- a/choir-app-frontend/src/app/features/donations/donation-cancel.component.ts
+++ b/choir-app-frontend/src/app/features/donations/donation-cancel.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-donation-cancel',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './donation-cancel.component.html',
+  styleUrls: ['./donation-cancel.component.scss']
+})
+export class DonationCancelComponent {
+  constructor(private router: Router) {}
+
+  back() {
+    this.router.navigate(['/']);
+  }
+}
+

--- a/choir-app-frontend/src/app/features/donations/donation-success.component.html
+++ b/choir-app-frontend/src/app/features/donations/donation-success.component.html
@@ -1,0 +1,9 @@
+<div class="legal-container">
+  <mat-card>
+    <mat-card-content>
+      <h2>Vielen Dank für deine Spende!</h2>
+      <p>Dein Beitrag hilft, die laufenden Kosten zu decken.</p>
+      <button mat-raised-button color="primary" (click)="back()">Zurück</button>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/choir-app-frontend/src/app/features/donations/donation-success.component.scss
+++ b/choir-app-frontend/src/app/features/donations/donation-success.component.scss
@@ -1,0 +1,1 @@
+.legal-container { padding: 1rem; }

--- a/choir-app-frontend/src/app/features/donations/donation-success.component.ts
+++ b/choir-app-frontend/src/app/features/donations/donation-success.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Router } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
+
+@Component({
+  selector: 'app-donation-success',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './donation-success.component.html',
+  styleUrls: ['./donation-success.component.scss']
+})
+export class DonationSuccessComponent implements OnInit {
+  constructor(private api: ApiService, private auth: AuthService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.api.registerDonation().subscribe(() => {
+      this.api.getCurrentUser().subscribe(user => this.auth.setCurrentUser(user));
+    });
+  }
+
+  back() {
+    this.router.navigate(['/']);
+  }
+}
+

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -6,6 +6,13 @@
   <span class="title"><a href="/" class="page-title-link">NAK Chorleiter</a></span>
 
   <span class="spacer"></span>
+  <ng-container *ngIf="(isLoggedIn$ | async) && !(donatedRecently$ | async)">
+    <button mat-button color="accent" routerLink="/donate">Spenden</button>
+  </ng-container>
+
+  <ng-container *ngIf="donatedRecently$ | async">
+    <mat-icon color="accent">favorite</mat-icon>
+  </ng-container>
 
   <ng-container *ngIf="isLoggedIn$ | async">
     <button mat-icon-button [matMenuTriggerFor]="userMenu" matTooltip="Benutzerprofil">

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -37,6 +37,7 @@ import { MatDrawer } from '@angular/material/sidenav';
 export class MainLayoutComponent implements OnInit{
   isLoggedIn$: Observable<boolean>;
   isAdmin$: Observable<boolean>;
+  donatedRecently$: Observable<boolean>;
   currentTheme: Theme;
   showAdminSubmenu: boolean = true;
   isExpanded = true;
@@ -61,6 +62,15 @@ export class MainLayoutComponent implements OnInit{
   ) {
     this.isLoggedIn$ = this.authService.isLoggedIn$;
     this.isAdmin$ = this.authService.isAdmin$;
+    this.donatedRecently$ = this.authService.currentUser$.pipe(
+      map(u => {
+        if (!u?.lastDonation) return false;
+        const last = new Date(u.lastDonation);
+        const yearAgo = new Date();
+        yearAgo.setFullYear(yearAgo.getFullYear() - 1);
+        return last > yearAgo;
+      })
+    );
     this.currentTheme = this.themeService.getCurrentTheme();
 
     this.isHandset$ = this.breakpointObserver.observe([Breakpoints.Handset]).pipe(


### PR DESCRIPTION
## Summary
- track user donations on the backend
- expose a POST endpoint to register donations
- create donation pages on the Angular frontend
- add donation button and heart indicator in header
- refresh user data after successful donations

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_685fa8fa1bcc83208976e478776072b6