### PR TITLE
Fix help wizard for demo user

### DIFF
--- a/choir-app-frontend/src/app/core/services/help.service.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@angular/core';
 import { User } from '../models/user';
 import { UserPreferencesService } from './user-preferences.service';
 
-const PREFIX = 'help-shown-';
-
 @Injectable({ providedIn: 'root' })
 export class HelpService {
   constructor(private prefs: UserPreferencesService) {}
@@ -11,16 +9,15 @@ export class HelpService {
   shouldShowHelp(user: User | null): boolean {
     if (!user) return false;
     if (user.role === 'demo') {
-      return !sessionStorage.getItem(PREFIX + 'demo');
+      // demo users see the help wizard every time they log in
+      return true;
     }
     return !this.prefs.getPreference('helpShown');
   }
 
   markHelpShown(user: User | null): void {
     if (!user) return;
-    if (user.role === 'demo') {
-      sessionStorage.setItem(PREFIX + 'demo', 'true');
-    } else {
+    if (user.role !== 'demo') {
       this.prefs.update({ helpShown: true }).subscribe();
     }
   }


### PR DESCRIPTION
## Summary
- show onboarding for demo user on each login
- persist onboarding completion for other users in preferences

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644b5339948320ae6daa1ee7d2cbfc