### PR TITLE
Persist user preferences server-side

### DIFF
--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -86,3 +86,30 @@ exports.registerDonation = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+exports.getPreferences = async (req, res) => {
+    try {
+        const user = await User.findByPk(req.userId);
+        if (!user) {
+            return res.status(404).send({ message: "User not found." });
+        }
+        res.status(200).send(user.preferences || {});
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.updatePreferences = async (req, res) => {
+    try {
+        const user = await User.findByPk(req.userId);
+        if (!user) {
+            return res.status(404).send({ message: "User not found." });
+        }
+        const prefs = Object.assign({}, user.preferences || {}, req.body || {});
+        user.preferences = prefs;
+        await user.save();
+        res.status(200).send(prefs);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -27,6 +27,11 @@ module.exports = (sequelize, DataTypes) => {
       lastDonation: {
         type: DataTypes.DATE,
         allowNull: true
+      },
+      preferences: {
+        type: DataTypes.JSON,
+        allowNull: true,
+        defaultValue: {}
       }
     });
     return User;

--- a/choir-app-backend/src/routes/user.routes.js
+++ b/choir-app-backend/src/routes/user.routes.js
@@ -7,5 +7,7 @@ router.use(authJwt.verifyToken);
 router.get("/me", controller.getMe);
 router.put("/me", controller.updateMe);
 router.post("/me/donate", controller.registerDonation);
+router.get("/me/preferences", controller.getPreferences);
+router.put("/me/preferences", controller.updatePreferences);
 
 module.exports = router;

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -17,7 +17,7 @@ const db = require('../src/models');
       }
     }
 
-    checkFields(db.user, ['email', 'role', 'lastDonation']);
+    checkFields(db.user, ['email', 'role', 'lastDonation', 'preferences']);
     checkFields(db.choir, ['name']);
     checkFields(db.piece, ['title']);
     checkFields(db.event, ['date', 'type']);

--- a/choir-app-frontend/src/app/core/models/user-preferences.ts
+++ b/choir-app-frontend/src/app/core/models/user-preferences.ts
@@ -1,0 +1,5 @@
+export interface UserPreferences {
+  theme?: 'light' | 'dark' | 'system';
+  helpShown?: boolean;
+  pageSizes?: { [key: string]: number };
+}

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -7,6 +7,8 @@ import { environment } from 'src/environments/environment';
 import { User } from '../models/user';
 import { Choir } from '../models/choir';
 import { SwitchChoirResponse } from '../models/auth';
+import { ThemeService } from './theme.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 const TOKEN_KEY = 'auth-token';
 const USER_KEY = 'user';
@@ -27,7 +29,10 @@ export class AuthService {
   // --- Wir leiten die Berechtigungen direkt vom currentUser$ ab ---
   public isAdmin$: Observable<boolean>;
 
-  constructor(private http: HttpClient, private router: Router) {
+  constructor(private http: HttpClient,
+              private router: Router,
+              private theme: ThemeService,
+              private prefs: UserPreferencesService) {
     this.isAdmin$ = this.currentUser$.pipe(map(user => user?.role === 'admin'));
   }
 
@@ -54,6 +59,12 @@ export class AuthService {
           this.currentUserSubject.next(user);
           this.activeChoir$.next(user.activeChoir || null);
           this.availableChoirs$.next(user.availableChoirs || []);
+
+          this.prefs.load().subscribe(p => {
+            if (p.theme) {
+              this.theme.setTheme(p.theme);
+            }
+          });
         }
       })
     );
