### PR TITLE
Show counts in choir overview

### DIFF
--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -15,7 +15,7 @@ router.get("/authors", controller.getAll(db.author));
 // ...
 
 // Routen für Chöre
-router.get("/choirs", controller.getAll(db.choir));
+router.get("/choirs", controller.getAllChoirs);
 router.post("/choirs", controller.create(db.choir));
 router.put("/choirs/:id", controller.update(db.choir));
 router.delete("/choirs/:id", controller.remove(db.choir));

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -3,4 +3,7 @@ export interface Choir {
     name: string;
     description?: string;
     location?: string;
+    memberCount?: number;
+    eventCount?: number;
+    pieceCount?: number;
 }

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
@@ -13,6 +13,21 @@
     <td mat-cell *matCellDef="let element">{{ element.location }}</td>
   </ng-container>
 
+  <ng-container matColumnDef="memberCount">
+    <th mat-header-cell *matHeaderCellDef>Mitglieder</th>
+    <td mat-cell *matCellDef="let element">{{ element.memberCount }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="eventCount">
+    <th mat-header-cell *matHeaderCellDef>Ereignisse</th>
+    <td mat-cell *matCellDef="let element">{{ element.eventCount }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="pieceCount">
+    <th mat-header-cell *matHeaderCellDef>Repertoire</th>
+    <td mat-cell *matCellDef="let element">{{ element.pieceCount }}</td>
+  </ng-container>
+
   <ng-container matColumnDef="actions">
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let element">

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
@@ -16,7 +16,7 @@ import { ChoirDialogComponent } from './choir-dialog/choir-dialog.component';
 })
 export class ManageChoirsComponent implements OnInit {
   choirs: Choir[] = [];
-  displayedColumns = ['name', 'location', 'actions'];
+  displayedColumns = ['name', 'location', 'memberCount', 'eventCount', 'pieceCount', 'actions'];
   dataSource = new MatTableDataSource<Choir>();
 
   constructor(private api: ApiService, private dialog: MatDialog) {}


### PR DESCRIPTION
## Summary
- extend choir model with member, event and repertoire counts
- display new statistics columns in admin choir table
- provide backend API for counts by choir

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686367ab547c832096a8cbc2f6762871