### PR TITLE
Add monthly plan routes and frontend component

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/import.controller.test.js"
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -61,6 +61,7 @@ const invitationRoutes = require("./routes/invitation.routes");
 const statsRoutes = require("./routes/stats.routes");
 const passwordResetRoutes = require("./routes/password-reset.routes");
 const repertoireFilterRoutes = require("./routes/repertoire-filter.routes");
+const monthlyPlanRoutes = require("./routes/monthlyPlan.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -80,6 +81,7 @@ app.use("/api/invitations", invitationRoutes);
 app.use("/api/stats", statsRoutes);
 app.use("/api/password-reset", passwordResetRoutes);
 app.use("/api/repertoire-filters", repertoireFilterRoutes);
+app.use("/api/monthly-plans", monthlyPlanRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -37,7 +37,7 @@ async function autoUpdatePieceStatuses(eventType, choirId, pieceIds) {
 }
 
 exports.create = async (req, res) => {
-    const { date, type, notes, pieceIds } = req.body;
+    const { date, type, notes, pieceIds, organistId, finalized, version, monthlyPlanId } = req.body;
     const choirId = req.activeChoirId;
     const userId = req.userId;
 
@@ -79,7 +79,11 @@ exports.create = async (req, res) => {
             type: type,
             notes: notes,
             choirId: choirId,
-            directorId: userId
+            directorId: userId,
+            organistId: organistId || null,
+            finalized: finalized || false,
+            version: version || 1,
+            monthlyPlanId: monthlyPlanId || null
         });
 
         // Unabhängig davon, ob neu oder aktualisiert, setzen Sie die Liste der Stücke neu.
@@ -90,7 +94,11 @@ exports.create = async (req, res) => {
 
         // Event inklusive Director neu laden, um den Namen zurückzugeben
         const fullEvent = await Event.findByPk(event.id, {
-            include: [{ model: User, as: 'director', attributes: ['name'] }]
+            include: [
+                { model: User, as: 'director', attributes: ['name'] },
+                { model: User, as: 'organist', attributes: ['name'], required: false },
+                { model: db.monthly_plan, as: 'monthlyPlan', attributes: ['month', 'year', 'finalized', 'version'], required: false }
+            ]
         });
 
         // Senden Sie eine Antwort, die dem Frontend mitteilt, was passiert ist.
@@ -150,7 +158,7 @@ exports.findLast = async (req, res) => {
                         }
                     }
                 ]
-            }, { model: User, as: 'director', attributes: ['name'] }]
+            }, { model: User, as: 'director', attributes: ['name'] }, { model: User, as: 'organist', attributes: ['name'], required: false }]
         });
 
         if (!lastEvent) {
@@ -179,7 +187,11 @@ exports.findAll = async (req, res) => {
         const events = await Event.findAll({
             where,
             order: [['date', 'DESC']],
-            include: [{ model: User, as: 'director', attributes: ['name'] }]
+            include: [
+                { model: User, as: 'director', attributes: ['name'] },
+                { model: User, as: 'organist', attributes: ['name'], required: false },
+                { model: db.monthly_plan, as: 'monthlyPlan', attributes: ['month', 'year', 'finalized', 'version'], required: false }
+            ]
         });
         res.status(200).send(events);
     } catch (err) {
@@ -214,7 +226,7 @@ exports.findOne = async (req, res) => {
                         }
                     }
                 ]
