### PR TITLE
Improve API error management

### DIFF
--- a/choir-app-frontend/src/app/core/guards/choir-admin-guard.ts
+++ b/choir-app-frontend/src/app/core/guards/choir-admin-guard.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { map, catchError, switchMap } from 'rxjs/operators';
 import { AuthService } from '../services/auth.service';
 import { ApiService } from '../services/api.service';
+import { ErrorService } from '../services/error.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +13,8 @@ export class ChoirAdminGuard implements CanActivate {
   constructor(
     private authService: AuthService,
     private apiService: ApiService,
-    private router: Router
+    private router: Router,
+    private errorService: ErrorService
   ) {}
 
   canActivate(): Observable<boolean | UrlTree> {
@@ -33,8 +35,10 @@ export class ChoirAdminGuard implements CanActivate {
               return this.router.createUrlTree(['/dashboard']);
             }
           }),
-          catchError(() => {
+          catchError((err) => {
             // Bei einem Fehler bei der API-Anfrage den Zugriff verweigern und umleiten.
+            console.error('ChoirAdminGuard API check failed', err);
+            this.errorService.setError({ message: 'Zugriff verweigert.', status: err.status });
             return of(this.router.createUrlTree(['/dashboard']));
           })
         );

--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -4,19 +4,25 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { ErrorService } from '../services/error.service';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
-  constructor(private dialog: MatDialog) {}
+  constructor(private dialog: MatDialog, private errorService: ErrorService) {}
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
       catchError((error) => {
+        const message = error.name === 'TimeoutError'
+          ? 'Die Anfrage hat zu lange gedauert.'
+          : (error instanceof HttpErrorResponse ? (error.error?.message || error.message) : 'Unbekannter Fehler');
+
+        this.errorService.setError({ message, status: error.status });
+        console.error('HTTP Error:', error);
+
         const data: ConfirmDialogData = {
           title: 'Fehler',
-          message: error.name === 'TimeoutError'
-            ? 'Die Anfrage hat zu lange gedauert.'
-            : (error instanceof HttpErrorResponse ? (error.error?.message || error.message) : 'Unbekannter Fehler'),
+          message,
           confirmButtonText: 'Erneut versuchen',
           cancelButtonText: 'Abbrechen'
         };

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -51,6 +51,7 @@ export class ManageChoirResolver implements Resolve<any> {
       }),
       catchError((error) => {
         const errorMessage = error.error?.message || 'Could not load data for choir management.';
+        console.error('ManageChoirResolver error', error);
         this.errorService.setError({ message: errorMessage, status: error.status });
         this.router.navigate(['/dashboard']);
         return of(null);


### PR DESCRIPTION
## Summary
- log HTTP errors in `ErrorInterceptor`
- expose errors through `ErrorService` in `ErrorInterceptor`
- report load/update issues in `LiteratureListComponent`
- add console logs for failed repertoire loading and other API checks

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636bab56f48320af2e519a38f5751f