### PR TITLE
Add automated build info generation

### DIFF
--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -7,7 +7,11 @@
     "startwithtimestamp": "node ./scripts/serve-with-timestamp.js",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "generate-build-info": "node ./scripts/generate-build-info.js",
+    "prebuild": "npm run generate-build-info",
+    "prestart": "npm run generate-build-info",
+    "prestartwithtimestamp": "npm run generate-build-info"
   },
   "private": true,
   "dependencies": {

--- a/choir-app-frontend/scripts/generate-build-info.js
+++ b/choir-app-frontend/scripts/generate-build-info.js
@@ -1,0 +1,28 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getGitCommit() {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch (err) {
+    return 'unknown';
+  }
+}
+
+const commit = getGitCommit();
+const buildDate = new Date().toISOString();
+const version = require('../package.json').version;
+
+const content = `export const buildInfo = {
+  version: '${version}',
+  commit: '${commit}',
+  date: '${buildDate}'
+};
+`;
+
+const outFile = path.join(__dirname, '..', 'src', 'environments', 'build-info.ts');
+fs.writeFileSync(outFile, content);
+console.log(`Generated ${outFile}`);
+
+

--- a/choir-app-frontend/src/environments/build-info.ts
+++ b/choir-app-frontend/src/environments/build-info.ts
@@ -1,0 +1,6 @@
+export const buildInfo = {
+  version: 'dev',
+  commit: 'dev',
+  date: 'dev'
+};
+


### PR DESCRIPTION
## Summary
- generate build information on each build
- store build metadata in `src/environments/build-info.ts`
- call generator script before builds and dev servers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b18dabd08320ada3f70bed9a16e8