### PR TITLE
Add repertoire stats columns

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -166,6 +166,42 @@ exports.findMyRepertoire = async (req, res) => {
                         LIMIT 1
                     )`),
                     'collectionNumber'
+                ],
+                [
+                    literal(`(
+                        SELECT MAX(e.date)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'SERVICE'
+                    )`),
+                    'lastSung'
+                ],
+                [
+                    literal(`(
+                        SELECT MAX(e.date)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'REHEARSAL'
+                    )`),
+                    'lastRehearsed'
+                ],
+                [
+                    literal(`(
+                        SELECT COUNT(*)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'SERVICE'
+                    )`),
+                    'timesSung'
+                ],
+                [
+                    literal(`(
+                        SELECT COUNT(*)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'REHEARSAL'
+                    )`),
+                    'timesRehearsed'
                 ]
             ]
         };
@@ -208,6 +244,38 @@ exports.findMyRepertoire = async (req, res) => {
                         sortDirection
                     ]
                 ];
+                break;
+            case 'lastSung':
+                order = [[literal(`(
+                        SELECT MAX(e.date)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'SERVICE'
+                    )`), sortDirection]];
+                break;
+            case 'lastRehearsed':
+                order = [[literal(`(
+                        SELECT MAX(e.date)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'REHEARSAL'
+                    )`), sortDirection]];
+                break;
+            case 'timesSung':
+                order = [[literal(`(
+                        SELECT COUNT(*)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'SERVICE'
+                    )`), sortDirection]];
+                break;
+            case 'timesRehearsed':
+                order = [[literal(`(
+                        SELECT COUNT(*)
+                        FROM event_pieces ep
+                        JOIN events e ON ep."eventId" = e.id
+                        WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'REHEARSAL'
+                    )`), sortDirection]];
                 break;
             case 'title':
             default:

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -34,4 +34,8 @@ export interface Piece {
   arrangers?: Composer[];
   links?: PieceLink[];
   events?: Event[];
+  lastSung?: string | null;
+  lastRehearsed?: string | null;
+  timesSung?: number;
+  timesRehearsed?: number;
 }

--- a/choir-app-frontend/src/app/core/models/user-preferences.ts
+++ b/choir-app-frontend/src/app/core/models/user-preferences.ts
@@ -2,4 +2,10 @@ export interface UserPreferences {
   theme?: 'light' | 'dark' | 'system';
   helpShown?: boolean;
   pageSizes?: { [key: string]: number };
+  repertoireColumns?: {
+    lastSung?: boolean;
+    lastRehearsed?: boolean;
+    timesSung?: boolean;
+    timesRehearsed?: boolean;
+  };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -45,7 +45,8 @@ export class ApiService {
     composerId?: number,
     categoryId?: number,
     collectionId?: number,
-    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection',
+    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection' |
+            'lastSung' | 'lastRehearsed' | 'timesSung' | 'timesRehearsed',
     page: number = 1,
     limit: number = 25,
     status?: string,

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -17,7 +17,8 @@ export class PieceService {
   getMyRepertoire(
     categoryId?: number,
     collectionId?: number,
-    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection',
+    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection' |
+             'lastSung' | 'lastRehearsed' | 'timesSung' | 'timesRehearsed',
     page = 1,
     limit = 25,
     status?: string,

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -54,6 +54,27 @@
         <button mat-icon-button (click)="saveCurrentPreset()" aria-label="Filter speichern">
           <mat-icon>save</mat-icon>
         </button>
+        <button mat-icon-button [matMenuTriggerFor]="columnMenu" aria-label="Spalten">
+          <mat-icon>view_column</mat-icon>
+        </button>
+        <mat-menu #columnMenu="matMenu">
+          <button mat-menu-item (click)="toggleColumn('lastSung')">
+            <mat-icon *ngIf="showLastSung">check</mat-icon>
+            <span>Zuletzt gesungen</span>
+          </button>
+          <button mat-menu-item (click)="toggleColumn('lastRehearsed')">
+            <mat-icon *ngIf="showLastRehearsed">check</mat-icon>
+            <span>Zuletzt geprobt</span>
+          </button>
+          <button mat-menu-item (click)="toggleColumn('timesSung')">
+            <mat-icon *ngIf="showTimesSung">check</mat-icon>
+            <span>Anzahl gesungen</span>
+          </button>
+          <button mat-menu-item (click)="toggleColumn('timesRehearsed')">
+            <mat-icon *ngIf="showTimesRehearsed">check</mat-icon>
+            <span>Anzahl geprobt</span>
+          </button>
+        </mat-menu>
         <h1>Chorrepertoire</h1>
         <button mat-flat-button color="primary" (click)="openAddPieceDialog()">
           <mat-icon>add</mat-icon>
@@ -94,6 +115,26 @@
               <td mat-cell *matCellDef="let piece">
                 {{piece.category?.name}}
               </td>
+            </ng-container>
+
+            <ng-container matColumnDef="lastSung">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="lastSung"> Zuletzt gesungen </th>
+              <td mat-cell *matCellDef="let piece"> {{ piece.lastSung ? (piece.lastSung | date:'shortDate') : '-' }} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="lastRehearsed">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="lastRehearsed"> Zuletzt geprobt </th>
+              <td mat-cell *matCellDef="let piece"> {{ piece.lastRehearsed ? (piece.lastRehearsed | date:'shortDate') : '-' }} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="timesSung">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="timesSung"> Anzahl gesungen </th>
+              <td mat-cell *matCellDef="let piece"> {{ piece.timesSung || 0 }} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="timesRehearsed">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="timesRehearsed"> Anzahl geprobt </th>
+              <td mat-cell *matCellDef="let piece"> {{ piece.timesRehearsed || 0 }} </td>
             </ng-container>
 
             <!-- Status Column (Not sortable in this example) -->

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -7,7 +7,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { PaginatorService } from '@core/services/paginator.service';
 import { MatTableDataSource } from '@angular/material/table';
 import { Observable, BehaviorSubject, merge, of } from 'rxjs';
-import { switchMap, map, startWith, catchError, tap } from 'rxjs/operators';
+import { switchMap, map, startWith, catchError, tap, take } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { MaterialModule } from '@modules/material.module';
@@ -22,6 +22,7 @@ import { FilterPresetService } from '@core/services/filter-preset.service';
 import { AuthService } from '@core/services/auth.service';
 import { FilterPresetDialogComponent, FilterPresetDialogData } from '../filter-preset-dialog/filter-preset-dialog.component';
 import { ErrorService } from '@core/services/error.service';
+import { UserPreferencesService } from '@core/services/user-preferences.service';
 
 @Component({
   selector: 'app-literature-list',
@@ -46,7 +47,11 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   public categories$!: Observable<Category[]>;
 
   // --- Table, Paginator, and Sort Logic ---
-  public displayedColumns: string[] = ['title', 'composer', 'category', 'reference', 'status', 'actions'];
+  public displayedColumns: string[] = [];
+  public showLastSung = false;
+  public showLastRehearsed = false;
+  public showTimesSung = false;
+  public showTimesRehearsed = false;
   public dataSource = new MatTableDataSource<Piece>();
   public totalPieces = 0;
   public pageSizeOptions: number[] = [10, 25, 50];
@@ -88,12 +93,14 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     public dialog: MatDialog,
     private snackBar: MatSnackBar, // Inject MatSnackBar for feedback
     private paginatorService: PaginatorService,
-    private errorService: ErrorService
+    private errorService: ErrorService,
+    private prefs: UserPreferencesService
   ) {
     this.pageSize = this.paginatorService.getPageSize('literature-list', this.pageSizeOptions[0]);
   }
 
   ngOnInit(): void {
+    this.updateDisplayedColumns();
     // Pre-fetch data for the filter dropdowns
     this.collections$ = this.apiService.getCollections();
     this.categories$ = this.apiService.getCategories();
@@ -113,6 +120,16 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         if (s.collectionId || s.categoryId || s.onlySingable || s.status) this.filtersExpanded = true;
       } catch { }
     }
+
+    const load$ = this.prefs.isLoaded() ? of(null) : this.prefs.load();
+    load$.pipe(take(1)).subscribe(() => {
+      const cols = this.prefs.getPreference('repertoireColumns') || {};
+      this.showLastSung = !!cols.lastSung;
+      this.showLastRehearsed = !!cols.lastRehearsed;
+      this.showTimesSung = !!cols.timesSung;
+      this.showTimesRehearsed = !!cols.timesRehearsed;
+      this.updateDisplayedColumns();
+    });
   }
 
   ngAfterViewInit(): void {
@@ -438,5 +455,43 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         this.loadPresets();
       });
     }
+  }
+
+  private updateDisplayedColumns(): void {
+    this.displayedColumns = ['title', 'composer', 'category', 'reference'];
+    if (this.showLastSung) this.displayedColumns.push('lastSung');
+    if (this.showLastRehearsed) this.displayedColumns.push('lastRehearsed');
+    if (this.showTimesSung) this.displayedColumns.push('timesSung');
+    if (this.showTimesRehearsed) this.displayedColumns.push('timesRehearsed');
+    this.displayedColumns.push('status', 'actions');
+  }
+
+  toggleColumn(col: 'lastSung' | 'lastRehearsed' | 'timesSung' | 'timesRehearsed'): void {
+    switch (col) {
+      case 'lastSung':
+        this.showLastSung = !this.showLastSung;
+        break;
+      case 'lastRehearsed':
+        this.showLastRehearsed = !this.showLastRehearsed;
+        break;
+      case 'timesSung':
+        this.showTimesSung = !this.showTimesSung;
+        break;
+      case 'timesRehearsed':
+        this.showTimesRehearsed = !this.showTimesRehearsed;
+        break;
+    }
+    this.saveColumnPrefs();
+    this.updateDisplayedColumns();
+  }
+
+  private saveColumnPrefs(): void {
+    const prefs = {
+      lastSung: this.showLastSung,
+      lastRehearsed: this.showLastRehearsed,
+      timesSung: this.showTimesSung,
+      timesRehearsed: this.showTimesRehearsed
+    };
+    this.prefs.update({ repertoireColumns: prefs }).subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- extend user preferences for repertoire view
- add last-sung/rehearsed stats to Piece model
- allow sorting by new fields
- display optional performance stats columns in repertoire list
- compute stats in backend repertoire query

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686415e78b6883208fbc6adaf5c82dfc