### PR TITLE
Support single-edition collections

### DIFF
--- a/choir-app-backend/src/models/collection.model.js
+++ b/choir-app-backend/src/models/collection.model.js
@@ -3,6 +3,8 @@ module.exports = (sequelize, DataTypes) => {
         title: { type: DataTypes.STRING, allowNull: false, unique: true },
         publisher: { type: DataTypes.STRING },
         prefix: { type: DataTypes.STRING }, // e.g., "GL", "EG"
+        // true if this collection represents a single edition (only one piece)
+        singleEdition: { type: DataTypes.BOOLEAN, defaultValue: false },
         // Optional filename of the uploaded cover image
         coverImage: { type: DataTypes.STRING }
     });

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -23,6 +23,7 @@ const db = require('../src/models');
     checkFields(db.event, ['date', 'type']);
     checkFields(db.composer, ['name']);
     checkFields(db.category, ['name']);
+    checkFields(db.collection, ['singleEdition']);
     checkFields(db.collection_piece, ['numberInCollection']);
     checkFields(db.user_choir, ['roleInChoir', 'registrationStatus']);
     checkFields(db.piece_change, ['data']);

--- a/choir-app-frontend/src/app/core/models/collection.ts
+++ b/choir-app-frontend/src/app/core/models/collection.ts
@@ -28,6 +28,11 @@ export interface Collection {
   prefix?: string;
 
   /**
+   * Indicates that this collection contains only a single piece.
+   */
+  singleEdition?: boolean;
+
+  /**
    * An optional array of Piece objects that are part of this collection.
    * This property may or may not be present depending on the API call.
    * For example, it would be included when fetching a single collection's details,

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -176,7 +176,7 @@ export class ApiService {
   }
 
 
-  createCollection(data: { title: string, publisher?: string, prefix?: string, pieceIds: number[] }): Observable<Collection> {
+  createCollection(data: any): Observable<Collection> {
     return this.http.post<Collection>(`${this.apiUrl}/collections`, data);
   }
 

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -39,6 +39,8 @@
           <input matInput formControlName="prefix" placeholder="CB">
         </mat-form-field>
 
+        <mat-checkbox formControlName="singleEdition">Einzelausgabe (nur ein Stück)</mat-checkbox>
+
         <div class="cover-upload">
           <div
             class="dropzone"
@@ -64,7 +66,7 @@
       </mat-card-header>
       <mat-card-content>
         <!-- This is the sub-form for adding a single piece-number link -->
-        <div class="add-piece-container">
+        <div class="add-piece-container" *ngIf="!collectionForm.value.singleEdition || selectedPieceLinks.length === 0">
           <h3>Stücke hinzufügen</h3>
           <form [formGroup]="addPieceForm" (ngSubmit)="addPieceToCollection()" class="add-piece-form">
             <!-- Autocomplete field to search for and select a piece -->
@@ -105,6 +107,10 @@
               <mat-icon>add</mat-icon> Hinzufügen
             </button>
           </form>
+        </div>
+
+        <div *ngIf="collectionForm.value.singleEdition && selectedPieceLinks.length > 0" class="single-hint">
+          Einzelausgabe: Es kann nur ein Stück hinzugefügt werden.
         </div>
 
         <br>

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -109,6 +109,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
             title: ['', Validators.required],
             publisher: [''],
             prefix: [''],
+            singleEdition: [false],
         });
 
         this.addPieceForm = this.fb.group({
@@ -284,6 +285,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
             title: collection.title,
             publisher: collection.publisher,
             prefix: collection.prefix,
+            singleEdition: collection.singleEdition,
         });
 
         if (collection.coverImage) {
@@ -331,6 +333,10 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
 
     addPieceToCollection(): void {
         if (this.addPieceForm.invalid) return;
+        if (this.collectionForm.value.singleEdition && this.selectedPieceLinks.length >= 1) {
+            this.snackBar.open('Einzelausgabe: nur ein Stück erlaubt.', 'OK', { duration: 3000 });
+            return;
+        }
 
         const piece = this.addPieceForm.value.piece as Piece;
         const number = this.addPieceForm.value.number;


### PR DESCRIPTION
## Summary
- mark collections as single editions in the model
- limit added pieces if collection is a single edition
- expose the field in the API and frontend
- allow editing of the flag in the collection form
- update model tests

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68619e18f2f08320b742f492077a00ab