### PR TITLE
Add admin choir member management

### DIFF
--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -19,6 +19,9 @@ router.get("/choirs", controller.getAllChoirs);
 router.post("/choirs", controller.create(db.choir));
 router.put("/choirs/:id", controller.update(db.choir));
 router.delete("/choirs/:id", controller.remove(db.choir));
+router.get("/choirs/:id/members", controller.getChoirMembers);
+router.post("/choirs/:id/members", controller.addUserToChoir);
+router.delete("/choirs/:id/members", controller.removeUserFromChoir);
 
 // Routen für Benutzer
 router.get("/users", controller.getAllUsers);

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -379,6 +379,19 @@ export class ApiService {
     return this.http.delete(`${this.apiUrl}/admin/choirs/${id}`);
   }
 
+  getChoirMembersAdmin(id: number): Observable<UserInChoir[]> {
+    return this.http.get<UserInChoir[]>(`${this.apiUrl}/admin/choirs/${id}/members`);
+  }
+
+  inviteUserToChoirAdmin(id: number, email: string, roleInChoir: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${this.apiUrl}/admin/choirs/${id}/members`, { email, roleInChoir });
+  }
+
+  removeUserFromChoirAdmin(id: number, userId: number): Observable<any> {
+    const options = { body: { userId } };
+    return this.http.delete(`${this.apiUrl}/admin/choirs/${id}/members`, options);
+  }
+
   getUsers(): Observable<User[]> {
     return this.http.get<User[]>(`${this.apiUrl}/admin/users`);
   }

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -14,6 +14,45 @@
       <input matInput formControlName="location">
     </mat-form-field>
   </form>
+
+  <div *ngIf="data">
+    <h2>Mitglieder</h2>
+    <button mat-flat-button color="accent" (click)="openInviteDialog()">
+      <mat-icon>add</mat-icon>
+      Mitglied hinzufügen
+    </button>
+    <table mat-table [dataSource]="dataSource" class="member-table">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let user">{{user.name}}</td>
+      </ng-container>
+      <ng-container matColumnDef="email">
+        <th mat-header-cell *matHeaderCellDef>E-Mail</th>
+        <td mat-cell *matCellDef="let user">{{user.email}}</td>
+      </ng-container>
+      <ng-container matColumnDef="role">
+        <th mat-header-cell *matHeaderCellDef>Rolle</th>
+        <td mat-cell *matCellDef="let user">{{user.membership?.roleInChoir | titlecase}}</td>
+      </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>Status</th>
+        <td mat-cell *matCellDef="let user">{{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}}</td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let user">
+          <button mat-icon-button color="warn" (click)="removeMember(user)">
+            <mat-icon>person_remove</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</td>
+      </tr>
+    </table>
+  </div>
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button (click)="onCancel()">Abbrechen</button>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.scss
@@ -1,3 +1,8 @@
 mat-form-field {
   display: block;
 }
+
+.member-table {
+  width: 100%;
+  margin-top: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -1,9 +1,15 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableDataSource } from '@angular/material/table';
 import { MaterialModule } from '@modules/material.module';
 import { Choir } from 'src/app/core/models/choir';
+import { UserInChoir } from 'src/app/core/models/user';
+import { ApiService } from 'src/app/core/services/api.service';
+import { InviteUserDialogComponent } from '../../choir-management/invite-user-dialog/invite-user-dialog.component';
+import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 
 @Component({
   selector: 'app-choir-dialog',
@@ -12,20 +18,72 @@ import { Choir } from 'src/app/core/models/choir';
   templateUrl: './choir-dialog.component.html',
   styleUrls: ['./choir-dialog.component.scss']
 })
-export class ChoirDialogComponent {
+export class ChoirDialogComponent implements OnInit {
   form: FormGroup;
   title = 'Chor hinzufügen';
+  displayedColumns: string[] = ['name', 'email', 'role', 'status', 'actions'];
+  dataSource = new MatTableDataSource<UserInChoir>();
 
   constructor(
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<ChoirDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: Choir | null
+    @Inject(MAT_DIALOG_DATA) public data: Choir | null,
+    private api: ApiService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
   ) {
     this.title = data ? 'Chor bearbeiten' : 'Chor hinzufügen';
     this.form = this.fb.group({
       name: [data?.name || '', Validators.required],
       description: [data?.description || ''],
       location: [data?.location || '']
+    });
+  }
+
+  ngOnInit(): void {
+    if (this.data?.id) {
+      this.loadMembers();
+    }
+  }
+
+  private loadMembers(): void {
+    if (!this.data?.id) return;
+    this.api.getChoirMembersAdmin(this.data.id).subscribe(m => this.dataSource.data = m);
+  }
+
+  openInviteDialog(): void {
+    if (!this.data?.id) return;
+    const ref = this.dialog.open(InviteUserDialogComponent, { width: '450px' });
+    ref.afterClosed().subscribe(result => {
+      if (result && result.email && result.role) {
+        this.api.inviteUserToChoirAdmin(this.data!.id, result.email, result.role).subscribe({
+          next: (resp) => {
+            this.snackBar.open(resp.message, 'OK', { duration: 4000 });
+            this.loadMembers();
+          },
+          error: err => this.snackBar.open(err.error?.message || 'Error', 'Close')
+        });
+      }
+    });
+  }
+
+  removeMember(user: UserInChoir): void {
+    if (!this.data?.id) return;
+    const data: ConfirmDialogData = {
+      title: 'Remove Member?',
+      message: `Are you sure you want to remove ${user.name} (${user.email}) from this choir?`
+    };
+    const ref = this.dialog.open(ConfirmDialogComponent, { data });
+    ref.afterClosed().subscribe(conf => {
+      if (conf) {
+        this.api.removeUserFromChoirAdmin(this.data!.id, user.id).subscribe({
+          next: () => {
+            this.snackBar.open('Member removed', 'OK', { duration: 3000 });
+            this.loadMembers();
+          },
+          error: err => this.snackBar.open('Error removing member', 'Close')
+        });
+      }
     });
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
@@ -42,10 +42,12 @@ export class ManageChoirsComponent implements OnInit {
   }
 
   editChoir(choir: Choir): void {
-    const ref = this.dialog.open(ChoirDialogComponent, { width: '400px', data: choir });
+    const ref = this.dialog.open(ChoirDialogComponent, { width: '600px', data: choir });
     ref.afterClosed().subscribe(result => {
       if (result) {
         this.api.updateChoir(choir.id, result).subscribe(() => this.loadChoirs());
+      } else {
+        this.loadChoirs();
       }
     });
   }


### PR DESCRIPTION
## Summary
- allow admins to manage choir members
- expose new admin membership endpoints in the backend
- support membership management in the admin choir dialog
- reload choir list after editing

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686423098de08320800d0fd797277b3c