### PR TITLE
Implement filter preset save dialog

### DIFF
--- a/choir-app-frontend/src/app/features/literature/filter-preset-dialog/filter-preset-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/filter-preset-dialog/filter-preset-dialog.component.html
@@ -1,0 +1,24 @@
+<h1 mat-dialog-title>Filter speichern</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" id="preset-form" (ngSubmit)="onSave()">
+    <mat-form-field appearance="outline">
+      <mat-label>Filternamen</mat-label>
+      <input matInput formControlName="name" cdkFocusInitial>
+    </mat-form-field>
+    <ng-container *ngIf="data.isAdmin || data.isChoirAdmin">
+      <mat-form-field appearance="outline">
+        <mat-label>Sichtbarkeit</mat-label>
+        <mat-select formControlName="visibility">
+          <mat-option value="personal">Persönlich</mat-option>
+          <mat-option value="local">Chorweit</mat-option>
+          <mat-option value="global">Global</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </ng-container>
+    <p>Vorhandene Filter mit gleichem Namen werden überschrieben.</p>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" type="submit" form="preset-form" [disabled]="form.invalid">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/literature/filter-preset-dialog/filter-preset-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/filter-preset-dialog/filter-preset-dialog.component.ts
@@ -1,0 +1,42 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+
+export interface FilterPresetDialogData {
+  isAdmin: boolean;
+  isChoirAdmin: boolean;
+}
+
+@Component({
+  selector: 'app-filter-preset-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './filter-preset-dialog.component.html',
+  styleUrls: ['./filter-preset-dialog.component.scss']
+})
+export class FilterPresetDialogComponent {
+  form: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<FilterPresetDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: FilterPresetDialogData
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      visibility: ['personal', Validators.required]
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onSave(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -20,6 +20,7 @@ import { PieceDialogComponent } from '../piece-dialog/piece-dialog.component';
 import { RepertoireFilter } from '@core/models/repertoire-filter';
 import { FilterPresetService } from '@core/services/filter-preset.service';
 import { AuthService } from '@core/services/auth.service';
+import { FilterPresetDialogComponent, FilterPresetDialogData } from '../filter-preset-dialog/filter-preset-dialog.component';
 
 @Component({
   selector: 'app-literature-list',
@@ -366,24 +367,21 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   }
 
   saveCurrentPreset(): void {
-    const name = prompt('Filternamen eingeben');
-    if (!name) return;
-    let visibility: 'personal' | 'local' | 'global' = 'personal';
-    if (this.isAdmin || this.isChoirAdmin) {
-      const vis = prompt('Sichtbarkeit (personal/local/global)', 'personal');
-      if (vis === 'local' || vis === 'global' || vis === 'personal') {
-        visibility = vis;
-      }
-    }
-    const data = {
-      collectionId: this.filterByCollectionId$.value,
-      categoryId: this.filterByCategoryId$.value,
-      onlySingable: this.onlySingable$.value,
-      search: this.searchControl.value
-    };
-    if (confirm('Filter speichern? Vorhandene mit gleichem Namen werden überschrieben.')) {
-      this.apiService.saveRepertoireFilter({ name, data, visibility }).subscribe(() => this.loadPresets());
-    }
+    const dialogRef = this.dialog.open<FilterPresetDialogComponent, FilterPresetDialogData, {name: string; visibility: 'personal' | 'local' | 'global'} | undefined>(FilterPresetDialogComponent, {
+      width: '400px',
+      data: { isAdmin: this.isAdmin, isChoirAdmin: this.isChoirAdmin }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (!result) return;
+      const data = {
+        collectionId: this.filterByCollectionId$.value,
+        categoryId: this.filterByCategoryId$.value,
+        onlySingable: this.onlySingable$.value,
+        search: this.searchControl.value
+      };
+      this.apiService.saveRepertoireFilter({ name: result.name, data, visibility: result.visibility }).subscribe(() => this.loadPresets());
+    });
   }
 
   canDeleteSelectedPreset(): boolean {


### PR DESCRIPTION
## Summary
- add filter preset dialog component to save presets
- replace browser prompts with new dialog in literature list

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619cf5b49883209c2857d801d67234