### PR TITLE
Add reference search in repertoire

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -115,11 +115,20 @@ exports.findMyRepertoire = async (req, res) => {
 
         if (search) {
             const tokens = parseSearchTokens(search);
+            const refSub = `(
+                        SELECT c.prefix || cp."numberInCollection"
+                        FROM collection_pieces cp
+                        JOIN collections c ON cp."collectionId" = c.id
+                        WHERE cp."pieceId" = "piece"."id"
+                        ORDER BY cp."numberInCollection"
+                        LIMIT 1
+                    )`;
             whereCondition[Op.and] = tokens.map(t => ({
                 [Op.or]: [
                     { title: { [Op.iLike]: `%${t}%` } },
                     { '$composer.name$': { [Op.iLike]: `%${t}%` } },
-                    { '$category.name$': { [Op.iLike]: `%${t}%` } }
+                    { '$category.name$': { [Op.iLike]: `%${t}%` } },
+                    literal(`${refSub} ILIKE '%${t}%'`)
                 ]
             }));
         }


### PR DESCRIPTION
## Summary
- allow repertoire search to match the reference prefix+number

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*
- `npm test` in frontend *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644171861c8320aafbe70fd3872331