### PR TITLE
Fix quoting in PowerShell deploy script

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -38,12 +38,12 @@ $FrontendArchive = [IO.Path]::GetTempFileName() + ".tar.gz"
 Invoke-Expression "$sshCmd $Remote \"mkdir -p '$BackendDest' '$FrontendDest'\""
 
 # Upload archives
-Invoke-Expression "$scpCmd $BackendArchive $Remote:/tmp/backend.tar.gz"
-Invoke-Expression "$scpCmd $FrontendArchive $Remote:/tmp/frontend.tar.gz"
+Invoke-Expression "$scpCmd $BackendArchive ${Remote}:/tmp/backend.tar.gz"
+Invoke-Expression "$scpCmd $FrontendArchive ${Remote}:/tmp/frontend.tar.gz"
 
 # Extract archives on server and clean up
-Invoke-Expression "$sshCmd $Remote \"tar -xzf /tmp/backend.tar.gz -C '$BackendDest' && rm /tmp/backend.tar.gz\""
-Invoke-Expression "$sshCmd $Remote \"tar -xzf /tmp/frontend.tar.gz -C '$FrontendDest' && rm /tmp/frontend.tar.gz\""
+Invoke-Expression "$sshCmd ${Remote} \"tar -xzf /tmp/backend.tar.gz -C '$BackendDest'; rm /tmp/backend.tar.gz\""
+Invoke-Expression "$sshCmd ${Remote} \"tar -xzf /tmp/frontend.tar.gz -C '$FrontendDest'; rm /tmp/frontend.tar.gz\""
 
 Remove-Item $BackendArchive
 Remove-Item $FrontendArchive


### PR DESCRIPTION
## Summary
- escape `$Remote` usage when appending remote paths
- use `;` instead of `&&` inside SSH commands

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6861b03e9bac8320b2828c08d7f552bd