### PR TITLE
Modify piece dialog layout

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -5,7 +5,7 @@
     <mat-sidenav mode="side" opened>
       <mat-nav-list>
         <a mat-list-item [class.active]="activeSection==='general'" (click)="activeSection='general'">Grundinformationen</a>
-        <a mat-list-item [class.active]="activeSection==='composer'" (click)="activeSection='composer'">Komponisten &amp; Arrangeure</a>
+        <a mat-list-item [class.active]="activeSection==='text'" (click)="activeSection='text'">Text</a>
         <a mat-list-item [class.active]="activeSection==='files'" (click)="activeSection='files'">Dateien &amp; Links</a>
       </mat-nav-list>
     </mat-sidenav>
@@ -50,6 +50,29 @@
               </mat-form-field>
 
               <mat-form-field appearance="outline">
+                <mat-label>Komponist</mat-label>
+                <mat-select formControlName="composerId">
+                  <mat-option [value]="addNewComposerId">
+                    <mat-icon>add</mat-icon>
+                    <span>Neuen Komponisten erstellen</span>
+                  </mat-option>
+                  <mat-divider></mat-divider>
+                  <mat-option *ngFor="let composer of composers$ | async" [value]="composer.id">
+                    {{ composer.name }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+
+              <mat-form-field appearance="outline">
+                <mat-label>Opus</mat-label>
+                <input matInput formControlName="opus" placeholder="">
+              </mat-form-field>
+            </div>
+          </ng-container>
+
+          <ng-container *ngSwitchCase="'text'">
+            <div class="form-section">
+              <mat-form-field appearance="outline">
                 <mat-label>Dichter</mat-label>
                 <mat-select formControlName="authorId">
                   <mat-option [value]="addNewAuthorId">
@@ -66,29 +89,6 @@
               <mat-form-field appearance="outline" class="lyrics-field">
                 <mat-label>Text</mat-label>
                 <textarea matInput formControlName="lyrics"></textarea>
-              </mat-form-field>
-
-              <mat-form-field appearance="outline">
-                <mat-label>Opus</mat-label>
-                <input matInput formControlName="opus" placeholder="">
-              </mat-form-field>
-            </div>
-          </ng-container>
-
-          <ng-container *ngSwitchCase="'composer'">
-            <div class="form-section">
-              <mat-form-field appearance="outline">
-                <mat-label>Komponist</mat-label>
-                <mat-select formControlName="composerId">
-                  <mat-option [value]="addNewComposerId">
-                    <mat-icon>add</mat-icon>
-                    <span>Neuen Komponisten erstellen</span>
-                  </mat-option>
-                  <mat-divider></mat-divider>
-                  <mat-option *ngFor="let composer of composers$ | async" [value]="composer.id">
-                    {{ composer.name }}
-                  </mat-option>
-                </mat-select>
               </mat-form-field>
             </div>
           </ng-container>

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
@@ -26,6 +26,11 @@ mat-sidenav-container.dialog-container {
   height: 100%;
 }
 
+div[mat-dialog-content] {
+  height: 80vh;
+  overflow: hidden;
+}
+
 mat-sidenav {
   width: 220px;
 }

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -41,7 +41,7 @@ export class PieceDialogComponent implements OnInit {
     public categories$!: Observable<Category[]>;
     isEditMode = false;
     isAdmin = false;
-    activeSection: 'general' | 'composer' | 'files' = 'general';
+    activeSection: 'general' | 'text' | 'files' = 'general';
 
     get linksFormArray(): FormArray {
         return this.pieceForm.get('links') as FormArray;
@@ -198,13 +198,9 @@ export class PieceDialogComponent implements OnInit {
     isGeneralStepInvalid(): boolean {
         return (
             this.pieceForm.get('title')?.invalid ||
-            this.pieceForm.get('authorId')?.invalid ||
+            this.pieceForm.get('composerId')?.invalid ||
             false
         );
-    }
-
-    isComposerStepInvalid(): boolean {
-        return this.pieceForm.get('composerId')?.invalid || false;
     }
 
     isFilesStepInvalid(): boolean {


### PR DESCRIPTION
## Summary
- change piece dialog sidebar to General/Text/Files
- relocate composer select to the general section
- move text author and lyrics into new Text section
- ensure dialog height stays constant

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862faa36e588320b0bfe3f9207430b1