### PR TITLE
Add status search filter

### DIFF
--- a/choir-app-frontend/src/app/core/models/repertoire-filter.ts
+++ b/choir-app-frontend/src/app/core/models/repertoire-filter.ts
@@ -6,6 +6,7 @@ export interface RepertoireFilter {
     collectionId?: number | null;
     categoryId?: number | null;
     onlySingable?: boolean;
+    status?: 'CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY' | null;
     search?: string;
   };
 }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -25,6 +25,15 @@
       <mat-checkbox [checked]="onlySingable$.value" (change)="onSingableToggle($event.checked)">
         Nur aufführbare
       </mat-checkbox>
+      <mat-form-field appearance="outline">
+        <mat-label>Status</mat-label>
+        <mat-select [value]="status$.value" (selectionChange)="onStatusFilterChange($event.value)">
+          <mat-option [value]="null">Alle</mat-option>
+          <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>
+          <mat-option value="IN_REHEARSAL">Wird geprobt</mat-option>
+          <mat-option value="NOT_READY">Nicht im Repertoire</mat-option>
+        </mat-select>
+      </mat-form-field>
       <button mat-button (click)="clearFilters()">Filter löschen</button>
     </div>
   </mat-drawer>


### PR DESCRIPTION
## Summary
- extend `RepertoireFilter` data to store a status
- allow filtering repertoire by status in the UI

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6863c3d751088320a264d143720b9176