### PR TITLE
Show demo onboarding once per session

### DIFF
--- a/choir-app-frontend/src/app/core/services/help.service.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.ts
@@ -7,12 +7,18 @@ const PREFIX = 'help-shown-';
 export class HelpService {
   shouldShowHelp(user: User | null): boolean {
     if (!user) return false;
-    if (user.role === 'demo') return true;
+    if (user.role === 'demo') {
+      return !sessionStorage.getItem(PREFIX + 'demo');
+    }
     return !localStorage.getItem(PREFIX + user.id);
   }
 
   markHelpShown(user: User | null): void {
-    if (!user || user.role === 'demo') return;
-    localStorage.setItem(PREFIX + user.id, 'true');
+    if (!user) return;
+    if (user.role === 'demo') {
+      sessionStorage.setItem(PREFIX + 'demo', 'true');
+    } else {
+      localStorage.setItem(PREFIX + user.id, 'true');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- only show onboarding wizard once per session for demo role

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm test --prefix choir-app-backend --silent` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68619b83613c8320bc5c6a7b98909d23