-            }, { model: User, as: 'director', attributes: ['name'] }]
+            }, { model: User, as: 'director', attributes: ['name'] }, { model: db.monthly_plan, as: 'monthlyPlan', attributes: ['month', 'year', 'finalized', 'version'], required: false }]
         });
 
         if (!event) {
@@ -229,7 +241,7 @@ exports.findOne = async (req, res) => {
 
 exports.update = async (req, res) => {
     const id = req.params.id;
-    const { date, type, notes, pieceIds } = req.body;
+    const { date, type, notes, pieceIds, organistId, finalized, version, monthlyPlanId } = req.body;
 
     try {
         const event = await Event.findOne({ where: { id, choirId: req.activeChoirId } });
@@ -237,7 +249,7 @@ exports.update = async (req, res) => {
             return res.status(404).send({ message: 'Event not found.' });
         }
 
-        await event.update({ date, type, notes, directorId: req.userId });
+        await event.update({ date, type, notes, directorId: req.userId, organistId, finalized, version, monthlyPlanId });
 
         if (Array.isArray(pieceIds)) {
             await event.setPieces(pieceIds);
@@ -247,7 +259,9 @@ exports.update = async (req, res) => {
         const updated = await Event.findByPk(id, {
             include: [
                 { model: Piece, as: 'pieces', through: { attributes: [] } },
-                { model: User, as: 'director', attributes: ['name'] }
+                { model: User, as: 'director', attributes: ['name'] },
+                { model: User, as: 'organist', attributes: ['name'], required: false },
+                { model: db.monthly_plan, as: 'monthlyPlan', attributes: ['month', 'year', 'finalized', 'version'], required: false }
             ]
         });
         res.status(200).send(updated);

--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -1,0 +1,64 @@
+const db = require('../models');
+const MonthlyPlan = db.monthly_plan;
+
+exports.findByMonth = async (req, res) => {
+    const { year, month } = req.params;
+    try {
+        const plan = await MonthlyPlan.findOne({
+            where: { choirId: req.activeChoirId, year, month },
+            include: [{
+                model: db.event,
+                as: 'events',
+                order: [['date', 'ASC']],
+                include: [
+                    { model: db.user, as: 'director', attributes: ['name'] },
+                    { model: db.user, as: 'organist', attributes: ['name'], required: false }
+                ]
+            }]
+        });
+        if (!plan) return res.status(404).send({ message: 'Plan not found.' });
+        res.status(200).send(plan);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not fetch plan.' });
+    }
+};
+
+exports.create = async (req, res) => {
+    const { year, month } = req.body;
+    if (!year || !month) {
+        return res.status(400).send({ message: 'year and month required' });
+    }
+    try {
+        const [plan, created] = await MonthlyPlan.findOrCreate({
+            where: { choirId: req.activeChoirId, year, month },
+            defaults: { choirId: req.activeChoirId, year, month }
+        });
+        res.status(created ? 201 : 200).send(plan);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not create plan.' });
+    }
+};
+
+exports.finalize = async (req, res) => {
+    const id = req.params.id;
+    try {
+        const plan = await MonthlyPlan.findOne({ where: { id, choirId: req.activeChoirId } });
+        if (!plan) return res.status(404).send({ message: 'Plan not found.' });
+        await plan.update({ finalized: true, version: plan.version + 1 });
+        res.status(200).send(plan);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not finalize plan.' });
+    }
+};
+
+exports.reopen = async (req, res) => {
+    const id = req.params.id;
+    try {
+        const plan = await MonthlyPlan.findOne({ where: { id, choirId: req.activeChoirId } });
+        if (!plan) return res.status(404).send({ message: 'Plan not found.' });
+        await plan.update({ finalized: false });
+        res.status(200).send(plan);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not reopen plan.' });
+    }
+};

--- a/choir-app-backend/src/models/event.model.js
+++ b/choir-app-backend/src/models/event.model.js
@@ -10,6 +10,22 @@ module.exports = (sequelize, DataTypes) => {
       },
       notes: {
         type: DataTypes.TEXT
+      },
+      organistId: {
+        type: DataTypes.INTEGER,
+        allowNull: true
+      },
+      finalized: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
+      },
+      version: {
+        type: DataTypes.INTEGER,
+        defaultValue: 1
+      },
+      monthlyPlanId: {
+        type: DataTypes.INTEGER,
+        allowNull: true
       }
     });
     return Event;

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -17,6 +17,7 @@ db.choir = require("./choir.model.js")(sequelize, Sequelize);
 db.user = require("./user.model.js")(sequelize, Sequelize);
 db.piece = require("./piece.model.js")(sequelize, Sequelize);
 db.event = require("./event.model.js")(sequelize, Sequelize);
+db.monthly_plan = require("./monthly_plan.model.js")(sequelize, Sequelize);
 db.event_pieces = require("./event_pieces.model.js")(sequelize, Sequelize);
 db.composer = require("./composer.model.js")(sequelize, Sequelize);
 db.category = require("./category.model.js")(sequelize, Sequelize);
@@ -49,6 +50,12 @@ db.event.belongsTo(db.choir, { foreignKey: "choirId", as: "choir" });
 // A User (director) created an Event
 db.user.hasMany(db.event, { as: "createdEvents"});
 db.event.belongsTo(db.user, { foreignKey: "directorId", as: "director"})
+db.user.hasMany(db.event, { as: "organistEvents", foreignKey: "organistId" });
+db.event.belongsTo(db.user, { foreignKey: "organistId", as: "organist" });
+db.choir.hasMany(db.monthly_plan, { as: "monthlyPlans" });
+db.monthly_plan.belongsTo(db.choir, { foreignKey: "choirId", as: "choir" });
+db.monthly_plan.hasMany(db.event, { as: "events" });
+db.event.belongsTo(db.monthly_plan, { foreignKey: "monthlyPlanId", as: "monthlyPlan" });
 
 // A User (director) created a Piece
 db.user.hasMany(db.piece, { as: "createdPieces"});

--- a/choir-app-backend/src/models/monthly_plan.model.js
+++ b/choir-app-backend/src/models/monthly_plan.model.js
@@ -1,0 +1,21 @@
+module.exports = (sequelize, DataTypes) => {
+    const MonthlyPlan = sequelize.define('monthly_plan', {
+        year: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        month: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        finalized: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false
+        },
+        version: {
+            type: DataTypes.INTEGER,
+            defaultValue: 1
+        }
+    });
+    return MonthlyPlan;
+};

--- a/choir-app-backend/src/models/user_choir.model.js
+++ b/choir-app-backend/src/models/user_choir.model.js
@@ -11,6 +11,10 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.ENUM('director', 'choir_admin'),
             defaultValue: 'director'
         },
+        isOrganist: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false
+        },
         registrationStatus: {
             type: DataTypes.ENUM('REGISTERED', 'PENDING'),
             defaultValue: 'REGISTERED'

--- a/choir-app-backend/src/routes/monthlyPlan.routes.js
+++ b/choir-app-backend/src/routes/monthlyPlan.routes.js
@@ -1,0 +1,12 @@
+const auth = require("../middleware/auth.middleware");
+const controller = require("../controllers/monthlyPlan.controller");
+const router = require("express").Router();
+
+router.use(auth.verifyToken);
+
+router.get(":year/:month", controller.findByMonth);
+router.post("/", auth.isChoirAdminOrAdmin, controller.create);
+router.put(":id/finalize", auth.isChoirAdminOrAdmin, controller.finalize);
+router.put(":id/reopen", auth.isChoirAdminOrAdmin, controller.reopen);
+
+module.exports = router;

--- a/choir-app-backend/tests/event.controller.test.js
+++ b/choir-app-backend/tests/event.controller.test.js
@@ -11,6 +11,8 @@ const controller = require('../src/controllers/event.controller');
     await db.sequelize.sync({ force: true });
     const choir = await db.choir.create({ name: 'Test Choir' });
     const user = await db.user.create({ email: 't@example.com', role: 'USER' });
+    const organist = await db.user.create({ email: 'o@example.com', role: 'USER' });
+    const plan = await db.monthly_plan.create({ choirId: choir.id, year: 2024, month: 1 });
 
     const baseReq = { activeChoirId: choir.id, userId: user.id };
     const res = {
@@ -19,8 +21,9 @@ const controller = require('../src/controllers/event.controller');
     };
 
     // First event should succeed
-    await controller.create({ ...baseReq, body: { date: '2024-01-01T10:00:00Z', type: 'SERVICE', pieceIds: [] } }, res);
+    await controller.create({ ...baseReq, body: { date: '2024-01-01T10:00:00Z', type: 'SERVICE', pieceIds: [], organistId: organist.id, monthlyPlanId: plan.id } }, res);
     assert.strictEqual(res.statusCode, 201);
+    assert.strictEqual(res.data.event.organistId, organist.id);
 
     // Same type on same day should be rejected
     await controller.create({ ...baseReq, body: { date: '2024-01-01T12:00:00Z', type: 'SERVICE', pieceIds: [] } }, res);

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -20,12 +20,13 @@ const db = require('../src/models');
     checkFields(db.user, ['email', 'role', 'lastDonation', 'preferences']);
     checkFields(db.choir, ['name']);
     checkFields(db.piece, ['title']);
-    checkFields(db.event, ['date', 'type']);
+    checkFields(db.event, ['date', 'type', 'organistId', 'finalized', 'version', 'monthlyPlanId']);
+    checkFields(db.monthly_plan, ['year', 'month', 'finalized', 'version']);
     checkFields(db.composer, ['name']);
     checkFields(db.category, ['name']);
     checkFields(db.collection, ['singleEdition']);
     checkFields(db.collection_piece, ['numberInCollection']);
-    checkFields(db.user_choir, ['roleInChoir', 'registrationStatus']);
+    checkFields(db.user_choir, ['roleInChoir', 'registrationStatus', 'isOrganist']);
     checkFields(db.piece_change, ['data']);
     checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
 
@@ -33,6 +34,7 @@ const db = require('../src/models');
     assert(db.user.associations.choirs, 'User should have choirs association');
     assert(db.piece.associations.composer, 'Piece should have composer association');
     assert(db.choir.associations.events, 'Choir should have events association');
+    assert(db.choir.associations.monthlyPlans, 'Choir should have monthlyPlans association');
 
     console.log('All model tests passed');
     await db.sequelize.close();

--- a/choir-app-backend/tests/monthlyPlan.controller.test.js
+++ b/choir-app-backend/tests/monthlyPlan.controller.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/monthlyPlan.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+    const choir = await db.choir.create({ name: 'Test Choir' });
+    const baseReq = { activeChoirId: choir.id };
+    const res = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+
+    await controller.create({ ...baseReq, body: { year: 2025, month: 7 } }, res);
+    assert.strictEqual(res.statusCode, 201);
+    const planId = res.data.id;
+
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 7 } }, res);
+    assert.strictEqual(res.statusCode, 200);
+
+    await controller.finalize({ ...baseReq, params: { id: planId } }, res);
+    assert.strictEqual(res.data.finalized, true);
+    const versionAfter = res.data.version;
+
+    await controller.reopen({ ...baseReq, params: { id: planId } }, res);
+    assert.strictEqual(res.data.finalized, false);
+    assert.strictEqual(res.data.version, versionAfter); // version should not change on reopen
+
+    console.log('monthlyPlan controller tests passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
 import { ManageChoirResolver } from '@features/choir-management/manage-choir-resolver';
 import { EventListComponent } from '@features/events/event-list/event-list.component';
+import { MonthlyPlanComponent } from '@features/monthly-plan/monthly-plan.component';
 import { InviteRegistrationComponent } from '@features/user/registration/invite-registration.component';
 import { StatisticsComponent } from '@features/home/stats/statistics.component';
 import { PasswordResetRequestComponent } from '@features/user/password-reset/password-reset-request.component';
@@ -95,6 +96,11 @@ export const routes: Routes = [
             {
                 path: 'events',
                 component: EventListComponent,
+                canActivate: [AuthGuard]
+            },
+            {
+                path: 'dienstplan',
+                component: MonthlyPlanComponent,
                 canActivate: [AuthGuard]
             },
             {

--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -8,6 +8,10 @@ export interface Event {
   createdAt: string;
   updatedAt: string;
   director?: { name: string };
+  organist?: { name: string } | null;
+  finalized?: boolean;
+  version?: number;
+  monthlyPlan?: { year: number; month: number; finalized: boolean; version: number } | null;
   pieces: Piece[];
 }
 

--- a/choir-app-frontend/src/app/core/models/monthly-plan.ts
+++ b/choir-app-frontend/src/app/core/models/monthly-plan.ts
@@ -1,0 +1,10 @@
+import { Event } from './event';
+
+export interface MonthlyPlan {
+  id: number;
+  year: number;
+  month: number;
+  finalized: boolean;
+  version: number;
+  events?: Event[];
+}

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -39,5 +39,6 @@ export interface UserInChoir extends User {
     membership?: { // Daten aus der Junction-Tabelle
         roleInChoir: 'director' | 'choir_admin';
         registrationStatus: 'REGISTERED' | 'PENDING';
+        isOrganist: boolean;
     }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -11,6 +11,7 @@ import { Category } from '../models/category';
 import { User, UserInChoir } from '../models/user';
 import { LoginAttempt } from '../models/login-attempt';
 import { CreateEventResponse, Event } from '../models/event';
+import { MonthlyPlan } from '../models/monthly-plan';
 import { Collection } from '../models/collection';
 import { LookupPiece } from '@core/models/lookup-piece';
 import { Author } from '@core/models/author';
@@ -259,6 +260,23 @@ export class ApiService {
     let params = new HttpParams().set('start', start).set('end', end);
     if (type) params = params.set('type', type);
     return this.http.delete(`${this.apiUrl}/events/range`, { params });
+  }
+
+  // --- Monthly Plan Methods ---
+  getMonthlyPlan(year: number, month: number): Observable<MonthlyPlan> {
+    return this.http.get<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${year}/${month}`);
+  }
+
+  createMonthlyPlan(year: number, month: number): Observable<MonthlyPlan> {
+    return this.http.post<MonthlyPlan>(`${this.apiUrl}/monthly-plans`, { year, month });
+  }
+
+  finalizeMonthlyPlan(id: number): Observable<MonthlyPlan> {
+    return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/finalize`, {});
+  }
+
+  reopenMonthlyPlan(id: number): Observable<MonthlyPlan> {
+    return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/reopen`, {});
   }
 
 

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -1,0 +1,31 @@
+<div class="plan" *ngIf="plan; else noPlan">
+  <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
+  <table mat-table [dataSource]="events" class="mat-elevation-z2">
+    <ng-container matColumnDef="date">
+      <th mat-header-cell *matHeaderCellDef>Datum</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef>Typ</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.type }}</td>
+    </ng-container>
+    <ng-container matColumnDef="director">
+      <th mat-header-cell *matHeaderCellDef>Chorleiter</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.director?.name }}</td>
+    </ng-container>
+    <ng-container matColumnDef="organist">
+      <th mat-header-cell *matHeaderCellDef>Organist</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.organist?.name }}</td>
+    </ng-container>
+    <ng-container matColumnDef="notes">
+      <th mat-header-cell *matHeaderCellDef>Notizen</th>
+      <td mat-cell *matCellDef="let ev">{{ ev.notes }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</div>
+<ng-template #noPlan>
+  <p>Kein Dienstplan für diesen Monat vorhanden.</p>
+  <button *ngIf="isChoirAdmin" mat-raised-button color="primary" (click)="createPlan()">Plan erstellen</button>
+</ng-template>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { MonthlyPlan } from '@core/models/monthly-plan';
+import { Event } from '@core/models/event';
+import { AuthService } from '@core/services/auth.service';
+
+@Component({
+  selector: 'app-monthly-plan',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './monthly-plan.component.html',
+  styleUrls: ['./monthly-plan.component.scss']
+})
+export class MonthlyPlanComponent implements OnInit {
+  plan: MonthlyPlan | null = null;
+  events: Event[] = [];
+  displayedColumns = ['date', 'type', 'director', 'organist', 'notes'];
+  isChoirAdmin = false;
+
+  constructor(private api: ApiService, private auth: AuthService) {}
+
+  ngOnInit(): void {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth() + 1;
+    this.loadPlan(year, month);
+    this.api.checkChoirAdminStatus().subscribe(r => this.isChoirAdmin = r.isChoirAdmin);
+  }
+
+  loadPlan(year: number, month: number): void {
+    this.api.getMonthlyPlan(year, month).subscribe({
+      next: plan => { this.plan = plan; this.events = plan.events || []; },
+      error: () => { this.plan = null; this.events = []; }
+    });
+  }
+
+  createPlan(): void {
+    const now = new Date();
+    this.api.createMonthlyPlan(now.getFullYear(), now.getMonth() + 1).subscribe(plan => {
+      this.plan = plan;
+      this.loadPlan(plan.year, plan.month);
+    });
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -143,6 +143,11 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
           visibleSubject: this.isLoggedIn$,
       },
       {
+        displayName: 'Dienstplan',
+        route: '/dienstplan',
+        visibleSubject: this.isLoggedIn$,
+      },
+      {
         displayName: 'Statistik',
         route: '/stats',
         visibleSubject: this.isLoggedIn$,


### PR DESCRIPTION
## Summary
- add backend route and controller method to fetch monthly plans
- expose `/api/monthly-plans` in the Express app
- implement Angular model and API methods for monthly plans
- add Dienstplan component and menu entry in the frontend

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686414d7d4808320ae2bdfe845a94b7e