### PR TITLE
Add drag-and-drop image upload for pieces

### DIFF
--- a/choir-app-backend/src/routes/piece.routes.js
+++ b/choir-app-backend/src/routes/piece.routes.js
@@ -1,8 +1,24 @@
 const authJwt = require("../middleware/auth.middleware");
 const controller = require("../controllers/piece.controller");
 const router = require("express").Router();
+const multer = require('multer');
+const path = require('path');
 
-// All piece routes are protected and require login
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../../uploads/piece-images'));
+  },
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + path.extname(file.originalname));
+  }
+});
+const upload = multer({ storage });
+
+// Public endpoint to fetch a piece image without authentication
+router.get("/:id/image", controller.getImage);
+
+// All other piece routes are protected and require login
 router.use(authJwt.verifyToken);
 
 router.get("/", controller.findAll);
@@ -10,5 +26,6 @@ router.get("/:id", controller.findOne);
 router.post("/", controller.create);
 router.put("/:id", controller.update);
 router.delete("/:id", controller.delete);
+router.post("/:id/image", upload.single('image'), controller.uploadImage);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -103,6 +103,18 @@ export class ApiService {
     return this.pieceService.updateGlobalPiece(id, pieceData);
   }
 
+  uploadPieceImage(id: number, file: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('image', file);
+    return this.http.post(`${this.apiUrl}/pieces/${id}/image`, formData);
+  }
+
+  getPieceImage(id: number): Observable<string> {
+    return this.http
+      .get<{ data: string }>(`${this.apiUrl}/pieces/${id}/image`)
+      .pipe(map(res => res.data));
+  }
+
   proposePieceChange(id: number, pieceData: any): Observable<any> {
     return this.pieceService.proposePieceChange(id, pieceData);
   }

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -109,7 +109,22 @@
             <mat-divider></mat-divider>
             <div class="form-section">
               <h4>Notenbild</h4>
-              <p>Platzhalter für Dateiupload-Komponente.</p>
+              <div class="image-upload">
+                <div
+                  class="dropzone"
+                  [class.dragover]="isDragOver"
+                  (dragover)="onDragOver($event)"
+                  (dragleave)="onDragLeave($event)"
+                  (drop)="onDrop($event)"
+                  (click)="fileInput.click()"
+                >
+                  <ng-container *ngIf="!imagePreview">
+                    <p>Bild hierher ziehen oder klicken</p>
+                  </ng-container>
+                  <img *ngIf="imagePreview" [src]="imagePreview" alt="Notenbild Vorschau" />
+                </div>
+                <input type="file" #fileInput accept="image/*" hidden (change)="onFileSelected($event)" />
+              </div>
             </div>
           </ng-container>
         </ng-container>

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
@@ -41,3 +41,24 @@ div[mat-dialog-content] {
 mat-sidenav {
   width: 220px;
 }
+
+.image-upload {
+  margin-top: 1rem;
+
+  .dropzone {
+    border: 2px dashed #ccc;
+    padding: 1rem;
+    text-align: center;
+    cursor: pointer;
+
+    &.dragover {
+      background-color: #f5f5f5;
+    }
+
+    img {
+      max-height: 150px;
+      width: auto;
+      object-fit: cover;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow storing and retrieving piece images on backend
- expose GET/POST routes for `/api/pieces/:id/image`
- support uploading piece images in frontend dialog via drag & drop
- preview uploaded image and fetch existing images

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6864ba23c9ec8320b2399f81afd272e1