### PR TITLE
Fix event import deduplication

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js"
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/import.controller.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -6,7 +6,7 @@ const Collection = db.collection;
 const CollectionPiece = db.collection_piece;
 const User = db.user;
 const logger = require("../config/logger");
-const { Op } = require("sequelize");
+const { Op, fn, col, where } = require("sequelize");
 
 async function autoUpdatePieceStatuses(eventType, choirId, pieceIds) {
     if (!Array.isArray(pieceIds) || pieceIds.length === 0) return;
@@ -47,16 +47,13 @@ exports.create = async (req, res) => {
 
     try {
         const targetDate = new Date(date);
-        const startOfDay = new Date(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate(), 0, 0, 0, 0);
-        const endOfDay = new Date(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate(), 23, 59, 59, 999);
+        const dateOnly = targetDate.toISOString().split('T')[0];
 
         // Prüfen, ob für diesen Chor an diesem Tag bereits Events existieren
         const eventsSameDay = await db.event.findAll({
             where: {
                 choirId: choirId,
-                date: {
-                    [Op.between]: [startOfDay, endOfDay]
-                }
+                [Op.and]: [where(fn('date', col('date')), dateOnly)]
             }
         });
 

--- a/choir-app-backend/tests/import.controller.test.js
+++ b/choir-app-backend/tests/import.controller.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/import.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+
+    const choir = await db.choir.create({ name: 'Test Choir' });
+    const user = await db.user.create({ email: 't@example.com', role: 'USER' });
+    const composer = await db.composer.create({ name: 'Composer' });
+    const piece = await db.piece.create({ title: 'Piece', composerId: composer.id });
+    const collection = await db.collection.create({ title: 'Coll', prefix: 'X' });
+    await piece.addCollection(collection, { through: { numberInCollection: '1' } });
+
+    const records = [
+      { reference: 'X1', date: '01.01.2024' },
+      { reference: 'X1', date: '01.01.2024' }
+    ];
+    const job = { id: 'job', logs: [], status: 'running', progress: 0, total: records.length };
+    await controller._test.processEventImport(job, 'SERVICE', records, choir.id, user.id);
+
+    const events = await db.event.findAll();
+    assert.strictEqual(events.length, 1, 'should only create one event');
+    const links = await db.event_pieces.count();
+    assert.strictEqual(links, 1, 'should only link piece once');
+
+    console.log('import.controller duplicate handling test passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- ensure event import checks existing events by date only to avoid duplicates
- adjust event creation to query by date only
- expose import helper for tests and add regression test

## Testing
- `npm test --silent --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686275ccda608320911ddd1fbe3d8fa6