### PR TITLE
Improve error handling and logging

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -1,5 +1,6 @@
 const db = require("../models");
 const { Op, literal } = require("sequelize");
+const logger = require("../config/logger");
 
 function parseSearchTokens(search) {
     const regex = /"([^"]+)"|([^"\s]+)/g;
@@ -233,9 +234,13 @@ exports.findMyRepertoire = async (req, res) => {
         res.status(200).send({ data: results, total: count });
 
     } catch (err) {
-        // Loggen Sie den Fehler im Backend für einfaches Debugging.
-        console.error("ERROR finding repertoire:", err);
-        res.status(500).send({ message: "An error occurred while retrieving the repertoire." });
+        // Verbessertes Logging für die Fehlersuche
+        logger.error(`ERROR finding repertoire for choir ${req.activeChoirId}: ${err.message}`);
+        logger.error(err.stack);
+        res.status(500).send({
+            message: "An error occurred while retrieving the repertoire.",
+            details: err.message
+        });
     }
 };
 

--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -17,7 +17,11 @@ export class ErrorInterceptor implements HttpInterceptor {
           ? 'Die Anfrage hat zu lange gedauert.'
           : (error instanceof HttpErrorResponse ? (error.error?.message || error.message) : 'Unbekannter Fehler');
 
-        this.errorService.setError({ message, status: error.status });
+        this.errorService.setError({
+          message,
+          status: error.status,
+          details: error.error?.details
+        });
         console.error('HTTP Error:', error);
 
         const data: ConfirmDialogData = {

--- a/choir-app-frontend/src/app/core/services/error.service.ts
+++ b/choir-app-frontend/src/app/core/services/error.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 export interface AppError {
   message: string;
   status?: number;
+  details?: string;
 }
 
 @Injectable({

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -152,8 +152,11 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
             catchError((err) => {
               const msg = err.error?.message || 'Could not load repertoire.';
               console.error('Failed to load repertoire list', err);
-              this.errorService.setError({ message: msg, status: err.status });
-              this.snackBar.open('Could not load repertoire.', 'Close', { duration: 5000 });
+              this.errorService.setError({
+                message: msg,
+                status: err.status,
+                details: err.error?.details
+              });
               return of({ data: [], total: 0 });
             })
           );

--- a/choir-app-frontend/src/app/shared/components/error-display/error-display.component.html
+++ b/choir-app-frontend/src/app/shared/components/error-display/error-display.component.html
@@ -4,6 +4,7 @@
     <h2>Ein Fehler ist aufgetreten</h2>
     <p>{{ error.message }}</p>
     <p *ngIf="error.status">Statuscode: {{ error.status }}</p>
+    <pre *ngIf="error.details" class="error-details">{{ error.details }}</pre>
     <button mat-flat-button color="warn" (click)="clear()">Schließen</button>
   </div>
 </div>

--- a/choir-app-frontend/src/app/shared/components/error-display/error-display.component.scss
+++ b/choir-app-frontend/src/app/shared/components/error-display/error-display.component.scss
@@ -19,3 +19,15 @@
   width: 48px;
   height: 48px;
 }
+
+.error-details {
+  text-align: left;
+  max-height: 200px;
+  overflow: auto;
+  background: #f5f5f5;
+  padding: 1rem;
+  margin-top: 1rem;
+  border-radius: 4px;
+  font-family: monospace;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- log repertoire errors via logger and return details
- show error details in overlay
- propagate backend error details to front-end services
- remove duplicate snackbar message

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638e0dfbf48320ab02aa1e50705852