### PR TITLE
Add quick user access from login attempts

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -122,6 +122,25 @@ exports.deleteUser = async (req, res) => {
     }
 };
 
+exports.getUserByEmail = async (req, res) => {
+    const { email } = req.params;
+    try {
+        const user = await db.user.findOne({
+            where: { email },
+            include: [{
+                model: db.choir,
+                as: 'choirs',
+                attributes: ['id', 'name'],
+                through: { attributes: ['roleInChoir', 'registrationStatus'] }
+            }]
+        });
+        if (!user) return res.status(404).send({ message: 'Not found' });
+        res.status(200).send(user);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
 const crypto = require('crypto');
 const emailService = require('../services/email.service');
 

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -22,6 +22,7 @@ router.delete("/choirs/:id", controller.remove(db.choir));
 
 // Routen für Benutzer
 router.get("/users", controller.getAllUsers);
+router.get("/users/email/:email", controller.getUserByEmail);
 router.post("/users", controller.createUser);
 router.put("/users/:id", controller.updateUser);
 router.delete("/users/:id", controller.deleteUser);

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -383,6 +383,10 @@ export class ApiService {
     return this.http.get<User[]>(`${this.apiUrl}/admin/users`);
   }
 
+  getUserByEmail(email: string): Observable<User> {
+    return this.http.get<User>(`${this.apiUrl}/admin/users/email/${encodeURIComponent(email)}`);
+  }
+
   createUser(data: any): Observable<User> {
     return this.http.post<User>(`${this.apiUrl}/admin/users`, data);
   }

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
@@ -1,7 +1,9 @@
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="email">
     <th mat-header-cell *matHeaderCellDef>Email</th>
-    <td mat-cell *matCellDef="let element">{{ element.email }}</td>
+    <td mat-cell *matCellDef="let element">
+      <a href="#" (click)="openUser(element.email); $event.preventDefault()">{{ element.email }}</a>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="success">


### PR DESCRIPTION
## Summary
- allow admins to fetch a user by email in the backend
- expose `getUserByEmail` in the Angular API service
- make login attempt emails clickable and open the user editor

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*
- `npm test` in frontend *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f20799088320b844b89abe1ad929