### PR TITLE
Update piece detail translations

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -18,6 +18,7 @@ import { EventImportDialogComponent } from '../event-import-dialog/event-import-
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
 import { EventCardComponent } from '../../home/event-card/event-card.component';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-event-list',
@@ -49,7 +50,8 @@ export class EventListComponent implements OnInit, AfterViewInit {
               private authService: AuthService,
               private dialog: MatDialog,
               private snackBar: MatSnackBar,
-              private paginatorService: PaginatorService) {
+              private paginatorService: PaginatorService,
+              private route: ActivatedRoute) {
     this.pageSize = this.paginatorService.getPageSize('event-list', this.pageSizeOptions[0]);
   }
 
@@ -63,6 +65,10 @@ export class EventListComponent implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.loadEvents();
+    const eventId = Number(this.route.snapshot.queryParamMap.get('eventId'));
+    if (eventId) {
+      this.apiService.getEventById(eventId).subscribe(e => this.selectedEvent = e);
+    }
     this.typeControl.valueChanges.pipe(startWith('ALL')).subscribe(() => this.loadEvents());
     this.apiService.checkChoirAdminStatus().subscribe(s => {
       this.isChoirAdmin = s.isChoirAdmin;

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -2,12 +2,17 @@
   <h2>{{ piece.title }}</h2>
   <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
-  <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status }}</p>
+  <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>
 
   <h3>Geprobt bei</h3>
   <mat-list *ngIf="piece.events?.length; else noEvents">
     <mat-list-item *ngFor="let ev of piece.events">
-      <div matLine>{{ ev.date | date:'mediumDate' }} - {{ ev.type }}</div>
+      <div matLine>
+        <a [routerLink]="['/events']" [queryParams]="{ eventId: ev.id }">
+          {{ ev.date | date:'mediumDate' }}
+        </a>
+        - {{ ev.type | eventTypeLabel }}
+      </div>
       <div matLine>{{ ev.notes }}</div>
     </mat-list-item>
   </mat-list>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -1,14 +1,23 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
+import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
+import { PieceStatusLabelPipe } from '@shared/pipes/piece-status-label.pipe';
 import { ApiService } from '@core/services/api.service';
 import { Piece } from '@core/models/piece';
 
 @Component({
   selector: 'app-piece-detail',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [
+    CommonModule,
+    MaterialModule,
+    RouterModule,
+    EventTypeLabelPipe,
+    PieceStatusLabelPipe
+  ],
   templateUrl: './piece-detail.component.html',
   styleUrls: ['./piece-detail.component.scss']
 })

--- a/choir-app-frontend/src/app/shared/pipes/piece-status-label.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/piece-status-label.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Wandelt die Repertoire-Statuswerte in ihre deutschen Bezeichnungen um.
+ */
+@Pipe({
+  name: 'pieceStatusLabel',
+  standalone: true
+})
+export class PieceStatusLabelPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+    switch (value) {
+      case 'CAN_BE_SUNG':
+        return 'Auff\u00fchrbar';
+      case 'IN_REHEARSAL':
+        return 'Wird geprobt';
+      case 'NOT_READY':
+        return 'Nicht im Repertoire';
+      default:
+        return value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- translate repertoire status with a new `pieceStatusLabel` pipe
- translate event type on piece detail
- add links to event list from piece detail
- allow opening a specific event via `eventId` query parameter

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68627f039d8c83209c8ace6aad4def9c