@@ -62,6 +73,7 @@ export class AuthService {
   logout(): void {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
+    this.prefs.clear();
     this.loggedIn.next(false);
     this.currentUserSubject.next(null);
     this.activeChoir$.next(null);

--- a/choir-app-frontend/src/app/core/services/help.service.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.ts
@@ -1,16 +1,19 @@
 import { Injectable } from '@angular/core';
 import { User } from '../models/user';
+import { UserPreferencesService } from './user-preferences.service';
 
 const PREFIX = 'help-shown-';
 
 @Injectable({ providedIn: 'root' })
 export class HelpService {
+  constructor(private prefs: UserPreferencesService) {}
+
   shouldShowHelp(user: User | null): boolean {
     if (!user) return false;
     if (user.role === 'demo') {
       return !sessionStorage.getItem(PREFIX + 'demo');
     }
-    return !localStorage.getItem(PREFIX + user.id);
+    return !this.prefs.getPreference('helpShown');
   }
 
   markHelpShown(user: User | null): void {
@@ -18,7 +21,7 @@ export class HelpService {
     if (user.role === 'demo') {
       sessionStorage.setItem(PREFIX + 'demo', 'true');
     } else {
-      localStorage.setItem(PREFIX + user.id, 'true');
+      this.prefs.update({ helpShown: true }).subscribe();
     }
   }
 }

--- a/choir-app-frontend/src/app/core/services/paginator.service.ts
+++ b/choir-app-frontend/src/app/core/services/paginator.service.ts
@@ -1,18 +1,21 @@
 import { Injectable } from '@angular/core';
+import { UserPreferencesService } from './user-preferences.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PaginatorService {
-  private readonly KEY_PREFIX = 'paginator-page-size-';
+  constructor(private prefs: UserPreferencesService) {}
 
   getPageSize(key: string, defaultSize: number): number {
-    const stored = localStorage.getItem(this.KEY_PREFIX + key);
-    const val = stored ? parseInt(stored, 10) : NaN;
-    return isNaN(val) ? defaultSize : val;
+    const map = this.prefs.getPreference('pageSizes') || {};
+    const val = map[key];
+    return val ? val : defaultSize;
   }
 
   setPageSize(key: string, size: number): void {
-    localStorage.setItem(this.KEY_PREFIX + key, size.toString());
+    const map = { ...(this.prefs.getPreference('pageSizes') || {}) };
+    map[key] = size;
+    this.prefs.update({ pageSizes: map }).subscribe();
   }
 }

--- a/choir-app-frontend/src/app/core/services/theme.service.spec.ts
+++ b/choir-app-frontend/src/app/core/services/theme.service.spec.ts
@@ -1,12 +1,18 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ThemeService } from './theme.service';
+import { UserPreferencesService } from './user-preferences.service';
+import { of } from 'rxjs';
 
 describe('ThemeService', () => {
   let service: ThemeService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserPreferencesService, useValue: { getPreference: () => null, update: () => of({}) } }
+      ]
+    });
     service = TestBed.inject(ThemeService);
   });
 

--- a/choir-app-frontend/src/app/core/services/theme.service.ts
+++ b/choir-app-frontend/src/app/core/services/theme.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { UserPreferencesService } from './user-preferences.service';
 
 export type Theme = 'light' | 'dark' | 'system';
-const THEME_KEY = 'choir-app-theme';
 
 @Injectable({
   providedIn: 'root'
@@ -10,17 +10,18 @@ export class ThemeService {
   private renderer: Renderer2;
   private currentTheme: Theme = 'system';
 
-  constructor(rendererFactory: RendererFactory2) {
+  constructor(rendererFactory: RendererFactory2,
+              private prefs: UserPreferencesService) {
     // Wir benötigen den Renderer, um Klassen sicher zum <body>-Tag hinzuzufügen.
     this.renderer = rendererFactory.createRenderer(null, null);
   }
 
   /**
    * Initialisiert das Theme beim Start der Anwendung.
-   * Lädt die Benutzereinstellung aus dem localStorage oder verwendet 'system' als Standard.
+   * Lädt die Benutzereinstellung aus dem gespeicherten Profil oder verwendet 'system' als Standard.
    */
   initializeTheme(): void {
-    const storedTheme = localStorage.getItem(THEME_KEY) as Theme | null;
+    const storedTheme = this.prefs.getPreference('theme') as Theme | undefined;
     this.currentTheme = storedTheme || 'system';
     this.applyTheme(this.currentTheme);
 
@@ -39,7 +40,7 @@ export class ThemeService {
    */
   setTheme(theme: Theme): void {
     this.currentTheme = theme;
-    localStorage.setItem(THEME_KEY, theme);
+    this.prefs.update({ theme }).subscribe();
     this.applyTheme(theme);
   }
 

--- a/choir-app-frontend/src/app/core/services/user-preferences.service.ts
+++ b/choir-app-frontend/src/app/core/services/user-preferences.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { UserPreferences } from '../models/user-preferences';
+
+@Injectable({ providedIn: 'root' })
+export class UserPreferencesService {
+  private prefs$ = new BehaviorSubject<UserPreferences>({});
+  private apiUrl = `${environment.apiUrl}/users/me/preferences`;
+
+  constructor(private http: HttpClient) {}
+
+  load(): Observable<UserPreferences> {
+    return this.http.get<UserPreferences>(this.apiUrl).pipe(
+      tap(p => this.prefs$.next(p))
+    );
+  }
+
+  getPreference<K extends keyof UserPreferences>(key: K): UserPreferences[K] | undefined {
+    return this.prefs$.value[key];
+  }
+
+  update(prefs: Partial<UserPreferences>): Observable<UserPreferences> {
+    const newPrefs = { ...this.prefs$.value, ...prefs };
+    return this.http.put<UserPreferences>(this.apiUrl, newPrefs).pipe(
+      tap(p => this.prefs$.next(p))
+    );
+  }
+
+  clear() {
+    this.prefs$.next({});
+  }
+}


### PR DESCRIPTION
## Summary
- extend user model with a `preferences` JSON column
- expose new endpoints `/users/me/preferences` to read and update preferences
- add `UserPreferencesService` on the frontend and use it for theme, help and paginator settings
- load preferences after login and apply stored theme
- update tests for new preferences logic

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --prefix choir-app-frontend` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621b58611c8320b72ffd97cfce6d55