### PR TITLE
Add admin build info dialog

### DIFF
--- a/choir-app-frontend/public/assets/build-info.json
+++ b/choir-app-frontend/public/assets/build-info.json
@@ -1,0 +1,6 @@
+{
+  "buildUser": "Unknown",
+  "buildDate": "2024-01-01T00:00:00Z",
+  "installUser": "Unknown",
+  "installDate": "2024-01-01T00:00:00Z"
+}

--- a/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.html
@@ -1,0 +1,13 @@
+<h2 mat-dialog-title>Build &amp; Installationsinfo</h2>
+<div mat-dialog-content>
+  <ng-container *ngIf="info; else loading">
+    <p><strong>Build von:</strong> {{ info.buildUser }}</p>
+    <p><strong>Build-Datum:</strong> {{ info.buildDate | date:'short' }}</p>
+    <p><strong>Installiert von:</strong> {{ info.installUser }}</p>
+    <p><strong>Installations-Datum:</strong> {{ info.installDate | date:'short' }}</p>
+  </ng-container>
+  <ng-template #loading>Informationen werden geladen...</ng-template>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="close()">Schließen</button>
+</div>

--- a/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.scss
@@ -1,0 +1,1 @@
+/* Add your styles here if needed */

--- a/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+
+interface BuildInfo {
+  buildUser: string;
+  buildDate: string;
+  installUser: string;
+  installDate: string;
+}
+
+@Component({
+  selector: 'app-build-info-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './build-info-dialog.component.html',
+  styleUrls: ['./build-info-dialog.component.scss']
+})
+export class BuildInfoDialogComponent implements OnInit {
+  info: BuildInfo | null = null;
+
+  constructor(private http: HttpClient, private dialogRef: MatDialogRef<BuildInfoDialogComponent>) {}
+
+  ngOnInit(): void {
+    this.http.get<BuildInfo>('assets/build-info.json').subscribe(data => this.info = data);
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -27,6 +27,10 @@
         <mat-icon>contrast</mat-icon>
         <span>Theme</span>
       </button>
+      <button *ngIf="isAdmin$ | async" mat-menu-item (click)="openBuildInfo()">
+        <mat-icon>info</mat-icon>
+        <span>Build Info</span>
+      </button>
       <button mat-menu-item (click)="openHelp()">
         <mat-icon>help_outline</mat-icon>
         <span>Hilfe</span>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -19,6 +19,7 @@ import { MatDrawer } from '@angular/material/sidenav';
 import { MatDialog } from '@angular/material/dialog';
 import { HelpWizardComponent } from '@shared/components/help-wizard/help-wizard.component';
 import { HelpService } from '@core/services/help.service';
+import { BuildInfoDialogComponent } from '@features/admin/build-info-dialog/build-info-dialog.component';
 
 @Component({
   selector: 'app-main-layout',
@@ -208,6 +209,10 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
     if (this.isHandset) {
       this.appDrawer?.close();
     }
+  }
+
+  openBuildInfo(): void {
+    this.dialog.open(BuildInfoDialogComponent, { width: '400px' });
   }
 
   openHelp(): void {


### PR DESCRIPTION
## Summary
- show build/install information to admins
- add `build-info.json`
- add dialog for the info
- expose dialog from user menu for admins

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6861af9239448320ba5db5e4a72d8b3e