### PR TITLE
Fix backend start message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Management of choirs for directors
 
+## Setup
+
+Before starting the backend, install its dependencies:
+
+```bash
+npm install --prefix choir-app-backend
+```
+
 ## Tests
 
 Run frontend unit tests with:

--- a/choir-app-backend/server.js
+++ b/choir-app-backend/server.js
@@ -1,4 +1,9 @@
-require("dotenv").config();
+try {
+    require("dotenv").config();
+} catch (err) {
+    console.error("Missing dependencies. Did you run 'npm install' in choir-app-backend?", err.message);
+    process.exit(1);
+}
 const app = require("./src/app");
 const db = require("./src/models");
 const bcrypt = require("bcryptjs");


### PR DESCRIPTION
## Summary
- show a helpful error when dependencies are missing
- document backend setup step in README

## Testing
- `node server.js 2>&1 | head -n 5`
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68643be8f5b883208446bd45efeaaec7