### PR TITLE
Enable adding only existing users to choirs

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
@@ -1,0 +1,25 @@
+<h1 mat-dialog-title>Mitglied hinzufügen</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" id="add-member-form" (ngSubmit)="onAdd()">
+    <mat-form-field appearance="outline">
+      <mat-label>Benutzer</mat-label>
+      <input type="text" matInput formControlName="user" [matAutocomplete]="auto" cdkFocusInitial>
+      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn.bind(this)">
+        <mat-option *ngFor="let u of filteredUsers | async" [value]="u">
+          {{u.name}} ({{u.email}})
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Rolle im Chor</mat-label>
+      <mat-select formControlName="role">
+        <mat-option value="director">Dirigent</mat-option>
+        <mat-option value="choir_admin">Chor-Admin</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" type="submit" form="add-member-form" [disabled]="form.invalid">Hinzufügen</button>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+
+import { AddMemberDialogComponent } from './add-member-dialog.component';
+import { ApiService } from 'src/app/core/services/api.service';
+
+describe('AddMemberDialogComponent', () => {
+  let component: AddMemberDialogComponent;
+  let fixture: ComponentFixture<AddMemberDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddMemberDialogComponent, HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: ApiService, useValue: { getUsers: () => ({ subscribe: () => {} }) } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddMemberDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
@@ -1,0 +1,67 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from 'src/app/core/services/api.service';
+import { User } from 'src/app/core/models/user';
+import { Observable, map, startWith } from 'rxjs';
+
+@Component({
+  selector: 'app-add-member-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './add-member-dialog.component.html',
+  styleUrls: ['./add-member-dialog.component.scss']
+})
+export class AddMemberDialogComponent implements OnInit {
+  form: FormGroup;
+  users: User[] = [];
+  filteredUsers: Observable<User[]> = new Observable<User[]>();
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<AddMemberDialogComponent>,
+    private api: ApiService
+  ) {
+    this.form = this.fb.group({
+      user: ['', Validators.required],
+      role: ['director', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.getUsers().subscribe(users => {
+      this.users = users;
+      this.filteredUsers = this.form.controls['user'].valueChanges.pipe(
+        startWith(''),
+        map(value => typeof value === 'string' ? value : value?.email),
+        map(val => this.filterUsers(val))
+      );
+    });
+  }
+
+  displayFn(user: User): string {
+    return user ? `${user.name} (${user.email})` : '';
+  }
+
+  private filterUsers(value: string | undefined): User[] {
+    const filterValue = (value || '').toLowerCase();
+    return this.users.filter(u =>
+      u.email.toLowerCase().includes(filterValue) ||
+      (u.name && u.name.toLowerCase().includes(filterValue))
+    );
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onAdd(): void {
+    if (this.form.valid) {
+      const user: User = this.form.value.user;
+      const role = this.form.value.role;
+      this.dialogRef.close({ email: user.email, role });
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -8,7 +8,7 @@ import { MaterialModule } from '@modules/material.module';
 import { Choir } from 'src/app/core/models/choir';
 import { UserInChoir } from 'src/app/core/models/user';
 import { ApiService } from 'src/app/core/services/api.service';
-import { InviteUserDialogComponent } from '../../../choir-management/invite-user-dialog/invite-user-dialog.component';
+import { AddMemberDialogComponent } from '../add-member-dialog/add-member-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 
 @Component({
@@ -53,7 +53,7 @@ export class ChoirDialogComponent implements OnInit {
 
   openInviteDialog(): void {
     if (!this.data?.id) return;
-    const ref = this.dialog.open(InviteUserDialogComponent, { width: '450px' });
+    const ref = this.dialog.open(AddMemberDialogComponent, { width: '450px' });
     ref.afterClosed().subscribe(result => {
       if (result && result.email && result.role) {
         this.api.inviteUserToChoirAdmin(this.data!.id, result.email, result.role).subscribe({


### PR DESCRIPTION
## Summary
- implement `AddMemberDialog` to pick users already in the database
- open this dialog from the admin choir dialog

## Testing
- `npm install --prefix choir-app-frontend` *(fails: registry.npmjs.org blocked)*
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686445a790348320bd540467a297622d