### PR TITLE
Implement admin bulk delete for events

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -18,11 +18,23 @@
     <mat-icon>upload_file</mat-icon>
     <span>Import</span>
   </button>
+  <button *ngIf="isAdmin" mat-stroked-button color="warn" (click)="deleteSelectedEvents()" [disabled]="selection.isEmpty()" style="margin-left:8px;">
+    <mat-icon>delete</mat-icon>
+    <span>Löschen</span>
+  </button>
 </div>
 
 
 <div class="table-wrapper mat-elevation-z4">
   <table mat-table [dataSource]="dataSource" class="event-table">
+    <ng-container matColumnDef="select">
+      <th mat-header-cell *matHeaderCellDef>
+        <mat-checkbox (change)="toggleAll()" [checked]="isAllSelected()" [indeterminate]="selection.hasValue() && !isAllSelected()"></mat-checkbox>
+      </th>
+      <td mat-cell *matCellDef="let ev">
+        <mat-checkbox (click)="$event.stopPropagation()" (change)="toggleEvent(ev)" [checked]="selection.isSelected(ev)"></mat-checkbox>
+      </td>
+    </ng-container>
     <ng-container matColumnDef="date">
       <th mat-header-cell *matHeaderCellDef>Datum</th>
       <td mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</td>


### PR DESCRIPTION
## Summary
- allow admins to select events via new checkbox column
- add bulk delete button for selected events

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68626d338d9c8320bfae2e1af6c32380