### PR TITLE
Translate remaining UI texts to German

### DIFF
--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
@@ -1,6 +1,6 @@
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="email">
-    <th mat-header-cell *matHeaderCellDef>Email</th>
+    <th mat-header-cell *matHeaderCellDef>E-Mail</th>
     <td mat-cell *matCellDef="let element">
       <a href="#" (click)="openUser(element.email); $event.preventDefault()">{{ element.email }}</a>
     </td>

--- a/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.html
@@ -1,5 +1,5 @@
 <div class="toolbar">
-  <button mat-flat-button color="primary" (click)="addAuthor()">Add Author</button>
+  <button mat-flat-button color="primary" (click)="addAuthor()">Dichter hinzufügen</button>
 </div>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
@@ -9,12 +9,12 @@
   </ng-container>
 
   <ng-container matColumnDef="birthYear">
-    <th mat-header-cell *matHeaderCellDef>Birth</th>
+    <th mat-header-cell *matHeaderCellDef>Geburt</th>
     <td mat-cell *matCellDef="let element">{{ element.birthYear }}</td>
   </ng-container>
 
   <ng-container matColumnDef="deathYear">
-    <th mat-header-cell *matHeaderCellDef>Death</th>
+    <th mat-header-cell *matHeaderCellDef>Tod</th>
     <td mat-cell *matCellDef="let element">{{ element.deathYear }}</td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-authors/manage-authors.component.ts
@@ -58,7 +58,7 @@ export class ManageAuthorsComponent implements OnInit {
 
   deleteAuthor(author: Author): void {
     if (!author.canDelete) return;
-    if (confirm('Delete author?')) {
+    if (confirm('Dichter löschen?')) {
       this.api.deleteAuthor(author.id).subscribe(() => this.loadAuthors());
     }
   }

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -61,7 +61,7 @@ export class ChoirDialogComponent implements OnInit {
             this.snackBar.open(resp.message, 'OK', { duration: 4000 });
             this.loadMembers();
           },
-          error: err => this.snackBar.open(err.error?.message || 'Error', 'Close')
+          error: err => this.snackBar.open(err.error?.message || 'Fehler', 'Schließen')
         });
       }
     });
