### PR TITLE
Fix import paths for dialogs and add missing type import

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -8,7 +8,7 @@ import { MaterialModule } from '@modules/material.module';
 import { Choir } from 'src/app/core/models/choir';
 import { UserInChoir } from 'src/app/core/models/user';
 import { ApiService } from 'src/app/core/services/api.service';
-import { InviteUserDialogComponent } from '../../choir-management/invite-user-dialog/invite-user-dialog.component';
+import { InviteUserDialogComponent } from '../../../choir-management/invite-user-dialog/invite-user-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 
 @Component({

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -23,6 +23,7 @@ import { AuthService } from '@core/services/auth.service';
 import { FilterPresetDialogComponent, FilterPresetDialogData } from '../filter-preset-dialog/filter-preset-dialog.component';
 import { ErrorService } from '@core/services/error.service';
 import { UserPreferencesService } from '@core/services/user-preferences.service';
+import { UserPreferences } from '@core/models/user-preferences';
 
 @Component({
   selector: 'app-literature-list',


### PR DESCRIPTION
## Summary
- fix relative path to `InviteUserDialogComponent`
- import `UserPreferences` interface

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864350ce53883209e045200c6bed559