### PR TITLE
Enable setting password in admin user dialog

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -10,6 +10,10 @@
       <input matInput formControlName="email">
     </mat-form-field>
     <mat-form-field appearance="outline">
+      <mat-label>Password</mat-label>
+      <input matInput type="password" formControlName="password">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
       <mat-label>Role</mat-label>
       <mat-select formControlName="role">
         <mat-option value="director">director</mat-option>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -25,7 +25,8 @@ export class UserDialogComponent {
     this.form = this.fb.group({
       name: [data?.name || '', Validators.required],
       email: [data?.email || '', [Validators.required, Validators.email]],
-      role: [data?.role || 'director', Validators.required]
+      role: [data?.role || 'director', Validators.required],
+      password: ['', data ? [] : [Validators.required]]
     });
   }
 
@@ -35,7 +36,11 @@ export class UserDialogComponent {
 
   onSave(): void {
     if (this.form.valid) {
-      this.dialogRef.close(this.form.value);
+      const value = { ...this.form.value };
+      if (!value.password) {
+        delete value.password;
+      }
+      this.dialogRef.close(value);
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow manual password entry when creating or editing users
- don't send empty password fields to the API

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6861aeb129948320a514667f435e9f53