### PR TITLE
Fix event import date parsing and add bulk deletion endpoint

### DIFF
--- a/choir-app-backend/src/routes/event.routes.js
+++ b/choir-app-backend/src/routes/event.routes.js
@@ -9,6 +9,7 @@ router.get("/", controller.findAll);
 router.get("/:id", controller.findOne);
 router.post("/", controller.create);
 router.put("/:id", controller.update);
+router.delete("/range", authJwt.isChoirAdminOrAdmin, controller.deleteRange);
 router.delete("/:id", authJwt.isChoirAdminOrAdmin, controller.delete);
 // Later you will add POST for creation: router.post("/", controller.create);
 

--- a/choir-app-backend/tests/event.controller.test.js
+++ b/choir-app-backend/tests/event.controller.test.js
@@ -31,7 +31,15 @@ const controller = require('../src/controllers/event.controller');
     assert.strictEqual(res.statusCode, 201);
     assert.ok(res.data.warning);
 
-    console.log('event.controller create test passed');
+    // Delete events in date range
+    const delReq = {
+      activeChoirId: choir.id,
+      query: { start: '2024-01-01', end: '2024-01-02' }
+    };
+    await controller.deleteRange(delReq, res);
+    assert.strictEqual(res.data.message.includes('events deleted'), true);
+
+    console.log('event.controller create and deleteRange tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -255,6 +255,12 @@ export class ApiService {
     return this.http.delete(`${this.apiUrl}/events/${id}`);
   }
 
+  deleteEventsInRange(start: string, end: string, type?: 'SERVICE' | 'REHEARSAL'): Observable<any> {
+    let params = new HttpParams().set('start', start).set('end', end);
+    if (type) params = params.set('type', type);
+    return this.http.delete(`${this.apiUrl}/events/range`, { params });
+  }
+
 
   // --- User Methods ---
 


### PR DESCRIPTION
## Summary
- handle German date format in event CSV import
- ignore the title column when importing events
- allow admins to delete events in a date range
- expose bulk delete route and frontend API helper
- adjust tests for new controller method

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626cb5a1ec832090039166a06b484b