### PR TITLE
Enable row click to open collections

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -63,19 +63,19 @@
             <button
               mat-stroked-button
               color="primary"
-              (click)="addCollectionToChoir(collection)"
+              (click)="addCollectionToChoir(collection); $event.stopPropagation()"
               [disabled]="collection.isAdded">
                 <mat-icon>add_circle_outline</mat-icon>
                 <span>Zum Repertoire hinzufügen</span>
             </button>
-            <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten">
+            <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
                 <mat-icon>edit</mat-icon>
             </button>
         </td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)"></tr>
   </table>
 
   <div *ngIf="dataSource.data.length === 0" class="empty-state">

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -61,3 +61,17 @@ mat-card-actions button mat-icon {
     width: auto;
     object-fit: cover;
 }
+
+.table-container .mat-row {
+    cursor: pointer;
+}
+
+.table-container .mat-row:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+}
+
+@media (prefers-color-scheme: dark) {
+    .table-container .mat-row:hover {
+        background-color: rgba(255, 255, 255, 0.08);
+    }
+}

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -8,7 +8,7 @@ import { ApiService } from '@core/services/api.service';
 import { Collection } from '@core/models/collection';
 import { forkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { RouterLink } from '@angular/router'; // Import RouterLink for the template
+import { RouterLink, Router } from '@angular/router'; // Import RouterLink and Router
 
 @Component({
   selector: 'app-collection-list',
@@ -36,7 +36,8 @@ export class CollectionListComponent implements OnInit {
 
   constructor(
     public apiService: ApiService,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private router: Router
   ) { }
 
   ngOnInit(): void {
@@ -84,5 +85,9 @@ export class CollectionListComponent implements OnInit {
         });
       }
     });
+  }
+
+  openCollection(collection: Collection): void {
+    this.router.navigate(['/collections/edit', collection.id]);
   }
 }


### PR DESCRIPTION
## Summary
- open collection editor when a row is clicked
- stop row click when using action buttons
- add pointer cursor and hover highlight for rows

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a908c55c832084f90e5f191bca11