### PR TITLE
Show rehearsal piece count in statistics

### DIFF
--- a/choir-app-backend/src/controllers/stats.controller.js
+++ b/choir-app-backend/src/controllers/stats.controller.js
@@ -47,10 +47,16 @@ exports.overview = async (req, res) => {
             where: { choirId, status: 'CAN_BE_SUNG' }
         });
 
+        // Count pieces currently in rehearsal
+        const rehearsalCount = await db.choir_repertoire.count({
+            where: { choirId, status: 'IN_REHEARSAL' }
+        });
+
         res.status(200).send({
             topServicePieces,
             topRehearsalPieces,
-            singableCount
+            singableCount,
+            rehearsalCount
         });
     } catch (err) {
         res.status(500).send({ message: err.message || 'Error generating statistics.' });

--- a/choir-app-frontend/src/app/core/models/stats-summary.ts
+++ b/choir-app-frontend/src/app/core/models/stats-summary.ts
@@ -8,4 +8,5 @@ export interface StatsSummary {
   topServicePieces: PieceStat[];
   topRehearsalPieces: PieceStat[];
   singableCount: number;
+  rehearsalCount: number;
 }

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -21,6 +21,6 @@
 
   <mat-card>
     <h3>Singfähige Stücke im Repertoire</h3>
-    <p>{{stats.singableCount}}</p>
+    <p>{{stats.singableCount}}/{{stats.rehearsalCount}}</p>
   </mat-card>
 </div>


### PR DESCRIPTION
## Summary
- include count of pieces in rehearsal in backend statistics API
- expose new property `rehearsalCount` in `StatsSummary`
- display `singableCount` and `rehearsalCount` in statistics view

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686291cd1720832087823a7683e64087