### PR TITLE
Translate remaining English texts

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -6,16 +6,16 @@
       <input matInput formControlName="name" cdkFocusInitial>
     </mat-form-field>
     <mat-form-field appearance="outline">
-      <mat-label>Description</mat-label>
+      <mat-label>Beschreibung</mat-label>
       <textarea matInput formControlName="description"></textarea>
     </mat-form-field>
     <mat-form-field appearance="outline">
-      <mat-label>Location</mat-label>
+      <mat-label>Ort</mat-label>
       <input matInput formControlName="location">
     </mat-form-field>
   </form>
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancel</button>
-  <button mat-flat-button color="primary" type="submit" form="choir-form" [disabled]="form.invalid">Save</button>
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" type="submit" form="choir-form" [disabled]="form.invalid">Speichern</button>
 </div>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -14,14 +14,14 @@ import { Choir } from 'src/app/core/models/choir';
 })
 export class ChoirDialogComponent {
   form: FormGroup;
-  title = 'Add Choir';
+  title = 'Chor hinzufügen';
 
   constructor(
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<ChoirDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: Choir | null
   ) {
-    this.title = data ? 'Edit Choir' : 'Add Choir';
+    this.title = data ? 'Chor bearbeiten' : 'Chor hinzufügen';
     this.form = this.fb.group({
       name: [data?.name || '', Validators.required],
       description: [data?.description || ''],

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
@@ -1,5 +1,5 @@
 <div class="toolbar">
-  <button mat-flat-button color="primary" (click)="addChoir()">Add Choir</button>
+  <button mat-flat-button color="primary" (click)="addChoir()">Chor hinzufügen</button>
 </div>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
@@ -9,7 +9,7 @@
   </ng-container>
 
   <ng-container matColumnDef="location">
-    <th mat-header-cell *matHeaderCellDef>Location</th>
+    <th mat-header-cell *matHeaderCellDef>Ort</th>
     <td mat-cell *matCellDef="let element">{{ element.location }}</td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.html
+++ b/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.html
@@ -1,14 +1,14 @@
-<h1 mat-dialog-title>Add New Category (Rubrik)</h1>
+<h1 mat-dialog-title>Neue Rubrik erstellen</h1>
 <div mat-dialog-content>
-  <p>Enter the name of the new category.</p>
+  <p>Name der neuen Rubrik eingeben.</p>
   <form [formGroup]="form" id="category-form" (ngSubmit)="onSave()">
     <mat-form-field appearance="outline">
-      <mat-label>Category Name</mat-label>
+      <mat-label>Name der Rubrik</mat-label>
       <input matInput formControlName="name" cdkFocusInitial>
     </mat-form-field>
   </form>
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancel</button>
-  <button mat-flat-button color="primary" type="submit" form="category-form" [disabled]="form.invalid">Save Category</button>
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" type="submit" form="category-form" [disabled]="form.invalid">Rubrik speichern</button>
 </div>

--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.html
@@ -1,23 +1,23 @@
-<h1 mat-dialog-title>Invite New Member</h1>
+<h1 mat-dialog-title>Neues Mitglied einladen</h1>
 <div mat-dialog-content>
-  <p>Enter the email address and assign a role for the new member.</p>
+  <p>E-Mail-Adresse eingeben und Rolle zuweisen.</p>
   <form [formGroup]="inviteForm" id="invite-form" (ngSubmit)="onInvite()">
     <mat-form-field appearance="outline">
-      <mat-label>Email Address</mat-label>
+      <mat-label>E-Mail-Adresse</mat-label>
       <input matInput formControlName="email" type="email" cdkFocusInitial>
     </mat-form-field>
     <mat-form-field appearance="outline">
-      <mat-label>Role in Choir</mat-label>
+      <mat-label>Rolle im Chor</mat-label>
       <mat-select formControlName="role">
-        <mat-option value="director">Director</mat-option>
-        <mat-option value="choir_admin">Choir Admin</mat-option>
+        <mat-option value="director">Dirigent</mat-option>
+        <mat-option value="choir_admin">Chor-Admin</mat-option>
       </mat-select>
     </mat-form-field>
   </form>
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-button (click)="onCancel()">Abbrechen</button>
   <button mat-flat-button color="primary" type="submit" form="invite-form" [disabled]="inviteForm.invalid">
-    Send Invitation
+    Einladung senden
   </button>
 </div>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -36,7 +36,7 @@
       <mat-card-title>Chorleiter</mat-card-title>
       <button mat-flat-button color="accent" (click)="openInviteDialog()">
         <mat-icon>add</mat-icon>
-        <span>Invite New Member</span>
+        <span>Neues Mitglied einladen</span>
       </button>
     </mat-card-header>
     <mat-card-content>
@@ -70,7 +70,7 @@
                 mat-icon-button
                 color="warn"
                 (click)="removeMember(user)"
-                matTooltip="Remove member from choir"
+                matTooltip="Mitglied aus dem Chor entfernen"
                 [disabled]="dataSource.data.length <= 1">
                 <mat-icon>person_remove</mat-icon>
               </button>
@@ -80,7 +80,7 @@
           <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
           <tr class="mat-row" *matNoDataRow>
             <td class="mat-cell" [attr.colspan]="displayedColumns.length">
-              No members found.
+              Keine Mitglieder gefunden.
             </td>
           </tr>
         </table>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -121,10 +121,10 @@ export class ManageChoirComponent implements OnInit {
       if (confirmed) {
         this.apiService.removeUserFromChoir(user.id).subscribe({
           next: () => {
-            this.snackBar.open(`${user.name} has been removed from the choir.`, 'OK', { duration: 3000 });
+            this.snackBar.open(`${user.name} wurde aus dem Chor entfernt.`, 'OK', { duration: 3000 });
             this.reloadData(); // Aktualisieren Sie die Datenquelle der Tabelle
           },
-          error: (err) => this.snackBar.open('Error removing member.', 'Close')
+          error: (err) => this.snackBar.open('Fehler beim Entfernen des Mitglieds.', 'Schließen')
         });
       }
     });

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -11,7 +11,7 @@
       color="accent"
       (click)="openImportDialog()">
       <mat-icon>upload_file</mat-icon>
-      Import from CSV
+      Import aus CSV
     </button>
   </div>
 
@@ -35,7 +35,7 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
-          <mat-label>Prefix (e.g., GL, EG)</mat-label>
+          <mat-label>Präfix (z.B. GL, EG)</mat-label>
           <input matInput formControlName="prefix" placeholder="CB">
         </mat-form-field>
 
@@ -155,13 +155,13 @@
 
           <ng-template #noPieces>
             <div class="no-pieces-message">
-              No pieces have been added to this collection yet. Use the form above to add one.
+              Es wurden noch keine Stücke zu dieser Sammlung hinzugefügt. Nutze das Formular oben, um eines hinzuzufügen.
             </div>
           </ng-template>
 
           <!-- Message shown when no pieces have been added yet -->
           <div *ngIf="selectedPieceLinks.length === 0" class="no-pieces-message">
-            No pieces have been added to this collection yet. Use the form above to add one.
+            Es wurden noch keine Stücke zu dieser Sammlung hinzugefügt. Nutze das Formular oben, um eines hinzuzufügen.
           </div>
         </div>
       </mat-card-content>
@@ -169,9 +169,9 @@
 
     <!-- The main actions footer for saving or canceling the entire collection -->
     <div class="actions-footer">
-      <button type="button" mat-stroked-button routerLink="/collections">Cancel</button>
+      <button type="button" mat-stroked-button routerLink="/collections">Abbrechen</button>
       <button type="submit" mat-flat-button color="primary" [disabled]="collectionForm.invalid">
-        {{ isEditMode ? 'Save Changes' : 'Save Collection' }}
+        {{ isEditMode ? 'Änderungen speichern' : 'Sammlung speichern' }}
       </button>
     </div>
   </form>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -39,7 +39,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
       <td mat-cell *matCellDef="let collection">
         <strong>{{ collection.title }}</strong>
-        <div class="prefix-hint" *ngIf="collection.prefix">Prefix: {{ collection.prefix }}</div>
+        <div class="prefix-hint" *ngIf="collection.prefix">Präfix: {{ collection.prefix }}</div>
       </td>
     </ng-container>
 
@@ -66,9 +66,9 @@
               (click)="addCollectionToChoir(collection)"
               [disabled]="collection.isAdded">
                 <mat-icon>add_circle_outline</mat-icon>
-                <span>Add to Repertoire</span>
+                <span>Zum Repertoire hinzufügen</span>
             </button>
-            <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Edit Collection">
+            <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten">
                 <mat-icon>edit</mat-icon>
             </button>
         </td>
@@ -79,6 +79,6 @@
   </table>
 
   <div *ngIf="dataSource.data.length === 0" class="empty-state">
-      <p>No collections have been created yet.</p>
+      <p>Es wurden noch keine Sammlungen erstellt.</p>
   </div>
 </div>

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>Import Pieces into "{{ data.collectionTitle }}"</h1>
+<h1 mat-dialog-title>Stücke in "{{ data.collectionTitle }}" importieren</h1>
 <!-- Fortschrittsbalken während des Imports -->
 <mat-progress-bar *ngIf="isImporting" mode="determinate" [value]="importProgress"></mat-progress-bar>
 <!-- Ladeanzeige für Vorschau -->
@@ -8,20 +8,20 @@
   <!-- Verstecken Sie den Upload-Bereich während des Imports -->
   <ng-container *ngIf="!isImporting">
     <div class="format-info">
-      <p>Please provide a CSV file with the following columns (header required):</p>
+      <p>Bitte eine CSV-Datei mit folgenden Spalten bereitstellen (Header erforderlich):</p>
       <code>nummer; titel; komponist; kategorie</code>
-      <p>The delimiter must be a semicolon (;).</p>
+      <p>Das Trennzeichen muss ein Semikolon (;) sein.</p>
     </div>
     <div class="upload-area">
       <button mat-stroked-button (click)="fileInput.click()">
-        <mat-icon>attach_file</mat-icon> Select CSV File
+        <mat-icon>attach_file</mat-icon> CSV-Datei auswählen
       </button>
       <input hidden (change)="onFileSelected($event)" #fileInput type="file" accept=".csv">
       <span *ngIf="selectedFile" class="file-name">{{ selectedFile.name }}</span>
     </div>
     <mat-divider *ngIf="previewData.length > 0"></mat-divider>
     <div *ngIf="previewData.length > 0" class="preview-area">
-    <p>Please check if the data is being read correctly.</p>
+    <p>Bitte prüfe, ob die Daten korrekt eingelesen werden.</p>
     <table mat-table [dataSource]="previewData">
       <ng-container matColumnDef="nummer">
         <th mat-header-cell *matHeaderCellDef> Nummer </th>
@@ -47,15 +47,15 @@
 
   <!-- Zeigen Sie das Log-Fenster an, sobald der Import gestartet wurde -->
   <div *ngIf="isImporting" class="log-area">
-    <h3>Import in Progress...</h3>
+    <h3>Import läuft...</h3>
     <textarea readonly class="log-textarea">{{ importLogs.join('\n') }}</textarea>
   </div>
 </div>
 
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()" [disabled]="isImporting">Cancel</button>
+  <button mat-button (click)="onCancel()" [disabled]="isImporting">Abbrechen</button>
   <button mat-flat-button color="primary" (click)="onImport()" [disabled]="!selectedFile || isLoading || isImporting">
     <mat-icon>file_upload</mat-icon>
-    Import All Rows
+    Alle Zeilen importieren
   </button>
 </div>

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.ts
@@ -53,7 +53,7 @@ export class ImportDialogComponent implements OnDestroy {
         this.isLoading = false;
       },
       error: (err) => {
-        this.snackBar.open(`Error getting preview: ${err.error?.message || 'Unknown error'}`, 'Close');
+        this.snackBar.open(`Fehler beim Laden der Vorschau: ${err.error?.message || 'Unbekannter Fehler'}`, 'Schließen');
         this.isLoading = false;
       }
     });
@@ -63,7 +63,7 @@ export class ImportDialogComponent implements OnDestroy {
     if (!this.selectedFile) return;
     this.isLoading = true;
     this.isImporting = true;
-    this.importLogs = ['Starting import process...'];
+    this.importLogs = ['Importvorgang wird gestartet...'];
     this.importProgress = 0;
 
     this.apiService.startCollectionCsvImport(this.data.collectionId, this.selectedFile).subscribe({
@@ -72,7 +72,7 @@ export class ImportDialogComponent implements OnDestroy {
         this.pollStatus(response.jobId);
       },
       error: (err) => {
-        this.snackBar.open(`Could not start import: ${err.error?.message || 'Unknown error'}`, 'Close');
+        this.snackBar.open(`Import konnte nicht gestartet werden: ${err.error?.message || 'Unbekannter Fehler'}`, 'Schließen');
         this.isLoading = false;
         this.isImporting = false;
       }
@@ -107,20 +107,20 @@ export class ImportDialogComponent implements OnDestroy {
         // Wenn der Job abgeschlossen ist, behandeln Sie das Endergebnis
         if (job.status === 'completed') {
           // Zeigen Sie die finale Erfolgsmeldung und Fehler an, falls vorhanden
-          let finalMessage = job.result?.message || 'Import completed successfully!';
+          let finalMessage = job.result?.message || 'Import erfolgreich abgeschlossen!';
           if (job.result?.errors?.length > 0) {
-            finalMessage += ` (${job.result.errors.length} errors encountered)`;
+            finalMessage += ` (${job.result.errors.length} Fehler aufgetreten)`;
           }
           this.snackBar.open(finalMessage, 'OK', { duration: 7000 });
           this.dialogRef.close(true); // Schließen und Erfolg signalisieren
         } else if (job.status === 'failed') {
-          this.snackBar.open(`Import failed: ${job.error}`, 'Close');
+          this.snackBar.open(`Import fehlgeschlagen: ${job.error}`, 'Schließen');
           this.isImporting = false;
         }
       },
       error: (err) => {
         // Fehler beim Abfragen des Status selbst
-        this.snackBar.open('Error polling for import status.', 'Close');
+        this.snackBar.open('Fehler beim Abrufen des Importstatus.', 'Schließen');
         this.isImporting = false;
         console.error('Polling error:', err);
       }

--- a/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.html
+++ b/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.html
@@ -16,6 +16,6 @@
   </form>
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancel</button>
-  <button mat-flat-button color="primary" type="submit" form="composer-form" [disabled]="form.invalid">Save</button>
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" type="submit" form="composer-form" [disabled]="form.invalid">Speichern</button>
 </div>

--- a/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.ts
@@ -17,7 +17,7 @@ import { MaterialModule } from '@modules/material.module';
 })
 export class ComposerDialogComponent {
   form: FormGroup;
-  title = 'Add New Composer';
+  title = 'Neuen Komponisten erstellen';
 
   constructor(
     private fb: FormBuilder,
@@ -26,8 +26,8 @@ export class ComposerDialogComponent {
   ) {
     const isEdit = !!data.record;
     this.title = data.role === 'author'
-      ? isEdit ? 'Edit Author' : 'Add New Author'
-      : isEdit ? 'Edit Composer' : 'Add New Composer';
+      ? isEdit ? 'Dichter bearbeiten' : 'Neuen Dichter erstellen'
+      : isEdit ? 'Komponist bearbeiten' : 'Neuen Komponisten erstellen';
     this.form = this.fb.group({
       name: [data.record?.name || '', Validators.required],
       birthYear: [data.record?.birthYear || ''],

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -28,9 +28,9 @@
     </mat-form-field>
 
     <!-- Piece Lookup -->
-    <h3 class="mat-subheading-2">Pieces</h3>
+    <h3 class="mat-subheading-2">Stücke</h3>
     <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Search by Title or Reference (e.g., CB45)</mat-label>
+      <mat-label>Nach Titel oder Referenz suchen (z.B. CB45)</mat-label>
       <input
         type="text"
         matInput
@@ -77,7 +77,7 @@
       <tr mat-header-row *matHeaderRowDef="pieceColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: pieceColumns;"></tr>
       <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell" [attr.colspan]="pieceColumns.length">No pieces selected for this event yet.</td>
+        <td class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</td>
       </tr>
     </table>
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -86,8 +86,8 @@ export class EventListComponent implements OnInit, AfterViewInit {
       dialogRef.afterClosed().subscribe(result => {
         if (result && result.id) {
           this.apiService.updateEvent(result.id, result).subscribe({
-            next: () => { this.snackBar.open('Event updated.', 'OK', { duration: 3000 }); this.loadEvents(); },
-            error: () => this.snackBar.open('Error updating event.', 'Close', { duration: 4000 })
+          next: () => { this.snackBar.open('Event aktualisiert.', 'OK', { duration: 3000 }); this.loadEvents(); },
+          error: () => this.snackBar.open('Fehler beim Aktualisieren des Events.', 'Schließen', { duration: 4000 })
           });
         }
       });
@@ -100,8 +100,8 @@ export class EventListComponent implements OnInit, AfterViewInit {
     ref.afterClosed().subscribe(confirmed => {
       if (confirmed) {
         this.apiService.deleteEvent(event.id).subscribe({
-          next: () => { this.snackBar.open('Event deleted.', 'OK', { duration: 3000 }); this.loadEvents(); },
-          error: () => this.snackBar.open('Error deleting event.', 'Close', { duration: 4000 })
+          next: () => { this.snackBar.open('Event gelöscht.', 'OK', { duration: 3000 }); this.loadEvents(); },
+          error: () => this.snackBar.open('Fehler beim Löschen des Events.', 'Schließen', { duration: 4000 })
         });
       }
     });

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -1,9 +1,9 @@
-<h1 mat-dialog-title>{{ isEditMode ? 'Edit Piece' : 'Create New Piece' }}</h1>
+<h1 mat-dialog-title>{{ isEditMode ? 'Stück bearbeiten' : 'Neues Stück erstellen' }}</h1>
 
 <div mat-dialog-content>
   <form [formGroup]="pieceForm" id="piece-form" (ngSubmit)="onSave()">
     <mat-tab-group>
-      <mat-tab label="Basic Info">
+      <mat-tab label="Grundinformationen">
         <div class="form-section">
           <!-- Title -->
           <mat-form-field appearance="outline">
@@ -13,29 +13,29 @@
 
           <!-- Voicing -->
           <mat-form-field appearance="outline">
-            <mat-label>Voicing (e.g., SATB)</mat-label>
+          <mat-label>Besetzung (z.B. SATB)</mat-label>
             <input matInput formControlName="voicing">
           </mat-form-field>
 
           <!-- Key / Tonart -->
           <mat-form-field appearance="outline">
-            <mat-label>Key (Tonart)</mat-label>
+          <mat-label>Tonart</mat-label>
             <input matInput formControlName="key">
           </mat-form-field>
 
           <!-- Time Signature / Takt -->
           <mat-form-field appearance="outline">
-            <mat-label>Time Signature (Takt)</mat-label>
+          <mat-label>Taktart</mat-label>
             <input matInput formControlName="timeSignature">
           </mat-form-field>
 
           <!-- Occasion -->
           <mat-form-field appearance="outline">
-            <mat-label>Category (Rubrik)</mat-label>
+          <mat-label>Rubrik</mat-label>
             <mat-select formControlName="categoryId">
               <mat-option [value]="addNewId">
                 <mat-icon>add</mat-icon>
-                <span>Add New Category</span>
+                <span>Neue Rubrik erstellen</span>
               </mat-option>
               <mat-divider></mat-divider>
               <!-- The rest of the options -->
@@ -58,7 +58,7 @@
       </mat-tab>
 
 
-      <mat-tab label="Authors & Arrangers">
+      <mat-tab label="Komponisten & Arrangeure">
         <div class="form-section">
           <mat-form-field appearance="outline">
             <mat-label>Komponist</mat-label>
@@ -93,29 +93,29 @@
       </mat-tab>
 
 
-      <mat-tab label="Files & Links">
+      <mat-tab label="Dateien & Links">
         <div class="form-section">
           <h4>Links</h4>
           <div formArrayName="links">
             <div *ngFor="let link of linksFormArray.controls; let i=index" [formGroupName]="i" class="link-row">
-              <mat-form-field appearance="outline"><mat-label>Description</mat-label><input matInput
+              <mat-form-field appearance="outline"><mat-label>Beschreibung</mat-label><input matInput
                   formControlName="description"></mat-form-field>
-              <mat-form-field appearance="outline"><mat-label>URL or File Path</mat-label><input matInput
+              <mat-form-field appearance="outline"><mat-label>URL oder Dateipfad</mat-label><input matInput
                   formControlName="url"></mat-form-field>
-              <mat-form-field appearance="outline"><mat-label>Type</mat-label><mat-select
-                  formControlName="type"><mat-option value="EXTERNAL">External Link</mat-option><mat-option
-                    value="FILE_DOWNLOAD">File Download</mat-option></mat-select></mat-form-field>
+              <mat-form-field appearance="outline"><mat-label>Typ</mat-label><mat-select
+                  formControlName="type"><mat-option value="EXTERNAL">Externer Link</mat-option><mat-option
+                    value="FILE_DOWNLOAD">Dateidownload</mat-option></mat-select></mat-form-field>
               <button mat-icon-button color="warn" (click)="removeLink(i)"
                 type="button"><mat-icon>delete</mat-icon></button>
             </div>
           </div>
-          <button mat-stroked-button (click)="addLink()" type="button">Add Link</button>
+          <button mat-stroked-button (click)="addLink()" type="button">Link hinzufügen</button>
         </div>
         <mat-divider></mat-divider>
         <div class="form-section">
-          <h4>Sheet Music Image</h4>
+          <h4>Notenbild</h4>
           <!-- A real file upload component would go here -->
-          <p>File upload component placeholder.</p>
+          <p>Platzhalter für Dateiupload-Komponente.</p>
         </div>
       </mat-tab>
     </mat-tab-group>

--- a/choir-app-frontend/src/app/features/login/login.component.ts
+++ b/choir-app-frontend/src/app/features/login/login.component.ts
@@ -57,8 +57,8 @@ export class LoginComponent {
       error: (err) => {
         this.isLoading = false;
         // Zeigen Sie dem Benutzer eine freundliche Fehlermeldung
-        const errorMessage = err.error?.message || 'Login failed. Please check your credentials.';
-        this.snackBar.open(errorMessage, 'Close', {
+        const errorMessage = err.error?.message || 'Anmeldung fehlgeschlagen. Bitte überprüfe deine Zugangsdaten.';
+        this.snackBar.open(errorMessage, 'Schließen', {
           duration: 5000,
           verticalPosition: 'top'
         });

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -16,14 +16,14 @@
           <mat-form-field appearance="outline">
             <mat-label>Vollständiger Name</mat-label>
             <input matInput formControlName="name">
-            <mat-error *ngIf="profileForm.get('name')?.hasError('required')">Name is required.</mat-error>
+            <mat-error *ngIf="profileForm.get('name')?.hasError('required')">Name ist erforderlich.</mat-error>
           </mat-form-field>
 
           <mat-form-field appearance="outline">
             <mat-label>E-Mail-Adresse</mat-label>
             <input matInput formControlName="email" type="email">
-            <mat-error *ngIf="profileForm.get('email')?.hasError('required')">Email is required.</mat-error>
-            <mat-error *ngIf="profileForm.get('email')?.hasError('email')">Please enter a valid email address.</mat-error>
+            <mat-error *ngIf="profileForm.get('email')?.hasError('required')">E-Mail ist erforderlich.</mat-error>
+            <mat-error *ngIf="profileForm.get('email')?.hasError('email')">Bitte eine gültige E-Mail-Adresse eingeben.</mat-error>
           </mat-form-field>
         </mat-card-content>
       </mat-card>
@@ -49,7 +49,7 @@
             <input matInput formControlName="confirmPassword" type="password" autocomplete="new-password">
             <!-- Fehlermeldung, wenn Passwörter nicht übereinstimmen -->
             <mat-error *ngIf="profileForm.get('passwords')?.hasError('passwordsMismatch')">
-              The new passwords do not match.
+              Die neuen Passwörter stimmen nicht überein.
             </mat-error>
           </mat-form-field>
         </mat-card-content>

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.html
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.html
@@ -1,13 +1,13 @@
-<h2>Invitation for {{choirName}}</h2>
-<p *ngIf="email">Register the account for {{email}}</p>
+<h2>Einladung für {{choirName}}</h2>
+<p *ngIf="email">Registriere den Account für {{email}}</p>
 <form [formGroup]="form" (ngSubmit)="submit()">
   <mat-form-field appearance="outline">
     <mat-label>Name</mat-label>
     <input matInput formControlName="name">
   </mat-form-field>
   <mat-form-field appearance="outline">
-    <mat-label>Password</mat-label>
+    <mat-label>Passwort</mat-label>
     <input matInput type="password" formControlName="password">
   </mat-form-field>
-  <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid">Register</button>
+  <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid">Registrieren</button>
 </form>

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.ts
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.ts
@@ -30,7 +30,7 @@ export class InviteRegistrationComponent implements OnInit {
     this.token = this.route.snapshot.params['token'];
     this.api.getInvitation(this.token).subscribe({
       next: data => { this.email = data.email; this.choirName = data.choirName; },
-      error: () => { this.snack.open('Invitation invalid or expired', 'Close'); }
+      error: () => { this.snack.open('Einladung ungültig oder abgelaufen', 'Schließen'); }
     });
   }
 
@@ -38,10 +38,10 @@ export class InviteRegistrationComponent implements OnInit {
     if (this.form.invalid) return;
     this.api.completeRegistration(this.token, this.form.value).subscribe({
       next: () => {
-        this.snack.open('Registration completed. You can now log in.', 'OK');
+        this.snack.open('Registrierung abgeschlossen. Du kannst dich jetzt anmelden.', 'OK');
         this.router.navigate(['/login']);
       },
-      error: err => this.snack.open(err.error?.message || 'Error', 'Close')
+      error: err => this.snack.open(err.error?.message || 'Fehler', 'Schließen')
     });
   }
 }

--- a/choir-app-frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/choir-app-frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -3,6 +3,6 @@
   <p>{{ data.message }}</p>
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onDismiss()">{{ data.cancelButtonText || 'Cancel' }}</button>
-  <button mat-flat-button color="warn" (click)="onConfirm()">{{ data.confirmButtonText || 'Confirm' }}</button>
+  <button mat-button (click)="onDismiss()">{{ data.cancelButtonText || 'Abbrechen' }}</button>
+  <button mat-flat-button color="warn" (click)="onConfirm()">{{ data.confirmButtonText || 'Bestätigen' }}</button>
 </div>

--- a/choir-app-frontend/src/app/shared/components/error-display/error-display.component.html
+++ b/choir-app-frontend/src/app/shared/components/error-display/error-display.component.html
@@ -1,9 +1,9 @@
 <div *ngIf="error$ | async as error" class="error-overlay">
   <div class="error-box">
     <mat-icon class="error-icon" color="warn">error</mat-icon>
-    <h2>An Error Occurred</h2>
+    <h2>Ein Fehler ist aufgetreten</h2>
     <p>{{ error.message }}</p>
-    <p *ngIf="error.status">Status Code: {{ error.status }}</p>
-    <button mat-flat-button color="warn" (click)="clear()">Dismiss</button>
+    <p *ngIf="error.status">Statuscode: {{ error.status }}</p>
+    <button mat-flat-button color="warn" (click)="clear()">Schließen</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- translate English UI strings in many Angular components
- update dialogs, error messages and labels

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68619d0f0d188320bc16009068a63b2d