### PR TITLE
Fix duplicate crypto import

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -171,8 +171,6 @@ exports.getUserByEmail = async (req, res) => {
     }
 };
 
-const crypto = require('crypto');
-const emailService = require('../services/email.service');
 
 exports.sendPasswordReset = async (req, res) => {
     const { id } = req.params;


### PR DESCRIPTION
## Summary
- remove an accidental duplicate `crypto` import in the backend

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68643cdc23ac8320aba004bf303d9391