### PR TITLE
Update deploy.ps1 with password storage and restart

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -15,6 +15,12 @@ Write-Host "Build finished."
 $Password = $null
 if (Test-Path $PasswordFile) {
     $Password = (Get-Content $PasswordFile -Raw).Trim()
+} else {
+    $create = Read-Host "Password file $PasswordFile not found. Create it? (y/N)"
+    if ($create -match '^[Yy]') {
+        $Password = Read-Host "SSH password for $Remote"
+        Set-Content -Path $PasswordFile -Value $Password
+    }
 }
 if (-not $Password) {
     $Password = Read-Host "SSH password for $Remote"
@@ -69,6 +75,9 @@ Invoke-Scp $FrontendArchive "${Remote}:/tmp/frontend.tar.gz"
 # Extract archives on server and clean up
 Invoke-Ssh "tar -xzf /tmp/backend.tar.gz -C '$BackendDest'; rm /tmp/backend.tar.gz"
 Invoke-Ssh "tar -xzf /tmp/frontend.tar.gz -C '$FrontendDest'; rm /tmp/frontend.tar.gz"
+
+# Restart backend
+Invoke-Ssh "pm2 restart chorleiter-api"
 
 Remove-Item $BackendArchive
 Remove-Item $FrontendArchive


### PR DESCRIPTION
## Summary
- create password file on demand and reuse stored password
- restart backend via pm2 after deploying

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b5229ed483209962bfa4ec3f8cb8