### PR TITLE
Fix reference sorting error

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -153,8 +153,18 @@ exports.findMyRepertoire = async (req, res) => {
                 break;
             case 'reference':
                 order = [
-                    [literal('"collections.prefix"'), sortDirection],
-                    [literal(`CAST("collections->collection_piece"."numberInCollection" AS INTEGER)`), sortDirection]
+                    // Sort first by the collection prefix (e.g. "CB" or "EG")
+                    [literal('"collections"."prefix"'), sortDirection],
+                    // Extract the numeric portion from the reference and sort
+                    // by it. Non numeric values will sort last because the
+                    // REGEXP_REPLACE will return an empty string which is
+                    // converted to NULL before casting.
+                    [
+                        literal(
+                            'NULLIF(REGEXP_REPLACE("collections->collection_piece"."numberInCollection", \'\\D\', \'\', \'g\'), \'\')::INTEGER'
+                        ),
+                        sortDirection
+                    ]
                 ];
                 break;
             case 'title':


### PR DESCRIPTION
## Summary
- fix quoting and sanitize numeric sorting when ordering by reference

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6862fd5fac8c83208f6adc73b1b4be92