### PR TITLE
Prevent saving unchanged events

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -106,9 +106,22 @@ export class EventListComponent implements OnInit, AfterViewInit {
       const dialogRef = this.dialog.open(EventDialogComponent, { width: '600px', data: { event: fullEvent } });
       dialogRef.afterClosed().subscribe(result => {
         if (result && result.id) {
+          const originalPieces = fullEvent.pieces.map(p => p.id).sort();
+          const newPieces = [...result.pieceIds].sort();
+          const changed =
+            new Date(result.date).getTime() !== new Date(fullEvent.date).getTime() ||
+            result.type !== fullEvent.type ||
+            (result.notes || '') !== (fullEvent.notes || '') ||
+            JSON.stringify(originalPieces) !== JSON.stringify(newPieces);
+
+          if (!changed) {
+            this.snackBar.open('Keine Änderungen vorgenommen.', 'OK', { duration: 3000 });
+            return;
+          }
+
           this.apiService.updateEvent(result.id, result).subscribe({
-          next: () => { this.snackBar.open('Event aktualisiert.', 'OK', { duration: 3000 }); this.loadEvents(); },
-          error: () => this.snackBar.open('Fehler beim Aktualisieren des Events.', 'Schließen', { duration: 4000 })
+            next: () => { this.snackBar.open('Event aktualisiert.', 'OK', { duration: 3000 }); this.loadEvents(); },
+            error: () => this.snackBar.open('Fehler beim Aktualisieren des Events.', 'Schließen', { duration: 4000 })
           });
         }
       });


### PR DESCRIPTION
## Summary
- avoid redundant updates when editing events on backend
- warn user when no changes were made on frontend
- extend backend tests for update logic

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6864411ca5448320a4a2cc2849cf57f1