### PR TITLE
Fix repertoire request param logic

### DIFF
--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -28,9 +28,10 @@ export class PieceService {
     if (categoryId) params = params.set('categoryId', categoryId.toString());
     if (collectionId) params = params.set('collectionId', collectionId.toString());
     if (sortBy) params = params.set('sortBy', sortBy);
-    params = params.set('page', page);
-    params = params.set('limit', limit);
-    params = params.set('sortDir', sortDir);
+    params = params.set('page', page.toString());
+    params = params.set('limit', limit.toString());
+    // Avoid sending empty sortDir which causes an empty query parameter
+    params = params.set('sortDir', sortDir || 'ASC');
     if (status) params = params.set('status', status);
     if (search) params = params.set('search', search);
 

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -138,6 +138,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
           if (cached) {
             return of({ data: cached, total: this.totalPieces });
           }
+          const dir = this._sort.direction ? this._sort.direction.toUpperCase() as 'ASC' | 'DESC' : 'ASC';
           return this.pieceService.getMyRepertoire(
             this.filterByCategoryId$.value ?? undefined,
             this.filterByCollectionId$.value ?? undefined,
@@ -145,7 +146,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
             pageIndex + 1,
             this._paginator.pageSize,
             this.onlySingable$.value ? 'CAN_BE_SUNG' : undefined,
-            this._sort.direction.toUpperCase() as 'ASC' | 'DESC',
+            dir,
             this.searchControl.value || undefined
           ).pipe(
             catchError((err) => {
@@ -187,6 +188,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     const nextIndex = this._paginator.pageIndex + 1;
     if (nextIndex * this._paginator.pageSize >= this.totalPieces) return;
     if (this.pageCache.has(nextIndex)) return;
+    const dir = this._sort.direction ? this._sort.direction.toUpperCase() as 'ASC' | 'DESC' : 'ASC';
     this.pieceService.getMyRepertoire(
       this.filterByCategoryId$.value ?? undefined,
       this.filterByCollectionId$.value ?? undefined,
@@ -194,7 +196,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
       nextIndex + 1,
       this._paginator.pageSize,
       this.onlySingable$.value ? 'CAN_BE_SUNG' : undefined,
-      this._sort.direction.toUpperCase() as 'ASC' | 'DESC',
+      dir,
       this.searchControl.value || undefined
     ).subscribe(res => this.pageCache.set(nextIndex, res.data));
   }


### PR DESCRIPTION
## Summary
- avoid empty sort parameters when requesting repertoire data
- ensure literature component uses default sort order when not set

## Testing
- `npm test --silent` *(fails: Cannot find module 'sequelize')*
- `npm test --silent` in `choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686371bac9d88320b907bd740f6a36e7