### PR TITLE
Add browser info to login attempts

### DIFF
--- a/choir-app-backend/src/models/login_attempt.model.js
+++ b/choir-app-backend/src/models/login_attempt.model.js
@@ -10,6 +10,9 @@ module.exports = (sequelize, DataTypes) => {
         },
         ipAddress: {
             type: DataTypes.STRING
+        },
+        userAgent: {
+            type: DataTypes.STRING
         }
     });
     return LoginAttempt;

--- a/choir-app-frontend/src/app/core/models/login-attempt.ts
+++ b/choir-app-frontend/src/app/core/models/login-attempt.ts
@@ -3,6 +3,7 @@ export interface LoginAttempt {
   email: string;
   success: boolean;
   ipAddress?: string;
+  userAgent?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
@@ -16,6 +16,11 @@
     <td mat-cell *matCellDef="let element">{{ element.ipAddress }}</td>
   </ng-container>
 
+  <ng-container matColumnDef="userAgent">
+    <th mat-header-cell *matHeaderCellDef>Browser</th>
+    <td mat-cell *matCellDef="let element">{{ element.userAgent }}</td>
+  </ng-container>
+
   <ng-container matColumnDef="createdAt">
     <th mat-header-cell *matHeaderCellDef>Datum</th>
     <td mat-cell *matCellDef="let element">{{ element.createdAt | date:'short' }}</td>

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.ts
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.ts
@@ -17,7 +17,7 @@ import { UserDialogComponent } from '../manage-users/user-dialog/user-dialog.com
 })
 export class LoginAttemptsComponent implements OnInit {
   attempts: LoginAttempt[] = [];
-  displayedColumns = ['email', 'success', 'ipAddress', 'createdAt'];
+  displayedColumns = ['email', 'success', 'ipAddress', 'userAgent', 'createdAt'];
   dataSource = new MatTableDataSource<LoginAttempt>();
 
   constructor(private api: ApiService, private dialog: MatDialog, private snack: MatSnackBar) {}


### PR DESCRIPTION
## Summary
- record user agent on login
- show browser info in admin login attempt list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644908a6648320b4c10a5fcc2b0751