### PR TITLE
Add filter preset support

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -60,6 +60,7 @@ const choirManagementRoutes = require("./routes/choir-management.routes");
 const invitationRoutes = require("./routes/invitation.routes");
 const statsRoutes = require("./routes/stats.routes");
 const passwordResetRoutes = require("./routes/password-reset.routes");
+const repertoireFilterRoutes = require("./routes/repertoire-filter.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -78,6 +79,7 @@ app.use("/api/choir-management", choirManagementRoutes);
 app.use("/api/invitations", invitationRoutes);
 app.use("/api/stats", statsRoutes);
 app.use("/api/password-reset", passwordResetRoutes);
+app.use("/api/repertoire-filters", repertoireFilterRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/repertoire-filter.controller.js
+++ b/choir-app-backend/src/controllers/repertoire-filter.controller.js
@@ -1,0 +1,81 @@
+const db = require("../models");
+const { Op } = require("sequelize");
+const RepertoireFilter = db.repertoire_filter;
+
+exports.list = async (req, res) => {
+    try {
+        const filters = await RepertoireFilter.findAll({
+            where: {
+                [Op.or]: [
+                    { visibility: 'global' },
+                    { visibility: 'local', choirId: req.activeChoirId },
+                    { visibility: 'personal', userId: req.userId }
+                ]
+            },
+            order: [['name','ASC']]
+        });
+        res.status(200).send(filters);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.save = async (req, res) => {
+    const { name, data, visibility = 'personal' } = req.body;
+    if (!name || !data) {
+        return res.status(400).send({ message: 'Name and data are required.' });
+    }
+    try {
+        if (visibility === 'global' && req.userRole !== 'admin') {
+            return res.status(403).send({ message: 'Require Admin Role!' });
+        }
+        if (visibility === 'local' && req.userRole !== 'admin') {
+            const assoc = await db.user_choir.findOne({ where: { userId: req.userId, choirId: req.activeChoirId } });
+            if (!assoc || assoc.roleInChoir !== 'choir_admin') {
+                return res.status(403).send({ message: 'Require Choir Admin Role!' });
+            }
+        }
+        const where = { name, visibility };
+        if (visibility === 'personal') where.userId = req.userId;
+        if (visibility === 'local') where.choirId = req.activeChoirId;
+
+        let preset = await RepertoireFilter.findOne({ where });
+        if (preset) {
+            await preset.update({ data });
+        } else {
+            preset = await RepertoireFilter.create({
+                name,
+                data,
+                visibility,
+                userId: visibility === 'personal' ? req.userId : null,
+                choirId: visibility === 'local' ? req.activeChoirId : null
+            });
+        }
+        res.status(200).send(preset);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.delete = async (req, res) => {
+    const id = req.params.id;
+    try {
+        const preset = await RepertoireFilter.findByPk(id);
+        if (!preset) return res.status(404).send({ message: 'Filter not found.' });
+
+        if (preset.visibility === 'global') {
+            if (req.userRole !== 'admin') return res.status(403).send({ message: 'Require Admin Role!' });
+        } else if (preset.visibility === 'local') {
+            if (req.userRole !== 'admin') {
+                const assoc = await db.user_choir.findOne({ where: { userId: req.userId, choirId: preset.choirId } });
+                if (!assoc || assoc.roleInChoir !== 'choir_admin') return res.status(403).send({ message: 'Require Choir Admin Role!' });
+            }
+        } else {
+            if (preset.userId !== req.userId) return res.status(403).send({ message: 'Not allowed.' });
+        }
+        await preset.destroy();
+        res.status(200).send({ message: 'Deleted' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -28,6 +28,7 @@ db.piece_arranger = require("./piece_arranger.model.js")(sequelize, Sequelize);
 db.piece_link = require("./piece_link.model.js")(sequelize, Sequelize);
 db.user_choir = require("./user_choir.model.js")(sequelize, Sequelize);
 db.piece_change = require("./piece_change.model.js")(sequelize, Sequelize);
+db.repertoire_filter = require("./repertoire_filter.model.js")(sequelize, Sequelize);
 
 // --- Define Associations ---
 // A Choir has many Users
@@ -84,6 +85,12 @@ db.piece.hasMany(db.piece_change, { as: 'changeRequests' });
 db.piece_change.belongsTo(db.piece, { foreignKey: 'pieceId' });
 db.user.hasMany(db.piece_change, { as: 'pieceChangeRequests' });
 db.piece_change.belongsTo(db.user, { foreignKey: 'userId', as: 'proposer' });
+
+// Repertoire Filter Presets
+db.user.hasMany(db.repertoire_filter, { as: 'repertoireFilters' });
+db.repertoire_filter.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
+db.choir.hasMany(db.repertoire_filter, { as: 'repertoireFilters' });
+db.repertoire_filter.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 
 
 module.exports = db;

--- a/choir-app-backend/src/models/repertoire_filter.model.js
+++ b/choir-app-backend/src/models/repertoire_filter.model.js
@@ -1,0 +1,23 @@
+module.exports = (sequelize, DataTypes) => {
+    const RepertoireFilter = sequelize.define('repertoire_filter', {
+        id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        name: {
+            type: DataTypes.STRING,
+            allowNull: false
+        },
+        data: {
+            type: DataTypes.JSON,
+            allowNull: false
+        },
+        visibility: {
+            type: DataTypes.ENUM('personal', 'local', 'global'),
+            allowNull: false,
+            defaultValue: 'personal'
+        }
+    });
+    return RepertoireFilter;
+};

--- a/choir-app-backend/src/routes/repertoire-filter.routes.js
+++ b/choir-app-backend/src/routes/repertoire-filter.routes.js
@@ -1,0 +1,11 @@
+const authJwt = require("../middleware/auth.middleware");
+const controller = require("../controllers/repertoire-filter.controller");
+const router = require("express").Router();
+
+router.use(authJwt.verifyToken);
+
+router.get("/", controller.list);
+router.post("/", controller.save);
+router.delete("/:id", controller.delete);
+
+module.exports = router;

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -26,6 +26,7 @@ const db = require('../src/models');
     checkFields(db.collection_piece, ['numberInCollection']);
     checkFields(db.user_choir, ['roleInChoir', 'registrationStatus']);
     checkFields(db.piece_change, ['data']);
+    checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
 
     // Basic association checks
     assert(db.user.associations.choirs, 'User should have choirs association');

--- a/choir-app-frontend/src/app/core/models/repertoire-filter.ts
+++ b/choir-app-frontend/src/app/core/models/repertoire-filter.ts
@@ -1,0 +1,11 @@
+export interface RepertoireFilter {
+  id: number;
+  name: string;
+  visibility: 'personal' | 'local' | 'global';
+  data: {
+    collectionId?: number | null;
+    categoryId?: number | null;
+    onlySingable?: boolean;
+    search?: string;
+  };
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -17,6 +17,8 @@ import { Choir } from '@core/models/choir';
 import { PieceChange } from '../models/piece-change';
 import { PieceService } from './piece.service';
 import { StatsSummary } from '../models/stats-summary';
+import { RepertoireFilter } from '../models/repertoire-filter';
+import { FilterPresetService } from './filter-preset.service';
 
 @Injectable({
   providedIn: 'root'
@@ -24,7 +26,9 @@ import { StatsSummary } from '../models/stats-summary';
 export class ApiService {
   private apiUrl = environment.apiUrl;
 
-  constructor(private http: HttpClient, private pieceService: PieceService) {
+  constructor(private http: HttpClient,
+              private pieceService: PieceService,
+              private filterPresetService: FilterPresetService) {
 
   }
 
@@ -391,4 +395,17 @@ export class ApiService {
   registerDonation(): Observable<any> {
         return this.http.post(`${this.apiUrl}/users/me/donate`, {});
     }
+
+  // --- Filter Preset Methods ---
+  getRepertoireFilters(): Observable<RepertoireFilter[]> {
+    return this.filterPresetService.getPresets();
+  }
+
+  saveRepertoireFilter(preset: { name: string; data: any; visibility: 'personal' | 'local' | 'global' }): Observable<RepertoireFilter> {
+    return this.filterPresetService.savePreset(preset);
+  }
+
+  deleteRepertoireFilter(id: number): Observable<any> {
+    return this.filterPresetService.deletePreset(id);
+  }
 }

--- a/choir-app-frontend/src/app/core/services/filter-preset.service.ts
+++ b/choir-app-frontend/src/app/core/services/filter-preset.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { RepertoireFilter } from '../models/repertoire-filter';
+
+@Injectable({ providedIn: 'root' })
+export class FilterPresetService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getPresets(): Observable<RepertoireFilter[]> {
+    return this.http.get<RepertoireFilter[]>(`${this.apiUrl}/repertoire-filters`);
+  }
+
+  savePreset(preset: { name: string; data: any; visibility: 'personal' | 'local' | 'global' }): Observable<RepertoireFilter> {
+    return this.http.post<RepertoireFilter>(`${this.apiUrl}/repertoire-filters`, preset);
+  }
+
+  deletePreset(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/repertoire-filters/${id}`);
+  }
+}

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -34,6 +34,17 @@
         <button mat-icon-button (click)="drawer.toggle()" aria-label="Toggle filters">
           <mat-icon>filter_list</mat-icon>
         </button>
+        <mat-form-field appearance="outline" class="preset-select">
+          <mat-select placeholder="Filter" [value]="selectedPresetId" (selectionChange)="onPresetSelect($event.value)">
+            <mat-option *ngFor="let p of presets" [value]="p.id">{{p.name}}</mat-option>
+          </mat-select>
+          <button mat-icon-button matSuffix *ngIf="selectedPresetId && canDeleteSelectedPreset()" (click)="deleteSelectedPreset(); $event.stopPropagation()">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </mat-form-field>
+        <button mat-icon-button (click)="saveCurrentPreset()" aria-label="Filter speichern">
+          <mat-icon>save</mat-icon>
+        </button>
         <h1>Chorrepertoire</h1>
         <button mat-flat-button color="primary" (click)="openAddPieceDialog()">
           <mat-icon>add</mat-icon>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -42,6 +42,11 @@
   }
 }
 
+.preset-select {
+  width: 200px;
+  margin: 0 1rem;
+}
+
 .filter-panel {
   width: 320px;
 }


### PR DESCRIPTION
## Summary
- add RepertoireFilter model and associations
- expose CRUD API for filter presets
- support saving/loading/deleting presets in repertoire view
- store presets on server with three visibility levels

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686037e73f708320a2bf37c365c7cffb