### PR TITLE
Fix collectionId case in repertoire SQL

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -149,20 +149,20 @@ exports.findMyRepertoire = async (req, res) => {
                     literal(`(
                         SELECT c.prefix
                         FROM collection_pieces cp
-                        JOIN collections c ON cp.collectionId = c.id
-                        WHERE cp.pieceId = "piece"."id"
-                        ORDER BY cp.numberInCollection
+                        JOIN collections c ON cp."collectionId" = c.id
+                        WHERE cp."pieceId" = "piece"."id"
+                        ORDER BY cp."numberInCollection"
                         LIMIT 1
                     )`),
                     'collectionPrefix'
                 ],
                 [
                     literal(`(
-                        SELECT cp.numberInCollection
+                        SELECT cp."numberInCollection"
                         FROM collection_pieces cp
-                        JOIN collections c ON cp.collectionId = c.id
-                        WHERE cp.pieceId = "piece"."id"
-                        ORDER BY cp.numberInCollection
+                        JOIN collections c ON cp."collectionId" = c.id
+                        WHERE cp."pieceId" = "piece"."id"
+                        ORDER BY cp."numberInCollection"
                         LIMIT 1
                     )`),
                     'collectionNumber'


### PR DESCRIPTION
## Summary
- correct quoting of `collectionId` and related columns in raw SQL

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68639fde8d208320949bb04bfd0217ba