### PR TITLE
Refactor piece dialog layout

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -2,8 +2,8 @@
 
 <div mat-dialog-content>
   <form [formGroup]="pieceForm" id="piece-form" (ngSubmit)="onSave()">
-    <mat-tab-group>
-      <mat-tab label="Grundinformationen">
+    <mat-vertical-stepper>
+      <mat-step label="Grundinformationen" [hasError]="isGeneralStepInvalid()">
         <div class="form-section">
           <!-- Title -->
           <mat-form-field appearance="outline">
@@ -45,6 +45,20 @@
             </mat-select>
           </mat-form-field>
 
+          <mat-form-field appearance="outline">
+            <mat-label>Dichter</mat-label>
+            <mat-select formControlName="authorId">
+              <mat-option [value]="addNewAuthorId">
+                <mat-icon>add</mat-icon>
+                <span>Neuen Dichter erstellen</span>
+              </mat-option>
+              <mat-divider></mat-divider>
+              <mat-option *ngFor="let author of authors$ | async" [value]="author.id">
+                {{ author.name }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+
           <mat-form-field appearance="outline" class="lyrics-field">
             <mat-label>Text</mat-label>
             <textarea matInput formControlName="lyrics"></textarea>
@@ -55,10 +69,10 @@
             <input matInput formControlName="opus" placeholder="">
           </mat-form-field>
         </div>
-      </mat-tab>
+      </mat-step>
 
 
-      <mat-tab label="Komponisten & Arrangeure">
+      <mat-step label="Komponisten & Arrangeure" [hasError]="isComposerStepInvalid()">
         <div class="form-section">
           <mat-form-field appearance="outline">
             <mat-label>Komponist</mat-label>
@@ -68,32 +82,16 @@
                 <span>Neuen Komponisten erstellen</span>
               </mat-option>
               <mat-divider></mat-divider>
-              <!-- The rest of the options -->
               <mat-option *ngFor="let composer of composers$ | async" [value]="composer.id">
                 {{ composer.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>
-
-          <mat-form-field appearance="outline">
-            <mat-label>Dichter</mat-label>
-            <mat-select formControlName="authorId">
-              <mat-option [value]="addNewAuthorId">
-                <mat-icon>add</mat-icon>
-                <span>Neuen Dichter erstellen</span>
-              </mat-option>
-              <mat-divider></mat-divider>
-              <!-- The rest of the options -->
-              <mat-option *ngFor="let author of authors$ | async" [value]="author.id">
-                {{ author.name }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
         </div>
-      </mat-tab>
+      </mat-step>
 
 
-      <mat-tab label="Dateien & Links">
+      <mat-step label="Dateien & Links" [hasError]="isFilesStepInvalid()">
         <div class="form-section">
           <h4>Links</h4>
           <div formArrayName="links">
@@ -117,8 +115,8 @@
           <!-- A real file upload component would go here -->
           <p>Platzhalter für Dateiupload-Komponente.</p>
         </div>
-      </mat-tab>
-    </mat-tab-group>
+      </mat-step>
+    </mat-vertical-stepper>
   </form>
 </div>
 <div mat-dialog-actions align="end">

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
@@ -20,3 +20,7 @@
     align-items: center;
     margin-bottom: 1rem;
 }
+
+mat-vertical-stepper {
+  max-width: 800px;
+}

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -194,6 +194,22 @@ export class PieceDialogComponent implements OnInit {
         this.linksFormArray.removeAt(index);
     }
 
+    isGeneralStepInvalid(): boolean {
+        return (
+            this.pieceForm.get('title')?.invalid ||
+            this.pieceForm.get('authorId')?.invalid ||
+            false
+        );
+    }
+
+    isComposerStepInvalid(): boolean {
+        return this.pieceForm.get('composerId')?.invalid || false;
+    }
+
+    isFilesStepInvalid(): boolean {
+        return this.linksFormArray.invalid;
+    }
+
     populateForm(piece: Piece): void {
         this.pieceForm.patchValue({
             title: piece.title,


### PR DESCRIPTION
## Summary
- restructure `piece-dialog` using a vertical stepper
- place author selection with lyrics on the first step
- add per-step validation helpers
- tweak dialog styles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f42b925c83208a0228c4cc4dc6dc