### PR TITLE
Enable editing global pieces

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -139,6 +139,9 @@
             <ng-container matColumnDef="actions">
               <th mat-header-cell *matHeaderCellDef></th>
               <td mat-cell *matCellDef="let link" class="actions-cell">
+                <button mat-icon-button (click)="openEditPieceDialog(link.piece.id)" matTooltip="Stück bearbeiten">
+                  <mat-icon>edit</mat-icon>
+                </button>
                 <button mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Remove piece from collection">
                   <mat-icon>delete</mat-icon>
                 </button>

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -331,6 +331,27 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
             });
     }
 
+    openEditPieceDialog(pieceId: number): void {
+        const dialogRef = this.dialog.open(PieceDialogComponent, {
+            width: '500px',
+            disableClose: true,
+            data: { pieceId }
+        });
+
+        dialogRef.afterClosed().subscribe(wasUpdated => {
+            if (wasUpdated) {
+                this.apiService.getPieceById(pieceId).subscribe(updatedPiece => {
+                    const idx = this.allPieces.findIndex(p => p.id === pieceId);
+                    if (idx !== -1) this.allPieces[idx] = updatedPiece;
+                    this.selectedPieceLinks = this.selectedPieceLinks.map(link =>
+                        link.piece.id === pieceId ? { ...link, piece: updatedPiece } : link
+                    );
+                    this.updateDataSource();
+                });
+            }
+        });
+    }
+
     addPieceToCollection(): void {
         if (this.addPieceForm.invalid) return;
         if (this.collectionForm.value.singleEdition && this.selectedPieceLinks.length >= 1) {


### PR DESCRIPTION
## Summary
- allow editing pieces from collection edit screen

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6861a8b51dc8832094f6e7380e756f0d