### PR TITLE
Add CSV import for events

### DIFF
--- a/choir-app-backend/src/controllers/import.controller.js
+++ b/choir-app-backend/src/controllers/import.controller.js
@@ -115,3 +115,122 @@ exports.getImportStatus = (req, res) => {
     }
     res.status(200).send(job);
 };
+
+// ------------------ EVENT CSV IMPORT ------------------
+
+const findPieceByReferenceOrTitle = async (reference, title) => {
+    let piece = null;
+    if (reference) {
+        const match = reference.match(/^(\D+)(\d+)$/);
+        if (match) {
+            const prefix = match[1];
+            const num = match[2];
+            piece = await db.piece.findOne({
+                include: [{
+                    model: db.collection,
+                    as: 'collections',
+                    where: { prefix },
+                    through: { where: { numberInCollection: num } }
+                }]
+            });
+        }
+    }
+    if (!piece && title) {
+        piece = await db.piece.findOne({ where: { title } });
+    }
+    return piece;
+};
+
+const processEventImport = async (job, eventType, records, choirId, userId) => {
+    jobs.updateJobProgress(job.id, 0, records.length);
+    let processed = 0;
+    const { Op } = require('sequelize');
+
+    for (const [index, record] of records.entries()) {
+        try {
+            const reference = record.referenz || record.reference;
+            const title = record.titel || record.title;
+            const dateStr = record.datum || record.date;
+
+            if (!title || !dateStr) {
+                throw new Error(`Missing data in row ${index + 1}`);
+            }
+
+            const piece = await findPieceByReferenceOrTitle(reference, title);
+            if (!piece) {
+                throw new Error(`Piece not found for "${title}"`);
+            }
+
+            const targetDate = new Date(dateStr);
+            const start = new Date(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate(), 0, 0, 0, 0);
+            const end = new Date(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate(), 23, 59, 59, 999);
+
+            let event = await db.event.findOne({
+                where: {
+                    choirId,
+                    type: eventType,
+                    date: { [Op.between]: [start, end] }
+                }
+            });
+
+            if (!event) {
+                event = await db.event.create({
+                    date: dateStr,
+                    type: eventType,
+                    choirId,
+                    directorId: userId
+                });
+                jobs.updateJobLog(job.id, `Event on ${dateStr} created.`);
+            }
+
+            const [link, created] = await db.event_pieces.findOrCreate({
+                where: { eventId: event.id, pieceId: piece.id }
+            });
+            if (created) {
+                jobs.updateJobLog(job.id, `Piece "${piece.title}" added to event ${dateStr}.`);
+            } else {
+                jobs.updateJobLog(job.id, `Piece "${piece.title}" already in event ${dateStr}.`);
+            }
+
+            processed++;
+        } catch (err) {
+            jobs.updateJobLog(job.id, `Error on row ${index + 1}: ${err.message}`);
+        }
+        jobs.updateJobProgress(job.id, index + 1, records.length);
+    }
+
+    const result = { message: `Import complete. ${processed} rows processed.` };
+    jobs.completeJob(job.id, result);
+};
+
+exports.startImportEvents = async (req, res) => {
+    const eventType = (req.query.type || '').toUpperCase();
+    if (!['REHEARSAL', 'SERVICE'].includes(eventType)) {
+        return res.status(400).send({ message: 'Invalid event type.' });
+    }
+    if (!req.file) return res.status(400).send({ message: 'No CSV file uploaded.' });
+
+    const fileContent = req.file.buffer.toString('utf-8');
+    const parser = parse(fileContent, { delimiter: ';', columns: header => header.map(h => h.trim().toLowerCase()), skip_empty_lines: true, trim: true });
+
+    const records = [];
+    try {
+        for await (const record of parser) { records.push(record); }
+    } catch (e) {
+        return res.status(400).send({ message: 'Could not parse CSV file.' });
+    }
+
+    if (req.query.mode === 'preview') {
+        return res.status(200).send(records.slice(0, 2));
+    }
+
+    const jobId = crypto.randomUUID();
+    const job = jobs.createJob(jobId);
+    job.status = 'running';
+
+    processEventImport(job, eventType, records, req.activeChoirId, req.userId).catch(err => {
+        jobs.failJob(jobId, err.message);
+    });
+
+    res.status(202).send({ jobId });
+};

--- a/choir-app-backend/src/routes/import.routes.js
+++ b/choir-app-backend/src/routes/import.routes.js
@@ -10,6 +10,7 @@ const upload = multer({ storage: storage });
 router.use(authJwt.verifyToken);
 
 router.post("/collection/:id", upload.single('csvfile'), controller.startImportCsvToCollection);
