### PR TITLE
Handle monthly plan 204 response

### DIFF
--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -16,7 +16,7 @@ exports.findByMonth = async (req, res) => {
                 ]
             }]
         });
-        if (!plan) return res.status(404).send({ message: 'Plan not found.' });
+        if (!plan) return res.status(204).send();
         res.status(200).send(plan);
     } catch (err) {
         res.status(500).send({ message: err.message || 'Could not fetch plan.' });

--- a/choir-app-backend/tests/monthlyPlan.controller.test.js
+++ b/choir-app-backend/tests/monthlyPlan.controller.test.js
@@ -20,6 +20,9 @@ const controller = require('../src/controllers/monthlyPlan.controller');
     await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 7 } }, res);
     assert.strictEqual(res.statusCode, 200);
 
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 8 } }, res);
+    assert.strictEqual(res.statusCode, 204);
+
     await controller.finalize({ ...baseReq, params: { id: planId } }, res);
     assert.strictEqual(res.data.finalized, true);
     const versionAfter = res.data.version;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -285,8 +285,8 @@ export class ApiService {
   }
 
   // --- Monthly Plan Methods ---
-  getMonthlyPlan(year: number, month: number): Observable<MonthlyPlan> {
-    return this.http.get<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${year}/${month}`);
+  getMonthlyPlan(year: number, month: number): Observable<MonthlyPlan | null> {
+    return this.http.get<MonthlyPlan | null>(`${this.apiUrl}/monthly-plans/${year}/${month}`);
   }
 
   createMonthlyPlan(year: number, month: number): Observable<MonthlyPlan> {

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -31,7 +31,7 @@ export class MonthlyPlanComponent implements OnInit {
 
   loadPlan(year: number, month: number): void {
     this.api.getMonthlyPlan(year, month).subscribe({
-      next: plan => { this.plan = plan; this.events = plan.events || []; },
+      next: plan => { this.plan = plan; this.events = plan?.events || []; },
       error: () => { this.plan = null; this.events = []; }
     });
   }


### PR DESCRIPTION
## Summary
- return HTTP 204 if monthly plan does not exist
- adjust frontend service and component to support null plan
- revert interceptor tweak
- extend backend tests

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864beb8c2b083209892d4ec61863fbb