### PR TITLE
Fix repertoire reference sorting

### DIFF
--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -21,6 +21,8 @@ export interface Piece {
     status: 'CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY';
   };
   collections?: CollectionReference[];
+  collectionPrefix?: string | null;
+  collectionNumber?: string | null;
 
   key?: string;
   timeSignature?: string;

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -198,6 +198,9 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
    * Formats the collection reference for display in the template.
    */
   formatReferenceForDisplay(piece: Piece): string {
+    if (piece.collectionPrefix && piece.collectionNumber) {
+      return `${piece.collectionPrefix}${piece.collectionNumber}`;
+    }
     if (piece.collections && piece.collections.length > 0) {
       const ref = piece.collections[0];
       const num = (ref as any).collection_piece.numberInCollection;


### PR DESCRIPTION
## Summary
- avoid duplicate rows when sorting by reference
- compute first collection reference via subquery
- adjust ordering to use computed reference
- expose reference fields on `Piece` model
- display prefix and number in literature list if available

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6863687572c88320852fcc4288aae1f9