### PR TITLE
Show event creator in dashboard cards

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -153,7 +153,7 @@ exports.findLast = async (req, res) => {
                         }
                     }
                 ]
-            }]
+            }, { model: User, as: 'director', attributes: ['name'] }]
         });
 
         if (!lastEvent) {

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.html
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.html
@@ -5,7 +5,10 @@
   <mat-card-content>
     <!-- Überprüfen Sie, ob ein Event-Objekt übergeben wurde -->
     <ng-container *ngIf="event; else noData">
-      <h3>{{ event.date | date:'fullDate' }}</h3>
+      <h3>
+        {{ event.date | date:'fullDate' }}
+        <span class="event-creator" *ngIf="event.director">({{ event.director.name }})</span>
+      </h3>
       <mat-list>
         <mat-list-item *ngFor="let piece of event.pieces">
           <div matListItemTitle>

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.scss
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.scss
@@ -17,6 +17,11 @@ mat-card-content h3 {
     margin: 0 0 1rem 0;
 }
 
+.event-creator {
+    font-size: 0.8em;
+    color: inherit;
+}
+
 .no-data-message {
     display: flex;
     justify-content: center;

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.spec.ts
@@ -20,4 +20,19 @@ describe('EventCardComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should display the director name if provided', () => {
+    component.event = {
+      id: 1,
+      date: '2023-01-01',
+      type: 'SERVICE',
+      createdAt: '2023-01-01',
+      updatedAt: '2023-01-01',
+      director: { name: 'Alice' },
+      pieces: []
+    } as any;
+    fixture.detectChanges();
+    const h3 = fixture.nativeElement.querySelector('h3');
+    expect(h3.textContent).toContain('(Alice)');
+  });
 });


### PR DESCRIPTION
## Summary
- show event creator in event cards on dashboard
- style creator text smaller and with same color as date
- test director name rendering
- include director info when fetching last event

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862228d1f88832099b19135424f37bd