### PR TITLE
Persist user theme across reloads

### DIFF
--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -73,6 +73,7 @@ export class AuthService {
   logout(): void {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
+    localStorage.removeItem('theme');
     this.prefs.clear();
     this.loggedIn.next(false);
     this.currentUserSubject.next(null);

--- a/choir-app-frontend/src/app/core/services/theme.service.spec.ts
+++ b/choir-app-frontend/src/app/core/services/theme.service.spec.ts
@@ -8,6 +8,7 @@ describe('ThemeService', () => {
   let service: ThemeService;
 
   beforeEach(() => {
+    localStorage.clear();
     TestBed.configureTestingModule({
       providers: [
         { provide: UserPreferencesService, useValue: { getPreference: () => null, update: () => of({}) } }
@@ -18,5 +19,11 @@ describe('ThemeService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should load theme from localStorage on init', () => {
+    localStorage.setItem('theme', 'dark');
+    service.initializeTheme();
+    expect(service.getCurrentTheme()).toBe('dark');
   });
 });

--- a/choir-app-frontend/src/app/core/services/theme.service.ts
+++ b/choir-app-frontend/src/app/core/services/theme.service.ts
@@ -9,6 +9,7 @@ export type Theme = 'light' | 'dark' | 'system';
 export class ThemeService {
   private renderer: Renderer2;
   private currentTheme: Theme = 'system';
+  private static readonly STORAGE_KEY = 'theme';
 
   constructor(rendererFactory: RendererFactory2,
               private prefs: UserPreferencesService) {
@@ -21,8 +22,10 @@ export class ThemeService {
    * Lädt die Benutzereinstellung aus dem gespeicherten Profil oder verwendet 'system' als Standard.
    */
   initializeTheme(): void {
+    const localTheme = localStorage.getItem(ThemeService.STORAGE_KEY) as Theme | null;
     const storedTheme = this.prefs.getPreference('theme') as Theme | undefined;
-    this.currentTheme = storedTheme || 'system';
+    this.currentTheme = localTheme ?? storedTheme ?? 'system';
+    localStorage.setItem(ThemeService.STORAGE_KEY, this.currentTheme);
     this.applyTheme(this.currentTheme);
 
     // Fügen Sie einen Listener hinzu, um auf Änderungen im System-Theme zu reagieren.
@@ -40,6 +43,7 @@ export class ThemeService {
    */
   setTheme(theme: Theme): void {
     this.currentTheme = theme;
+    localStorage.setItem(ThemeService.STORAGE_KEY, theme);
     this.prefs.update({ theme }).subscribe();
     this.applyTheme(theme);
   }


### PR DESCRIPTION
## Summary
- persist selected theme in local storage
- clear stored theme on logout
- test that theme initializes from local storage

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628e29cf6483208e7c378226f7174a