### PR TITLE
Modify repertoire filter side nav

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -1,5 +1,8 @@
 <mat-drawer-container class="drawer-container">
-  <mat-drawer #drawer position="start" mode="over" class="filter-drawer" [(opened)]="filtersExpanded">
+  <mat-drawer #drawer position="start" mode="side" class="filter-drawer" [(opened)]="filtersExpanded">
+    <button mat-icon-button class="close-button" (click)="drawer.toggle()" aria-label="Filter ausblenden">
+      <mat-icon>chevron_left</mat-icon>
+    </button>
     <div class="filter-controls">
       <mat-form-field appearance="outline">
         <mat-label>Search</mat-label>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -13,6 +13,9 @@
 .filter-drawer {
   width: 360px;
   padding: 1rem;
+  .close-button {
+    margin-left: auto;
+  }
 }
 
 // Header der Seite (Titel und Button)


### PR DESCRIPTION
## Summary
- keep the repertoire filter persistent by using `mode="side"`
- add a chevron button inside the filter to close it
- style the new close button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686442a91534832085ee744a1ec963ba