+router.post("/events", upload.single('csvfile'), controller.startImportEvents);
 router.get("/status/:jobId", controller.getImportStatus);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -289,6 +289,20 @@ export class ApiService {
     return this.http.post<{ jobId: string }>(`${this.apiUrl}/import/collection/${collectionId}`, formData);
   }
 
+  uploadEventCsv(file: File, type: 'REHEARSAL' | 'SERVICE', mode: 'preview' | 'import'): Observable<any> {
+    const formData = new FormData();
+    formData.append('csvfile', file, file.name);
+    const params = new HttpParams().set('mode', mode).set('type', type);
+    return this.http.post(`${this.apiUrl}/import/events`, formData, { params });
+  }
+
+  startEventCsvImport(file: File, type: 'REHEARSAL' | 'SERVICE'): Observable<{ jobId: string }> {
+    const formData = new FormData();
+    formData.append('csvfile', file, file.name);
+    const params = new HttpParams().set('type', type);
+    return this.http.post<{ jobId: string }>(`${this.apiUrl}/import/events`, formData, { params });
+  }
+
   // Diese Methode fragt den Status eines Jobs ab
   getImportStatus(jobId: string): Observable<any> {
     return this.http.get(`${this.apiUrl}/import/status/${jobId}`);

--- a/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.html
@@ -1,0 +1,60 @@
+<h1 mat-dialog-title>Ereignisse importieren</h1>
+<mat-progress-bar *ngIf="isImporting" mode="determinate" [value]="importProgress"></mat-progress-bar>
+<mat-progress-bar *ngIf="isLoading && !isImporting" mode="indeterminate"></mat-progress-bar>
+
+<div mat-dialog-content>
+  <ng-container *ngIf="!isImporting">
+    <div class="format-info">
+      <p>CSV mit folgenden Spalten bereitstellen (Header erforderlich):</p>
+      <code>referenz; titel; datum</code>
+      <p>Trennzeichen ist ein Semikolon (;).</p>
+    </div>
+    <mat-form-field appearance="outline">
+      <mat-label>Typ</mat-label>
+      <mat-select [(ngModel)]="eventType" disableRipple>
+        <mat-option value="SERVICE">Gottesdienst</mat-option>
+        <mat-option value="REHEARSAL">Probe</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <div class="upload-area">
+      <button mat-stroked-button (click)="fileInput.click()">
+        <mat-icon>attach_file</mat-icon> CSV-Datei auswählen
+      </button>
+      <input hidden (change)="onFileSelected($event)" #fileInput type="file" accept=".csv">
+      <span *ngIf="selectedFile" class="file-name">{{ selectedFile.name }}</span>
+    </div>
+    <mat-divider *ngIf="previewData.length > 0"></mat-divider>
+    <div *ngIf="previewData.length > 0" class="preview-area">
+      <p>Bitte prüfe, ob die Daten korrekt eingelesen werden.</p>
+      <table mat-table [dataSource]="previewData">
+        <ng-container matColumnDef="reference">
+          <th mat-header-cell *matHeaderCellDef>Referenz</th>
+          <td mat-cell *matCellDef="let row">{{ row.referenz || row.reference }}</td>
+        </ng-container>
+        <ng-container matColumnDef="title">
+          <th mat-header-cell *matHeaderCellDef>Titel</th>
+          <td mat-cell *matCellDef="let row">{{ row.titel || row.title }}</td>
+        </ng-container>
+        <ng-container matColumnDef="date">
+          <th mat-header-cell *matHeaderCellDef>Datum</th>
+          <td mat-cell *matCellDef="let row">{{ row.datum || row.date }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="previewColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: previewColumns;"></tr>
+      </table>
+    </div>
+  </ng-container>
+
+  <div *ngIf="isImporting" class="log-area">
+    <h3>Import läuft...</h3>
+    <textarea readonly class="log-textarea">{{ importLogs.join('\n') }}</textarea>
+  </div>
+</div>
+
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()" [disabled]="isImporting">Abbrechen</button>
+  <button mat-flat-button color="primary" (click)="onImport()" [disabled]="!selectedFile || isLoading || isImporting">
+    <mat-icon>file_upload</mat-icon>
+    Alle Zeilen importieren
+  </button>
+</div>

--- a/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.scss
@@ -1,0 +1,21 @@
+.format-info {
+  margin-bottom: 1em;
+}
+.upload-area {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+.preview-area {
+  max-height: 200px;
+  overflow: auto;
+}
+.log-area {
+  max-height: 200px;
+  overflow: auto;
+}
+.log-textarea {
+  width: 100%;
+  height: 180px;
+}

--- a/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Subscription, timer } from 'rxjs';
+import { switchMap, takeWhile, tap } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-event-import-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MaterialModule],
+  templateUrl: './event-import-dialog.component.html',
+  styleUrls: ['./event-import-dialog.component.scss']
+})
+export class EventImportDialogComponent implements OnDestroy {
+  selectedFile: File | null = null;
+  previewData: any[] = [];
+  isLoading = false;
+  isImporting = false;
+  importLogs: string[] = [];
+  importProgress = 0;
+  eventType: 'REHEARSAL' | 'SERVICE' = 'SERVICE';
+  private statusSubscription?: Subscription;
+
+  previewColumns: string[] = ['reference', 'title', 'date'];
+
+  constructor(
+    private dialogRef: MatDialogRef<EventImportDialogComponent>,
+    private apiService: ApiService,
+    private snackBar: MatSnackBar
+  ) {}
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.selectedFile = input.files[0];
+      this.previewData = [];
+      this.isImporting = false;
+      this.getPreview();
+    }
+  }
+
+  getPreview(): void {
+    if (!this.selectedFile) return;
+    this.isLoading = true;
+    this.apiService.uploadEventCsv(this.selectedFile, this.eventType, 'preview').subscribe({
+      next: preview => { this.previewData = preview; this.isLoading = false; },
+      error: err => { this.snackBar.open(`Fehler beim Laden der Vorschau: ${err.error?.message || 'Unbekannter Fehler'}`, 'Schließen'); this.isLoading = false; }
+    });
+  }
+
+  onImport(): void {
+    if (!this.selectedFile) return;
+    this.isLoading = true;
+    this.isImporting = true;
+    this.importLogs = ['Importvorgang wird gestartet...'];
+    this.importProgress = 0;
+
+    this.apiService.startEventCsvImport(this.selectedFile, this.eventType).subscribe({
+      next: res => { this.isLoading = false; this.pollStatus(res.jobId); },
+      error: err => { this.snackBar.open(`Import konnte nicht gestartet werden: ${err.error?.message || 'Unbekannter Fehler'}`, 'Schließen'); this.isLoading = false; this.isImporting = false; }
+    });
+  }
+
+  private pollStatus(jobId: string): void {
+    if (this.statusSubscription) this.statusSubscription.unsubscribe();
+
+    this.statusSubscription = timer(0, 500).pipe(
+      switchMap(() => this.apiService.getImportStatus(jobId)),
+      tap(job => console.log('Polling status:', job)),
+      takeWhile(job => job.status === 'running' || job.status === 'pending', true)
+    ).subscribe({
+      next: job => {
+        this.importLogs = job.logs;
+        if (job.total > 0) {
+          this.importProgress = Math.round((job.progress / job.total) * 100);
+        } else {
+          this.importProgress = 0;
+        }
+        if (job.status === 'completed') {
+          this.snackBar.open(job.result?.message || 'Import erfolgreich abgeschlossen!', 'OK', { duration: 7000 });
+          this.dialogRef.close(true);
+        } else if (job.status === 'failed') {
+          this.snackBar.open(`Import fehlgeschlagen: ${job.error}`, 'Schließen');
+          this.isImporting = false;
+        }
+      },
+      error: () => { this.snackBar.open('Fehler beim Abrufen des Importstatus.', 'Schließen'); this.isImporting = false; }
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  ngOnDestroy(): void {
+    if (this.statusSubscription) this.statusSubscription.unsubscribe();
+  }
+}

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -14,6 +14,10 @@
     <mat-icon>add</mat-icon>
     <span>Neues Ereignis</span>
   </button>
+  <button mat-stroked-button color="accent" (click)="openImportDialog()" style="margin-left:8px;">
+    <mat-icon>upload_file</mat-icon>
+    <span>Import</span>
+  </button>
 </div>
 
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -12,6 +12,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { PaginatorService } from '@core/services/paginator.service';
 import { startWith } from 'rxjs/operators';
 import { EventDialogComponent } from '../event-dialog/event-dialog.component';
+import { EventImportDialogComponent } from '../event-import-dialog/event-import-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
 import { EventCardComponent } from '../../home/event-card/event-card.component';
@@ -127,6 +128,15 @@ export class EventListComponent implements OnInit, AfterViewInit {
             this.snackBar.open(msg, 'Schließen', { duration: 5000 });
           }
         });
+      }
+    });
+  }
+
+  openImportDialog(): void {
+    const dialogRef = this.dialog.open(EventImportDialogComponent, { width: '800px' });
+    dialogRef.afterClosed().subscribe(wasImported => {
+      if (wasImported) {
+        this.loadEvents();
       }
     });
   }


### PR DESCRIPTION
## Summary
- enable event import via CSV on the backend
- expose new import endpoints in the API service
- create EventImportDialog to upload and monitor CSV imports
- add Import button on event list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623419e6848320999064a9fd79465d