### PR TITLE
Add external data enrichment for composers and authors

### DIFF
--- a/choir-app-backend/src/controllers/author.controller.js
+++ b/choir-app-backend/src/controllers/author.controller.js
@@ -65,3 +65,31 @@ exports.remove = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+exports.enrich = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const author = await Author.findByPk(id);
+        if (!author) return res.status(404).send({ message: "Author not found." });
+
+        const query = encodeURIComponent(author.name);
+        const url = `https://musicbrainz.org/ws/2/artist/?query=${query}&fmt=json&limit=1`;
+        const response = await fetch(url, {
+            headers: { 'User-Agent': 'chorleiter/1.0 ( https://example.com )' }
+        });
+        if (!response.ok) throw new Error('Failed to fetch data');
+        const data = await response.json();
+        const artist = data.artists && data.artists[0];
+        if (artist && artist["life-span"]) {
+            const span = artist["life-span"];
+            if (span.begin) author.birthYear = span.begin.substring(0, 4);
+            if (span.end) author.deathYear = span.end.substring(0, 4);
+            await author.save();
+            return res.status(200).send(author);
+        } else {
+            return res.status(404).send({ message: "No data found" });
+        }
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/controllers/composer.controller.js
+++ b/choir-app-backend/src/controllers/composer.controller.js
@@ -67,3 +67,31 @@ exports.remove = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+exports.enrich = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const composer = await Composer.findByPk(id);
+        if (!composer) return res.status(404).send({ message: "Composer not found." });
+
+        const query = encodeURIComponent(composer.name);
+        const url = `https://musicbrainz.org/ws/2/artist/?query=${query}&fmt=json&limit=1`;
+        const response = await fetch(url, {
+            headers: { 'User-Agent': 'chorleiter/1.0 ( https://example.com )' }
+        });
+        if (!response.ok) throw new Error('Failed to fetch data');
+        const data = await response.json();
+        const artist = data.artists && data.artists[0];
+        if (artist && artist["life-span"]) {
+            const span = artist["life-span"];
+            if (span.begin) composer.birthYear = span.begin.substring(0, 4);
+            if (span.end) composer.deathYear = span.end.substring(0, 4);
+            await composer.save();
+            return res.status(200).send(composer);
+        } else {
+            return res.status(404).send({ message: "No data found" });
+        }
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/routes/author.routes.js
+++ b/choir-app-backend/src/routes/author.routes.js
@@ -8,5 +8,6 @@ router.post("/", controller.create);
 router.get("/", controller.findAll);
 router.put("/:id", controller.update);
 router.delete("/:id", controller.remove);
+router.post("/:id/enrich", controller.enrich);
 
 module.exports = router;

--- a/choir-app-backend/src/routes/composer.routes.js
+++ b/choir-app-backend/src/routes/composer.routes.js
@@ -8,5 +8,6 @@ router.post("/", controller.create);
 router.get("/", controller.findAll);
 router.put("/:id", controller.update);
 router.delete("/:id", controller.remove);
+router.post("/:id/enrich", controller.enrich);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -136,6 +136,10 @@ export class ApiService {
     return this.http.delete(`${this.apiUrl}/composers/${id}`);
   }
 
+  enrichComposer(id: number): Observable<Composer> {
+    return this.http.post<Composer>(`${this.apiUrl}/composers/${id}/enrich`, {});
+  }
+
   getAuthors(): Observable<Author[]> {
     return this.http.get<Author[]>(`${this.apiUrl}/authors`);
   }
@@ -150,6 +154,10 @@ export class ApiService {
 
   deleteAuthor(id: number): Observable<any> {
     return this.http.delete(`${this.apiUrl}/authors/${id}`);
+  }
+
+  enrichAuthor(id: number): Observable<Author> {
+    return this.http.post<Author>(`${this.apiUrl}/authors/${id}/enrich`, {});
   }
 
 

--- a/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.html
@@ -24,6 +24,9 @@
       <button mat-icon-button color="primary" (click)="editAuthor(element)">
         <mat-icon>edit</mat-icon>
       </button>
+      <button mat-icon-button color="accent" (click)="enrichAuthor(element)">
+        <mat-icon>cloud_download</mat-icon>
+      </button>
       <button mat-icon-button color="warn" (click)="deleteAuthor(element)" [disabled]="!element.canDelete">
         <mat-icon>delete</mat-icon>
       </button>

--- a/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.ts
@@ -62,4 +62,14 @@ export class ManageAuthorsComponent implements OnInit {
       this.api.deleteAuthor(author.id).subscribe(() => this.loadAuthors());
     }
   }
+
+  enrichAuthor(author: Author): void {
+    this.api.enrichAuthor(author.id).subscribe(updated => {
+      const idx = this.authors.findIndex(a => a.id === author.id);
+      if (idx !== -1) {
+        this.authors[idx] = { ...author, ...updated } as Author;
+        this.dataSource.data = this.authors;
+      }
+    });
+  }
 }

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
@@ -30,6 +30,9 @@
       <button mat-icon-button color="primary" (click)="editComposer(element)">
         <mat-icon>edit</mat-icon>
       </button>
+      <button mat-icon-button color="accent" (click)="enrichComposer(element)">
+        <mat-icon>cloud_download</mat-icon>
+      </button>
       <button mat-icon-button color="warn" (click)="deleteComposer(element)" [disabled]="!element.canDelete">
         <mat-icon>delete</mat-icon>
       </button>

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.ts
@@ -106,4 +106,14 @@ export class ManageComposersComponent implements OnInit, AfterViewInit {
       this.adminApiService.deleteComposer(composer.id).subscribe(() => this.loadComposers());
     }
   }
+
+  enrichComposer(composer: Composer): void {
+    this.adminApiService.enrichComposer(composer.id).subscribe(updated => {
+      const idx = this.composers.findIndex(c => c.id === composer.id);
+      if (idx !== -1) {
+        this.composers[idx] = { ...composer, ...updated } as Composer;
+        this.applyFilter();
+      }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- fetch composer/author life-span from MusicBrainz
- expose `/enrich` endpoint on composer and author routes
- add API service helpers for enrichment
- provide new buttons in composer/author admin tables

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a56f82588320b2e5689575ce4d07