### PR TITLE
Align deploy scripts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,6 +16,13 @@ echo "Build finished."
 # Get password from file or prompt
 if [[ -f "$PASSWORD_FILE" ]]; then
     PASSWORD=$(<"$PASSWORD_FILE")
+else
+    read -r -p "Password file $PASSWORD_FILE not found. Create it? (y/N) " create
+    if [[ $create =~ ^[Yy] ]]; then
+        read -s -p "SSH password for ${REMOTE}: " PASSWORD
+        echo
+        echo "$PASSWORD" > "$PASSWORD_FILE"
+    fi
 fi
 
 if [[ -z "$PASSWORD" ]]; then
@@ -24,19 +31,35 @@ if [[ -z "$PASSWORD" ]]; then
 fi
 
 SSH_CMD="ssh"
-RSYNC_CMD="rsync -avz"
+SCP_CMD="scp"
 if command -v sshpass >/dev/null; then
     SSH_CMD="sshpass -p \"$PASSWORD\" ssh -o StrictHostKeyChecking=no"
-    RSYNC_CMD="sshpass -p \"$PASSWORD\" rsync -avz"
+    SCP_CMD="sshpass -p \"$PASSWORD\" scp"
 fi
+
+# Create temporary archives
+BACKEND_ARCHIVE=$(mktemp --suffix=.tar.gz)
+FRONTEND_ARCHIVE=$(mktemp --suffix=.tar.gz)
+
+# Pack directories
+tar --exclude=".env" -czf "$BACKEND_ARCHIVE" -C "choir-app-backend" .
+tar -czf "$FRONTEND_ARCHIVE" -C "choir-app-frontend/dist/choir-app-frontend/browser" .
 
 # Create remote directories
 $SSH_CMD $REMOTE "mkdir -p \"$BACKEND_DEST\" \"$FRONTEND_DEST\""
 
-# Deploy backend (excluding .env)
-$RSYNC_CMD --delete --exclude='.env' choir-app-backend/ ${REMOTE}:"$BACKEND_DEST/"
+# Upload archives
+$SCP_CMD "$BACKEND_ARCHIVE" ${REMOTE}:/tmp/backend.tar.gz
+$SCP_CMD "$FRONTEND_ARCHIVE" ${REMOTE}:/tmp/frontend.tar.gz
 
-# Deploy compiled frontend
-$RSYNC_CMD --delete choir-app-frontend/dist/choir-app-frontend/browser/ ${REMOTE}:"$FRONTEND_DEST/"
+# Extract archives on server and clean up
+$SSH_CMD $REMOTE "tar -xzf /tmp/backend.tar.gz -C \"$BACKEND_DEST\"; rm /tmp/backend.tar.gz"
+$SSH_CMD $REMOTE "tar -xzf /tmp/frontend.tar.gz -C \"$FRONTEND_DEST\"; rm /tmp/frontend.tar.gz"
+
+# Restart backend
+$SSH_CMD $REMOTE "pm2 restart chorleiter-api"
+
+# Remove local archives
+rm -f "$BACKEND_ARCHIVE" "$FRONTEND_ARCHIVE"
 
 echo "Deployment completed."


### PR DESCRIPTION
## Summary
- unify Windows and Linux deployment steps
- ensure both deploy scripts create temp archives, upload, extract, and restart backend

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68623769db348320a63c4698f7d2cab0