### PR TITLE
Fix browserslist for Angular 20

### DIFF
--- a/choir-app-frontend/.browserslistrc
+++ b/choir-app-frontend/.browserslistrc
@@ -1,12 +1,6 @@
-# Browser compatibility target list
-# See https://github.com/browserslist/browserslist#queries
+# This file is used by the build system to adjust CSS and JS output
+# See https://angular.io/guide/browser-support for the supported list.
 
-[production]
->0.2%
-not dead
-not op_mini all
-
-[development]
 last 1 Chrome version
 last 1 Firefox version
 last 2 Edge major versions


### PR DESCRIPTION
## Summary
- update `.browserslistrc` to remove unsupported browser queries

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b260273c832091c2bcbda009c3ff