### PR TITLE
Persist paginator page size

### DIFF
--- a/choir-app-frontend/src/app/core/services/paginator.service.ts
+++ b/choir-app-frontend/src/app/core/services/paginator.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PaginatorService {
+  private readonly KEY_PREFIX = 'paginator-page-size-';
+
+  getPageSize(key: string, defaultSize: number): number {
+    const stored = localStorage.getItem(this.KEY_PREFIX + key);
+    const val = stored ? parseInt(stored, 10) : NaN;
+    return isNaN(val) ? defaultSize : val;
+  }
+
+  setPageSize(key: string, size: number): void {
+    localStorage.setItem(this.KEY_PREFIX + key, size.toString());
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
@@ -40,4 +40,7 @@
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
 
-<mat-paginator [length]="totalComposers" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons></mat-paginator>
+<mat-paginator [length]="totalComposers"
+               [pageSizeOptions]="pageSizeOptions"
+               [pageSize]="pageSize"
+               showFirstLastButtons></mat-paginator>

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.ts
@@ -6,6 +6,7 @@ import { MaterialModule } from '@modules/material.module';
 import { CommonModule } from '@angular/common';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
+import { PaginatorService } from '@core/services/paginator.service';
 import { ComposerDialogComponent } from '@features/composers/composer-dialog/composer-dialog.component';
 // ...
 @Component({
@@ -26,10 +27,13 @@ export class ManageComposersComponent implements OnInit, AfterViewInit {
   selectedLetter = 'Alle';
   totalComposers = 0;
   pageSizeOptions: number[] = [10, 25, 50];
+  pageSize = this.paginatorService.getPageSize('manage-composers', this.pageSizeOptions[0]);
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
-  constructor(private adminApiService: ApiService, private dialog: MatDialog) {}
+  constructor(private adminApiService: ApiService,
+              private dialog: MatDialog,
+              private paginatorService: PaginatorService) {}
 
   ngOnInit() {
     this.loadComposers();
@@ -37,8 +41,10 @@ export class ManageComposersComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     if (this.paginator) {
+      this.paginator.pageSize = this.pageSize;
       this.dataSource.paginator = this.paginator;
       this.applyFilter();
+      this.paginator.page.subscribe(e => this.paginatorService.setPageSize('manage-composers', e.pageSize));
     }
   }
 

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -146,7 +146,8 @@
 
           <mat-paginator
             *ngIf="selectedPieceLinks.length > 0"
-            [pageSizeOptions]="[10, 20, 50]"
+            [pageSizeOptions]="pageSizeOptions"
+            [pageSize]="pageSize"
             showFirstLastButtons
             aria-label="Select page of pieces">
           </mat-paginator>

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -31,6 +31,7 @@ import { Collection } from 'src/app/core/models/collection';
 import { PieceDialogComponent } from '../../literature/piece-dialog/piece-dialog.component';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { PaginatorService } from '@core/services/paginator.service';
 import { MatSort } from '@angular/material/sort';
 
 interface SelectedPieceWithNumber {
@@ -74,6 +75,8 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
 
     public pieceLinkDataSource =
         new MatTableDataSource<SelectedPieceWithNumber>([]);
+    pageSizeOptions: number[] = [10, 20, 50];
+    pageSize = this.paginatorService.getPageSize('collection-edit', this.pageSizeOptions[0]);
 
     private _sort!: MatSort;
     @ViewChild(MatSort) set sort(sort: MatSort) {
@@ -87,7 +90,9 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     @ViewChild(MatPaginator) set paginator(paginator: MatPaginator) {
         if (paginator) {
             this._paginator = paginator;
+            this._paginator.pageSize = this.pageSize;
             this.pieceLinkDataSource.paginator = this._paginator;
+            this._paginator.page.subscribe(e => this.paginatorService.setPageSize('collection-edit', e.pageSize));
         }
     }
 
@@ -97,7 +102,8 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
         private snackBar: MatSnackBar,
         private router: Router,
         private route: ActivatedRoute,
-        public dialog: MatDialog
+        public dialog: MatDialog,
+        private paginatorService: PaginatorService
     ) {
         this.collectionForm = this.fb.group({
             title: ['', Validators.required],

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -58,7 +58,9 @@
     </tr>
   </table>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25]" showFirstLastButtons></mat-paginator>
+  <mat-paginator [pageSizeOptions]="pageSizeOptions"
+                 [pageSize]="pageSize"
+                 showFirstLastButtons></mat-paginator>
 </div>
 
 <app-event-card *ngIf="selectedEvent" cardTitle="Gesungene Literatur" [event]="selectedEvent"></app-event-card>

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -9,6 +9,7 @@ import { AuthService } from '@core/services/auth.service';
 import { CreateEventResponse, Event } from '@core/models/event';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
+import { PaginatorService } from '@core/services/paginator.service';
 import { startWith } from 'rxjs/operators';
 import { EventDialogComponent } from '../event-dialog/event-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
@@ -28,17 +29,31 @@ import { EventCardComponent } from '../../home/event-card/event-card.component';
   templateUrl: './event-list.component.html',
   styleUrls: ['./event-list.component.scss']
 })
-export class EventListComponent implements OnInit {
+export class EventListComponent implements OnInit, AfterViewInit {
   typeControl = new FormControl('ALL');
   displayedColumns: string[] = ['date', 'type', 'updatedAt', 'director', 'actions'];
   dataSource = new MatTableDataSource<Event>();
   selectedEvent: Event | null = null;
   isChoirAdmin = false;
   isAdmin = false;
+  pageSizeOptions: number[] = [5, 10, 25];
+  pageSize = this.paginatorService.getPageSize('event-list', this.pageSizeOptions[0]);
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
-  constructor(private apiService: ApiService, private authService: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {}
+  constructor(private apiService: ApiService,
+              private authService: AuthService,
+              private dialog: MatDialog,
+              private snackBar: MatSnackBar,
+              private paginatorService: PaginatorService) {}
+
+  ngAfterViewInit(): void {
+    if (this.paginator) {
+      this.paginator.pageSize = this.pageSize;
+      this.paginator.page.subscribe(e => this.paginatorService.setPageSize('event-list', e.pageSize));
+      this.dataSource.paginator = this.paginator;
+    }
+  }
 
   ngOnInit(): void {
     this.loadEvents();

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -113,7 +113,10 @@
         </div>
 
         <!-- The Paginator -->
-        <mat-paginator [length]="totalPieces" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons>
+        <mat-paginator [length]="totalPieces"
+                       [pageSizeOptions]="pageSizeOptions"
+                       [pageSize]="pageSize"
+                       showFirstLastButtons>
         </mat-paginator>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add PaginatorService to store paginator size in localStorage
- apply paginator persistence on literature, events, composers and collection pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffdb0c8e48320b9ef8f6c23b85a61