### PR TITLE
Add fields to collections

### DIFF
--- a/choir-app-backend/src/controllers/collection.controller.js
+++ b/choir-app-backend/src/controllers/collection.controller.js
@@ -9,7 +9,7 @@ const fs = require('fs').promises;
 
 // Die create- und update-Funktionen bleiben unverändert, aber wir fügen eine Fehlerbehandlung hinzu.
 exports.create = async (req, res, next) => {
-    const { title, publisher, prefix, singleEdition, pieces } = req.body;
+    const { title, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
     try {
         if (req.userRole === 'demo') {
             return res.status(403).send({ message: 'Demo user cannot modify collections.' });
@@ -17,7 +17,7 @@ exports.create = async (req, res, next) => {
         if (singleEdition && pieces && pieces.length > 1) {
             return res.status(400).send({ message: 'Einzelausgabe kann nur ein Stück enthalten.' });
         }
-        const collection = await Collection.create({ title, publisher, prefix, singleEdition });
+        const collection = await Collection.create({ title, publisher, prefix, description, publisherNumber, singleEdition });
         if (pieces && pieces.length > 0) {
             for (const pieceInfo of pieces) {
                 await collection.addPiece(pieceInfo.pieceId, {
@@ -31,7 +31,7 @@ exports.create = async (req, res, next) => {
 
 exports.update = async (req, res, next) => {
     const id = req.params.id;
-    const { title, publisher, prefix, singleEdition, pieces } = req.body;
+    const { title, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
     try {
         if (req.userRole === 'demo') {
             return res.status(403).send({ message: 'Demo user cannot modify collections.' });
@@ -42,7 +42,7 @@ exports.update = async (req, res, next) => {
         if (singleEdition && pieces && pieces.length > 1) {
             return res.status(400).send({ message: 'Einzelausgabe kann nur ein Stück enthalten.' });
         }
-        await collection.update({ title, publisher, prefix, singleEdition });
+        await collection.update({ title, publisher, prefix, description, publisherNumber, singleEdition });
         await collection.setPieces([]);
         if (pieces && pieces.length > 0) {
             for (const pieceLink of pieces) {

--- a/choir-app-backend/src/models/collection.model.js
+++ b/choir-app-backend/src/models/collection.model.js
@@ -3,6 +3,8 @@ module.exports = (sequelize, DataTypes) => {
         title: { type: DataTypes.STRING, allowNull: false, unique: true },
         publisher: { type: DataTypes.STRING },
         prefix: { type: DataTypes.STRING }, // e.g., "GL", "EG"
+        description: { type: DataTypes.TEXT },
+        publisherNumber: { type: DataTypes.STRING },
         // true if this collection represents a single edition (only one piece)
         singleEdition: { type: DataTypes.BOOLEAN, defaultValue: false },
         // Optional filename of the uploaded cover image

--- a/choir-app-frontend/src/app/core/models/collection.ts
+++ b/choir-app-frontend/src/app/core/models/collection.ts
@@ -21,6 +21,12 @@ export interface Collection {
    */
   publisher?: string;
 
+  /** Description text for the collection */
+  description?: string;
+
+  /** Publisher number identifying the edition */
+  publisherNumber?: string;
+
   /**
    * A short prefix or abbreviation for the collection (e.g., "GL", "CFC", "EG").
    * This is optional.

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -39,6 +39,16 @@
           <input matInput formControlName="prefix" placeholder="CB">
         </mat-form-field>
 
+        <mat-form-field appearance="outline">
+          <mat-label>Verlagsnummer</mat-label>
+          <input matInput formControlName="publisherNumber">
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Beschreibung</mat-label>
+          <textarea matInput formControlName="description" rows="3"></textarea>
+        </mat-form-field>
+
         <mat-checkbox formControlName="singleEdition">Einzelausgabe (nur ein Stück)</mat-checkbox>
 
         <div class="cover-upload">

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -109,6 +109,8 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
             title: ['', Validators.required],
             publisher: [''],
             prefix: [''],
+            publisherNumber: [''],
+            description: [''],
             singleEdition: [false],
         });
 
@@ -285,6 +287,8 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
             title: collection.title,
             publisher: collection.publisher,
             prefix: collection.prefix,
+            publisherNumber: collection.publisherNumber,
+            description: collection.description,
             singleEdition: collection.singleEdition,
         });
 


### PR DESCRIPTION
## Summary
- extend collection model with `description` and `publisherNumber`
- allow these fields in collection creation/update
- adapt frontend model and edit form to handle new fields

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6861a822fb0c832083965a266af597f4