### PR TITLE
Fix sorting for repertoire last date fields

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -258,22 +258,32 @@ exports.findMyRepertoire = async (req, res) => {
                     ]
                 ];
                 break;
-            case 'lastSung':
-                order = [[literal(`(
+            case 'lastSung': {
+                const base = `(
                         SELECT MAX(e.date)
                         FROM event_pieces ep
                         JOIN events e ON ep."eventId" = e.id
                         WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'SERVICE'
-                    )`), sortDirection]];
+                    )`;
+                const expr = sortDirection === 'DESC'
+                    ? `COALESCE(${base}, TO_TIMESTAMP(0))`
+                    : base;
+                order = [[literal(expr), sortDirection]];
                 break;
-            case 'lastRehearsed':
-                order = [[literal(`(
+            }
+            case 'lastRehearsed': {
+                const base = `(
                         SELECT MAX(e.date)
                         FROM event_pieces ep
                         JOIN events e ON ep."eventId" = e.id
                         WHERE ep."pieceId" = "piece"."id" AND e."choirId" = ${req.activeChoirId} AND e.type = 'REHEARSAL'
-                    )`), sortDirection]];
+                    )`;
+                const expr = sortDirection === 'DESC'
+                    ? `COALESCE(${base}, TO_TIMESTAMP(0))`
+                    : base;
+                order = [[literal(expr), sortDirection]];
                 break;
+            }
             case 'timesSung':
                 order = [[literal(`(
                         SELECT COUNT(*)


### PR DESCRIPTION
## Summary
- handle descending sort for `lastSung` and `lastRehearsed` when values are missing

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: missing sequelize)*

------
https://chatgpt.com/codex/tasks/task_e_6864489d845c832093dd9f02963dba51