### PR TITLE
Persist onboarding state and update wizard

### DIFF
--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -34,6 +34,13 @@ export class AuthService {
               private theme: ThemeService,
               private prefs: UserPreferencesService) {
     this.isAdmin$ = this.currentUser$.pipe(map(user => user?.role === 'admin'));
+    if (this.hasToken()) {
+      this.prefs.load().subscribe(p => {
+        if (p.theme) {
+          this.theme.setTheme(p.theme);
+        }
+      });
+    }
   }
 
   private hasToken(): boolean {

--- a/choir-app-frontend/src/app/core/services/user-preferences.service.ts
+++ b/choir-app-frontend/src/app/core/services/user-preferences.service.ts
@@ -9,13 +9,21 @@ import { UserPreferences } from '../models/user-preferences';
 export class UserPreferencesService {
   private prefs$ = new BehaviorSubject<UserPreferences>({});
   private apiUrl = `${environment.apiUrl}/users/me/preferences`;
+  private loaded = false;
 
   constructor(private http: HttpClient) {}
 
   load(): Observable<UserPreferences> {
     return this.http.get<UserPreferences>(this.apiUrl).pipe(
-      tap(p => this.prefs$.next(p))
+      tap(p => {
+        this.prefs$.next(p);
+        this.loaded = true;
+      })
     );
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
   }
 
   getPreference<K extends keyof UserPreferences>(key: K): UserPreferences[K] | undefined {

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.spec.ts
@@ -4,6 +4,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { HelpService } from '@core/services/help.service';
+import { UserPreferencesService } from '@core/services/user-preferences.service';
+import { of } from 'rxjs';
 
 import { DashboardComponent } from './dashboard.component';
 
@@ -19,7 +21,8 @@ describe('DashboardComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useValue: {} },
         { provide: MatSnackBar, useValue: { open: () => {} } },
-        { provide: HelpService, useValue: { shouldShowHelp: () => false, markHelpShown: () => {} } }
+        { provide: HelpService, useValue: { shouldShowHelp: () => false, markHelpShown: () => {} } },
+        { provide: UserPreferencesService, useValue: { isLoaded: () => true, load: () => of({}) } }
       ]
     })
     .compileComponents();

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -17,6 +17,7 @@ import { Choir } from '@core/models/choir';
 import { PieceChange } from '@core/models/piece-change';
 import { HelpService } from '@core/services/help.service';
 import { HelpWizardComponent } from '@shared/components/help-wizard/help-wizard.component';
+import { UserPreferencesService } from '@core/services/user-preferences.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -44,7 +45,8 @@ export class DashboardComponent implements OnInit {
     private authService: AuthService,
     private dialog: MatDialog, // Zum Öffnen von Dialogen
     private snackBar: MatSnackBar, // Zum Anzeigen von Benachrichtigungen
-    private help: HelpService
+    private help: HelpService,
+    private prefs: UserPreferencesService
   ) {
     this.activeChoir$ = this.authService.activeChoir$;
   }
@@ -65,10 +67,14 @@ export class DashboardComponent implements OnInit {
 
     // Willkommenstext ggf. anzeigen
     this.authService.currentUser$.pipe(take(1)).subscribe(user => {
-      if (this.help.shouldShowHelp(user)) {
-        const ref = this.dialog.open(HelpWizardComponent, { width: '600px' });
-        ref.afterClosed().subscribe(() => this.help.markHelpShown(user));
-      }
+      if (!user) return;
+      const load$ = this.prefs.isLoaded() ? of(null) : this.prefs.load();
+      load$.pipe(take(1)).subscribe(() => {
+        if (this.help.shouldShowHelp(user)) {
+          const ref = this.dialog.open(HelpWizardComponent, { width: '600px' });
+          ref.afterClosed().subscribe(() => this.help.markHelpShown(user));
+        }
+      });
     });
   }
 

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
@@ -26,6 +26,14 @@
       </div>
     </mat-step>
     <mat-step>
+      <ng-template matStepLabel>Spenden</ng-template>
+      <p>Die Nutzung des Chorleiters ist f&uuml;r dich vollkommen kostenlos. Wir freuen uns jedoch &uuml;ber jede Spende, um die Weiterentwicklung zu unterst&uuml;tzen.</p>
+      <div>
+        <button mat-button matStepperPrevious>Zur&uuml;ck</button>
+        <button mat-flat-button color="primary" matStepperNext>Weiter</button>
+      </div>
+    </mat-step>
+    <mat-step>
       <ng-template matStepLabel>&Auml;nderungsvorschl&auml;ge</ng-template>
       <p>Hast du einen Fehler in den Daten gefunden? Super. Dann reiche die Änderungen doch einfach als Änderungsvorschlag ein. Gerade die einzelnen Stücke sind für alle Chöre gleich. Ein Administrator wird die Änderungen prüfen und Übernehmen.</p>
       <p>Diese Hilfe findest du jederzeit &uuml;ber das Benutzermen&uuml;.</p>


### PR DESCRIPTION
## Summary
- load user preferences when a session already exists
- track whether preferences were loaded
- delay showing onboarding until preferences are loaded
- add donation step to onboarding wizard
- adjust dashboard tests for new dependencies

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b0b0ea308320b08c9a1c6e0147b9