### PR TITLE
Fix drawer responsive behavior

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -56,7 +56,7 @@
 
 <mat-sidenav-container class="site-container">
   <mat-sidenav #appDrawer mode="over" [fixedInViewport]="false" [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
-    [mode]="(isHandset$ | async) ? 'over' : 'side'" [opened]="!(isHandset$ | async)" class="appDrawer">
+    [mode]="(isHandset$ | async) ? 'over' : 'side'" [opened]="!(isHandset$ | async) && drawerOpenByWidth" class="appDrawer">
 
     <mat-nav-list>
       <app-choir-switcher *ngIf="isLoggedIn$ | async"></app-choir-switcher>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, HostListener, AfterViewInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router'; // RouterModule importieren
 import { AuthService } from 'src/app/core/services/auth.service';
 
@@ -37,7 +37,7 @@ import { HelpService } from '@core/services/help.service';
   ],
   providers: [NavService],
 })
-export class MainLayoutComponent implements OnInit{
+export class MainLayoutComponent implements OnInit, AfterViewInit{
   isLoggedIn$: Observable<boolean>;
   isAdmin$: Observable<boolean>;
   donatedRecently$: Observable<boolean>;
@@ -47,6 +47,10 @@ export class MainLayoutComponent implements OnInit{
   isShowing = false;
   @ViewChild('appDrawer') appDrawer: MatDrawer | undefined;
    private isHandset: boolean = false;
+
+  drawerOpenByWidth = true;
+  private readonly drawerWidth = 220;
+  private readonly maxDrawerRatio = 0.4;
 
   headerHeight = 64;
   footerHeight = 56;
@@ -84,7 +88,22 @@ export class MainLayoutComponent implements OnInit{
     this.isHandset$.subscribe(match => {
       this.isHandset = match;
       this.headerHeight = match ? 56 : 64;
+      this.evaluateDrawerWidth();
     });
+  }
+
+  ngAfterViewInit(): void {
+    this.evaluateDrawerWidth();
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.evaluateDrawerWidth();
+  }
+
+  private evaluateDrawerWidth() {
+    const width = window.innerWidth;
+    this.drawerOpenByWidth = (this.drawerWidth / width) <= this.maxDrawerRatio;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- keep sidenav closed when it would cover more than 40% of the viewport
- track window resize and adjust the drawer open state

## Testing
- `npm test` *(fails: `ng: not found`)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6861aa8e15c48320819fe78f0218be8c