### PR TITLE
Fix deploy script password reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ supports content negotiation for pre-compressed assets.
 ## Deployment
 
 Use `deploy.sh` on Unix systems or `deploy.ps1` on Windows to upload the backend
-and frontend via SSH. Both scripts establish a persistent SSH connection so the
-password is only requested once if `sshpass` is not installed. Optionally create
-a file named `.chorleiter_deploy_pw` in your home directory containing the SSH
-password to avoid interactive prompts altogether.
+and frontend via SSH. Both scripts establish a persistent SSH connection.
+When [`sshpass`](https://www.gnu.org/software/sshpass/) is available, the
+password can be read from a file named `.chorleiter_deploy_pw` in your home
+directory to perform a fully non‑interactive deployment. Without `sshpass`, the
+password still needs to be entered once when the connection is initiated.

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,8 @@ echo "Build finished."
 
 # Get password from file or prompt
 if [[ -f "$PASSWORD_FILE" ]]; then
-    PASSWORD=$(<"$PASSWORD_FILE")
+    # Remove trailing newlines to avoid authentication issues
+    PASSWORD=$(tr -d '\r\n' < "$PASSWORD_FILE")
 else
     read -r -p "Password file $PASSWORD_FILE not found. Create it? (y/N) " create
     if [[ $create =~ ^[Yy] ]]; then


### PR DESCRIPTION
## Summary
- trim newline characters when reading `.chorleiter_deploy_pw`
- clarify deployment docs about `sshpass`

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6862f72229b08320b9a0785ecab7f126