### PR TITLE
Add Windows deployment script

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = 'Stop'
+
+$PasswordFile = "$env:USERPROFILE\.chorleiter_deploy_pw"
+$RemoteUser = "root"
+$RemoteHost = "88.222.220.28"
+$Remote = "$RemoteUser@$RemoteHost"
+$BackendDest = "/usr/local/lsws/ChorStatistik/backend"
+$FrontendDest = "/usr/local/lsws/ChorStatistik/html"
+
+# Build Angular frontend
+npm --prefix choir-app-frontend run build
+
+Write-Host "Build finished."
+
+$Password = $null
+if (Test-Path $PasswordFile) {
+    $Password = (Get-Content $PasswordFile -Raw).Trim()
+}
+if (-not $Password) {
+    $Password = Read-Host "SSH password for $Remote"
+}
+
+$sshCmd = "ssh"
+$scpCmd = "scp"
+if (Get-Command sshpass -ErrorAction SilentlyContinue) {
+    $sshCmd = "sshpass -p `"$Password`" ssh -o StrictHostKeyChecking=no"
+    $scpCmd = "sshpass -p `"$Password`" scp"
+}
+
+$BackendArchive = [IO.Path]::GetTempFileName() + ".tar.gz"
+$FrontendArchive = [IO.Path]::GetTempFileName() + ".tar.gz"
+
+# Pack directories
+& tar --exclude=".env" -czf $BackendArchive -C "choir-app-backend" .
+& tar -czf $FrontendArchive -C "choir-app-frontend/dist/choir-app-frontend/browser" .
+
+# Create remote directories
+Invoke-Expression "$sshCmd $Remote \"mkdir -p '$BackendDest' '$FrontendDest'\""
+
+# Upload archives
+Invoke-Expression "$scpCmd $BackendArchive $Remote:/tmp/backend.tar.gz"
+Invoke-Expression "$scpCmd $FrontendArchive $Remote:/tmp/frontend.tar.gz"
+
+# Extract archives on server and clean up
+Invoke-Expression "$sshCmd $Remote \"tar -xzf /tmp/backend.tar.gz -C '$BackendDest' && rm /tmp/backend.tar.gz\""
+Invoke-Expression "$sshCmd $Remote \"tar -xzf /tmp/frontend.tar.gz -C '$FrontendDest' && rm /tmp/frontend.tar.gz\""
+
+Remove-Item $BackendArchive
+Remove-Item $FrontendArchive
+
+Write-Host "Deployment completed."

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+PASSWORD_FILE="${HOME}/.chorleiter_deploy_pw"
+REMOTE_USER="root"
+REMOTE_HOST="88.222.220.28"
+REMOTE="${REMOTE_USER}@${REMOTE_HOST}"
+BACKEND_DEST="/usr/local/lsws/ChorStatistik/backend"
+FRONTEND_DEST="/usr/local/lsws/ChorStatistik/html"
+
+# Build Angular frontend
+npm --prefix choir-app-frontend run build
+
+echo "Build finished." 
+
+# Get password from file or prompt
+if [[ -f "$PASSWORD_FILE" ]]; then
+    PASSWORD=$(<"$PASSWORD_FILE")
+fi
+
+if [[ -z "$PASSWORD" ]]; then
+    read -s -p "SSH password for ${REMOTE}: " PASSWORD
+    echo
+fi
+
+SSH_CMD="ssh"
+RSYNC_CMD="rsync -avz"
+if command -v sshpass >/dev/null; then
+    SSH_CMD="sshpass -p \"$PASSWORD\" ssh -o StrictHostKeyChecking=no"
+    RSYNC_CMD="sshpass -p \"$PASSWORD\" rsync -avz"
+fi
+
+# Create remote directories
+$SSH_CMD $REMOTE "mkdir -p \"$BACKEND_DEST\" \"$FRONTEND_DEST\""
+
+# Deploy backend (excluding .env)
+$RSYNC_CMD --delete --exclude='.env' choir-app-backend/ ${REMOTE}:"$BACKEND_DEST/"
+
+# Deploy compiled frontend
+$RSYNC_CMD --delete choir-app-frontend/dist/choir-app-frontend/browser/ ${REMOTE}:"$FRONTEND_DEST/"
+
+echo "Deployment completed."


### PR DESCRIPTION
## Summary
- add `deploy.ps1` for Windows deployment

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm test --prefix choir-app-backend` *(fails: `Cannot find module 'sequelize'`)*


------
https://chatgpt.com/codex/tasks/task_e_6861ac1eff408320bad79605fa736392