### PR TITLE
Handle offline backend with maintenance view

### DIFF
--- a/choir-app-frontend/src/app/app.component.html
+++ b/choir-app-frontend/src/app/app.component.html
@@ -1,1 +1,2 @@
-<router-outlet></router-outlet>
+<app-service-unavailable *ngIf="!backendAvailable"></app-service-unavailable>
+<router-outlet *ngIf="backendAvailable"></router-outlet>

--- a/choir-app-frontend/src/app/app.component.spec.ts
+++ b/choir-app-frontend/src/app/app.component.spec.ts
@@ -2,9 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { AppComponent } from './app.component';
 import { ApiService } from '@core/services/api.service';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ServiceUnavailableComponent } from '@features/service-unavailable/service-unavailable.component';
 
 class ApiServiceStub {
   pingBackend() { return of({ message: 'PONG' }); }
@@ -15,7 +15,7 @@ describe('AppComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         AppComponent,
-        MatSnackBarModule,
+        ServiceUnavailableComponent,
         HttpClientTestingModule,
         RouterTestingModule
       ],
@@ -29,10 +29,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render router outlet or maintenance message', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('router-outlet')).toBeTruthy();
+    expect(compiled.querySelector('router-outlet') || compiled.querySelector('app-service-unavailable')).toBeTruthy();
   });
 });

--- a/choir-app-frontend/src/app/app.component.ts
+++ b/choir-app-frontend/src/app/app.component.ts
@@ -1,28 +1,28 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
 import { ThemeService } from '@core/services/theme.service';
 import { ApiService } from '@core/services/api.service';
+import { ServiceUnavailableComponent } from '@features/service-unavailable/service-unavailable.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterModule, MatSnackBarModule],
+  imports: [RouterModule, ServiceUnavailableComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+  backendAvailable = true;
+
   constructor(private themeService: ThemeService,
-              private api: ApiService,
-              private snackBar: MatSnackBar) {
+              private api: ApiService) {
     // Rufen Sie die Initialisierungsmethode auf, wenn die App startet.
     this.themeService.initializeTheme();
 
     this.api.pingBackend().subscribe({
-      error: () => this.snackBar.open('Backend nicht erreichbar', 'Close', {
-        duration: 5000,
-        verticalPosition: 'top'
-      })
+      next: () => this.backendAvailable = true,
+      error: () => this.backendAvailable = false
     });
   }
 }

--- a/choir-app-frontend/src/app/features/service-unavailable/service-unavailable.component.html
+++ b/choir-app-frontend/src/app/features/service-unavailable/service-unavailable.component.html
@@ -1,0 +1,8 @@
+<div class="maintenance-container">
+  <mat-card>
+    <mat-card-content>
+      <h2>Dienst nicht erreichbar</h2>
+      <p>Am Dienst wird aktuell gearbeitet. Bitte versuche es später erneut.</p>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/choir-app-frontend/src/app/features/service-unavailable/service-unavailable.component.scss
+++ b/choir-app-frontend/src/app/features/service-unavailable/service-unavailable.component.scss
@@ -1,0 +1,13 @@
+.maintenance-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  text-align: center;
+  padding: 1rem;
+}
+
+mat-card {
+  max-width: 400px;
+  width: 100%;
+}

--- a/choir-app-frontend/src/app/features/service-unavailable/service-unavailable.component.ts
+++ b/choir-app-frontend/src/app/features/service-unavailable/service-unavailable.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+
+@Component({
+  selector: 'app-service-unavailable',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './service-unavailable.component.html',
+  styleUrls: ['./service-unavailable.component.scss']
+})
+export class ServiceUnavailableComponent {}


### PR DESCRIPTION
## Summary
- show a dedicated maintenance message if the backend cannot be reached
- create `ServiceUnavailableComponent` to render this info
- wire the maintenance component into the root component and adjust unit tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643d45b0748320aabae81d88eae941