### PR TITLE
Fix repertoire list pagination after sorting

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -81,7 +81,6 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     if (paginator) {
       this._paginator = paginator;
       this._paginator.pageSize = this.pageSize;
-      this.dataSource.paginator = this._paginator;
       this._paginator.page.subscribe(e => this.paginatorService.setPageSize('literature-list', e.pageSize));
     }
   }
@@ -147,7 +146,6 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.dataSource.paginator = this._paginator;
     this.dataSource.sort = this._sort;
 
     const sort$ = this._sort.sortChange.pipe(tap(() => this._paginator.pageIndex = 0));


### PR DESCRIPTION
## Summary
- avoid hooking Angular paginator into the data source

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6864bfe00c78832090ae0be8dd01a4b6