@@ -70,18 +70,18 @@ export class ChoirDialogComponent implements OnInit {
   removeMember(user: UserInChoir): void {
     if (!this.data?.id) return;
     const data: ConfirmDialogData = {
-      title: 'Remove Member?',
-      message: `Are you sure you want to remove ${user.name} (${user.email}) from this choir?`
+      title: 'Mitglied entfernen?',
+      message: `Soll ${user.name} (${user.email}) aus diesem Chor entfernt werden?`
     };
     const ref = this.dialog.open(ConfirmDialogComponent, { data });
     ref.afterClosed().subscribe(conf => {
       if (conf) {
         this.api.removeUserFromChoirAdmin(this.data!.id, user.id).subscribe({
           next: () => {
-            this.snackBar.open('Member removed', 'OK', { duration: 3000 });
+            this.snackBar.open('Mitglied entfernt', 'OK', { duration: 3000 });
             this.loadMembers();
           },
-          error: err => this.snackBar.open('Error removing member', 'Close')
+          error: err => this.snackBar.open('Fehler beim Entfernen des Mitglieds', 'Schließen')
         });
       }
     });

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
@@ -53,7 +53,7 @@ export class ManageChoirsComponent implements OnInit {
   }
 
   deleteChoir(choir: Choir): void {
-    if (confirm('Delete choir?')) {
+    if (confirm('Chor löschen?')) {
       this.api.deleteChoir(choir.id).subscribe(() => this.loadChoirs());
     }
   }

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.html
@@ -1,5 +1,5 @@
 <div class="toolbar">
-  <button mat-flat-button color="primary" (click)="addComposer()">Add Composer</button>
+  <button mat-flat-button color="primary" (click)="addComposer()">Komponist hinzufügen</button>
 </div>
 
 <div class="letter-filter">
@@ -15,12 +15,12 @@
   </ng-container>
 
   <ng-container matColumnDef="birthYear">
-    <th mat-header-cell *matHeaderCellDef>Birth</th>
+    <th mat-header-cell *matHeaderCellDef>Geburt</th>
     <td mat-cell *matCellDef="let element">{{ element.birthYear }}</td>
   </ng-container>
 
   <ng-container matColumnDef="deathYear">
-    <th mat-header-cell *matHeaderCellDef>Death</th>
+    <th mat-header-cell *matHeaderCellDef>Tod</th>
     <td mat-cell *matCellDef="let element">{{ element.deathYear }}</td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-composers/manage-composers.component.ts
@@ -102,7 +102,7 @@ export class ManageComposersComponent implements OnInit, AfterViewInit {
 
   deleteComposer(composer: Composer): void {
     if (!composer.canDelete) return;
-    if (confirm('Delete composer?')) {
+    if (confirm('Komponist löschen?')) {
       this.adminApiService.deleteComposer(composer.id).subscribe(() => this.loadComposers());
     }
   }

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -1,5 +1,5 @@
 <div class="toolbar">
-  <button mat-flat-button color="primary" (click)="addUser()">Add User</button>
+  <button mat-flat-button color="primary" (click)="addUser()">Benutzer hinzufügen</button>
 </div>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
@@ -9,17 +9,17 @@
   </ng-container>
 
   <ng-container matColumnDef="email">
-    <th mat-header-cell *matHeaderCellDef>Email</th>
+    <th mat-header-cell *matHeaderCellDef>E-Mail</th>
     <td mat-cell *matCellDef="let element">{{ element.email }}</td>
   </ng-container>
 
   <ng-container matColumnDef="role">
-    <th mat-header-cell *matHeaderCellDef>Role</th>
+    <th mat-header-cell *matHeaderCellDef>Rolle</th>
     <td mat-cell *matCellDef="let element">{{ element.role }}</td>
   </ng-container>
 
   <ng-container matColumnDef="choirs">
-    <th mat-header-cell *matHeaderCellDef>Choirs</th>
+    <th mat-header-cell *matHeaderCellDef>Chöre</th>
     <td mat-cell *matCellDef="let element">{{ choirList(element) }}</td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -52,15 +52,15 @@ export class ManageUsersComponent implements OnInit {
   }
 
   deleteUser(user: User): void {
-    if (confirm('Delete user?')) {
+    if (confirm('Benutzer löschen?')) {
       this.api.deleteUser(user.id).subscribe(() => this.loadUsers());
     }
   }
 
   sendReset(user: User): void {
-    if (confirm('Send password reset email?')) {
+    if (confirm('Passwort-Reset-E-Mail senden?')) {
       this.api.sendPasswordReset(user.id).subscribe(() => {
-        this.snack.open('Email sent if user exists.', 'OK', { duration: 3000 });
+        this.snack.open('E-Mail gesendet, falls der Benutzer existiert.', 'OK', { duration: 3000 });
       });
     }
   }

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -6,24 +6,24 @@
       <input matInput formControlName="name" cdkFocusInitial>
     </mat-form-field>
     <mat-form-field appearance="outline">
-      <mat-label>Email</mat-label>
+      <mat-label>E-Mail</mat-label>
       <input matInput formControlName="email">
     </mat-form-field>
     <mat-form-field appearance="outline">
-      <mat-label>Password</mat-label>
+      <mat-label>Passwort</mat-label>
       <input matInput type="password" formControlName="password">
     </mat-form-field>
     <mat-form-field appearance="outline">
-      <mat-label>Role</mat-label>
+      <mat-label>Rolle</mat-label>
       <mat-select formControlName="role">
-        <mat-option value="director">director</mat-option>
-        <mat-option value="choir_admin">choir_admin</mat-option>
-        <mat-option value="admin">admin</mat-option>
+        <mat-option value="director">Dirigent</mat-option>
+        <mat-option value="choir_admin">Chor-Admin</mat-option>
+        <mat-option value="admin">Admin</mat-option>
       </mat-select>
     </mat-form-field>
   </form>
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-button (click)="onCancel()">Cancel</button>
-  <button mat-flat-button color="primary" type="submit" form="user-form" [disabled]="form.invalid">Save</button>
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" type="submit" form="user-form" [disabled]="form.invalid">Speichern</button>
 </div>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -14,14 +14,14 @@ import { User } from 'src/app/core/models/user';
 })
 export class UserDialogComponent {
   form: FormGroup;
-  title = 'Add User';
+  title = 'Benutzer hinzufügen';
 
   constructor(
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<UserDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: User | null
   ) {
-    this.title = data ? 'Edit User' : 'Add User';
+    this.title = data ? 'Benutzer bearbeiten' : 'Benutzer hinzufügen';
     this.form = this.fb.group({
       name: [data?.name || '', Validators.required],
       email: [data?.email || '', [Validators.required, Validators.email]],

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -79,7 +79,7 @@ export class ManageChoirComponent implements OnInit {
         this.snackBar.open('Choir details updated successfully!', 'OK', { duration: 3000 });
         this.choirForm.markAsPristine(); // Markiert das Formular als "unverändert"
       },
-      error: (err) => this.snackBar.open('Error updating choir details.', 'Close')
+      error: (err) => this.snackBar.open('Fehler beim Aktualisieren der Chordaten.', 'Schließen')
     });
   }
 
@@ -98,7 +98,7 @@ export class ManageChoirComponent implements OnInit {
             this.snackBar.open(response.message, 'OK', { duration: 4000 });
             this.reloadData(); // Aktualisieren Sie die Datenquelle der Tabelle
           },
-          error: (err) => this.snackBar.open(`Error inviting user: ${err.error.message}`, 'Close')
+          error: (err) => this.snackBar.open(`Fehler beim Einladen: ${err.error.message}`, 'Schließen')
         });
       }
     });
@@ -109,8 +109,8 @@ export class ManageChoirComponent implements OnInit {
       return;
     }
     const dialogData: ConfirmDialogData = {
-      title: 'Remove Member?',
-      message: `Are you sure you want to remove ${user.name} (${user.email}) from this choir? This cannot be undone.`
+      title: 'Mitglied entfernen?',
+      message: `Soll ${user.name} (${user.email}) aus diesem Chor entfernt werden? Dies kann nicht rückgängig gemacht werden.`
     };
 
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -135,13 +135,13 @@
           <table class="piece-link-table" mat-table [dataSource]="pieceLinkDataSource" matSort matSortActive="number" matSortDirection="asc">
             <!-- Number Column Definition -->
             <ng-container matColumnDef="number">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="number"> Number </th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="number"> Nr. </th>
               <td mat-cell *matCellDef="let link"> {{link.numberInCollection}} </td>
             </ng-container>
 
             <!-- Title Column Definition -->
             <ng-container matColumnDef="title">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Title </th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
               <td mat-cell *matCellDef="let link"> {{link.piece.title}} </td>
             </ng-container>
 
@@ -152,7 +152,7 @@
                 <button mat-icon-button (click)="openEditPieceDialog(link.piece.id)" matTooltip="Stück bearbeiten">
                   <mat-icon>edit</mat-icon>
                 </button>
-                <button mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Remove piece from collection">
+                <button mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Stück aus Sammlung entfernen">
                   <mat-icon>delete</mat-icon>
                 </button>
               </td>
@@ -168,7 +168,7 @@
             [pageSizeOptions]="pageSizeOptions"
             [pageSize]="pageSize"
             showFirstLastButtons
-            aria-label="Select page of pieces">
+            aria-label="Seite auswählen">
           </mat-paginator>
           </div>
 

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -274,7 +274,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
                 });
             },
             error: (err) => {
-                this.snackBar.open(`Error: ${err.message}`, 'Close', {
+                this.snackBar.open(`Fehler: ${err.message}`, 'Schließen', {
                     duration: 5000,
                     verticalPosition: 'top',
                 });

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -79,7 +79,7 @@ export class CollectionListComponent implements OnInit {
         this.loadCollections();
       },
       error: (err) => {
-        this.snackBar.open(`Fehler beim Hinzufügen der Sammlung: ${err.message}`, 'Close', {
+        this.snackBar.open(`Fehler beim Hinzufügen der Sammlung: ${err.message}`, 'Schließen', {
           duration: 5000,
           verticalPosition: 'top'
         });

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -5,21 +5,21 @@
     </button>
     <div class="filter-controls">
       <mat-form-field appearance="outline">
-        <mat-label>Search</mat-label>
+        <mat-label>Suche</mat-label>
         <input matInput [formControl]="searchControl" placeholder="Repertoire durchsuchen" />
-        <mat-hint>Use quotes for phrases</mat-hint>
+        <mat-hint>Anführungszeichen für Wortgruppen verwenden</mat-hint>
       </mat-form-field>
       <mat-form-field appearance="outline">
-        <mat-label>Collection</mat-label>
+        <mat-label>Sammlung</mat-label>
         <mat-select [value]="filterByCollectionId$.value" (selectionChange)="onCollectionFilterChange($event.value)">
-          <mat-option [value]="null">All</mat-option>
+          <mat-option [value]="null">Alle</mat-option>
           <mat-option *ngFor="let collection of collections$ | async" [value]="collection.id">
             {{ collection.title }}
           </mat-option>
         </mat-select>
       </mat-form-field>
       <mat-form-field appearance="outline">
-        <mat-label>Category</mat-label>
+        <mat-label>Rubrik</mat-label>
         <mat-select multiple [value]="filterByCategoryIds$.value" (selectionChange)="onCategoryFilterChange($event.value)">
           <mat-option *ngFor="let cat of categories$ | async" [value]="cat.id">{{cat.name}}</mat-option>
         </mat-select>
@@ -42,7 +42,7 @@
   <mat-drawer-content>
     <div class="page">
       <div class="header-container">
-        <button mat-icon-button (click)="drawer.toggle()" aria-label="Toggle filters">
+        <button mat-icon-button (click)="drawer.toggle()" aria-label="Filter ein-/ausblenden">
           <mat-icon>filter_list</mat-icon>
         </button>
         <mat-form-field appearance="outline" class="preset-select">

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -381,7 +381,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         console.error('Failed to update status', err);
         const msg = err.error?.message || 'Could not update status.';
         this.errorService.setError({ message: msg, status: err.status });
-        this.snackBar.open('Error: Could not update status.', 'Close', { duration: 5000 });
+        this.snackBar.open('Fehler: Status konnte nicht aktualisiert werden.', 'Schließen', { duration: 5000 });
         // Optional: you might want to refresh the list here to revert the visual change
         this.refresh$.next();
       }

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -16,7 +16,7 @@
           <ng-container *ngSwitchCase="'general'">
             <div class="form-section">
               <mat-form-field appearance="outline">
-                <mat-label>Title</mat-label>
+                <mat-label>Titel</mat-label>
                 <input matInput formControlName="title" cdkFocusInitial>
               </mat-form-field>
 

--- a/choir-app-frontend/src/app/features/login/login.component.html
+++ b/choir-app-frontend/src/app/features/login/login.component.html
@@ -5,7 +5,7 @@
       <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
         <p>
           <mat-form-field appearance="outline">
-            <mat-label>Email</mat-label>
+          <mat-label>E-Mail</mat-label>
             <input matInput formControlName="email" type="email">
           </mat-form-field>
         </p>

--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.html
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.html
@@ -4,7 +4,7 @@
     <mat-card-content>
       <form [formGroup]="form" (ngSubmit)="submit()">
         <mat-form-field appearance="outline">
-          <mat-label>Email</mat-label>
+          <mat-label>E-Mail</mat-label>
           <input matInput type="email" formControlName="email">
         </mat-form-field>
         <mat-card-actions align="end">

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -97,8 +97,8 @@ export class ProfileComponent implements OnInit {
         this.profileForm.get('passwords')?.reset();
       },
       error: (err) => {
-        const errorMessage = err.error?.message || 'Failed to update profile.';
-        this.snackBar.open(errorMessage, 'Close', { duration: 5000,  verticalPosition: 'top'  });
+        const errorMessage = err.error?.message || 'Profilaktualisierung fehlgeschlagen.';
+        this.snackBar.open(errorMessage, 'Schließen', { duration: 5000,  verticalPosition: 'top'  });
       }
     });
   }


### PR DESCRIPTION
## Summary
- translate filter labels and hints
- localize admin pages and dialogs
- change confirmation prompts and error snackbars to German
- update forms to use "E-Mail"

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686446aa54648320aee7b01498749b96