### PR TITLE
Add admin log viewer

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -317,3 +317,27 @@ exports.removeUserFromChoir = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+const logService = require('../services/log.service');
+
+exports.listLogs = async (req, res) => {
+    try {
+        const files = await logService.listLogFiles();
+        res.status(200).send(files);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.getLog = async (req, res) => {
+    const { filename } = req.params;
+    try {
+        const data = await logService.readLogFile(filename);
+        if (data === null) {
+            return res.status(404).send({ message: 'Log file not found' });
+        }
+        res.status(200).send(data);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -32,4 +32,8 @@ router.delete("/users/:id", controller.deleteUser);
 router.post("/users/:id/send-password-reset", controller.sendPasswordReset);
 router.get("/login-attempts", controller.getLoginAttempts);
 
+router.get('/logs', controller.listLogs);
+router.get('/logs/:filename', controller.getLog);
+
 module.exports = router;
+

--- a/choir-app-backend/src/services/log.service.js
+++ b/choir-app-backend/src/services/log.service.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_DIR = path.join(__dirname, '..', '..', 'logs');
+
+const logLineRegex = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[([^\]]+)\]: (.*)$/;
+
+function parseStandardLog(content) {
+    const lines = content.split(/\r?\n/);
+    const entries = [];
+    let current = null;
+    for (const line of lines) {
+        if (!line) continue;
+        const match = line.match(logLineRegex);
+        if (match) {
+            current = { timestamp: match[1], level: match[2], message: match[3] };
+            entries.push(current);
+        } else if (current) {
+            current.message += '\n' + line;
+        }
+    }
+    return entries;
+}
+
+function parseJsonLog(content) {
+    const lines = content.split(/\r?\n/).filter(Boolean);
+    return lines.map(l => {
+        try {
+            return JSON.parse(l);
+        } catch (err) {
+            return { raw: l };
+        }
+    });
+}
+
+async function listLogFiles() {
+    try {
+        const files = await fs.promises.readdir(LOG_DIR);
+        return files.filter(f => f.endsWith('.log'));
+    } catch {
+        return [];
+    }
+}
+
+async function readLogFile(filename) {
+    const safe = path.basename(filename);
+    const filePath = path.join(LOG_DIR, safe);
+    try {
+        const data = await fs.promises.readFile(filePath, 'utf8');
+        if (safe === 'exceptions.log' || safe === 'rejections.log') {
+            return parseJsonLog(data);
+        }
+        return parseStandardLog(data);
+    } catch (err) {
+        if (err.code === 'ENOENT') return null;
+        throw err;
+    }
+}
+
+module.exports = { listLogFiles, readLogFile };

--- a/choir-app-backend/tests/log.service.test.js
+++ b/choir-app-backend/tests/log.service.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const service = require('../src/services/log.service');
+
+(async () => {
+  try {
+    const logDir = path.join(__dirname, '..', 'logs');
+    await fs.promises.mkdir(logDir, { recursive: true });
+
+    const errorSample = `2025-07-01 08:00:00 [ERROR]: Something failed\n    at line`;
+    await fs.promises.writeFile(path.join(logDir, 'error.log'), errorSample);
+
+    const jsonSample = '{"date":"now","level":"error"}\n';
+    await fs.promises.writeFile(path.join(logDir, 'exceptions.log'), jsonSample);
+
+    const errorEntries = await service.readLogFile('error.log');
+    const jsonEntries = await service.readLogFile('exceptions.log');
+
+    if (!Array.isArray(errorEntries) || errorEntries.length !== 1) throw new Error('error log parse failed');
+    if (!Array.isArray(jsonEntries) || jsonEntries.length !== 1) throw new Error('json log parse failed');
+
+    console.log('log.service tests passed');
+    fs.rmSync(logDir, { recursive: true, force: true });
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import { ManageChoirsComponent } from '@features/admin/manage-choirs/manage-choi
 import { ManageUsersComponent } from '@features/admin/manage-users/manage-users.component';
 import { BackupComponent } from '@features/admin/backup/backup.component';
 import { LoginAttemptsComponent } from '@features/admin/login-attempts/login-attempts.component';
+import { LogViewerComponent } from '@features/admin/log-viewer/log-viewer.component';
 import { LoginGuard } from '@core/guards/login.guard';
 import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
@@ -138,6 +139,7 @@ export const routes: Routes = [
             { path: 'users', component: ManageUsersComponent },
             { path: 'backup', component: BackupComponent },
             { path: 'login-attempts', component: LoginAttemptsComponent },
+            { path: 'logs', component: LogViewerComponent },
         ],
     },
 

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -70,6 +70,14 @@ export class AdminService {
     return this.http.get<LoginAttempt[]>(`${this.apiUrl}/admin/login-attempts`);
   }
 
+  listLogs(): Observable<string[]> {
+    return this.http.get<string[]>(`${this.apiUrl}/admin/logs`);
+  }
+
+  getLog(filename: string): Observable<any[]> {
+    return this.http.get<any[]>(`${this.apiUrl}/admin/logs/${encodeURIComponent(filename)}`);
+  }
+
   downloadBackup(): Observable<Blob> {
     return this.http.get(`${this.apiUrl}/backup/export`, { responseType: 'blob' });
   }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -443,6 +443,14 @@ export class ApiService {
     return this.adminService.getLoginAttempts();
   }
 
+  listLogs(): Observable<string[]> {
+    return this.adminService.listLogs();
+  }
+
+  getLog(filename: string): Observable<any[]> {
+    return this.adminService.getLog(filename);
+  }
+
   downloadBackup(): Observable<Blob> {
     return this.adminService.downloadBackup();
   }

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
@@ -1,0 +1,32 @@
+<div class="controls">
+  <mat-form-field appearance="fill">
+    <mat-label>Log-Datei</mat-label>
+    <mat-select [(value)]="selected" (selectionChange)="loadLog()">
+      <mat-option *ngFor="let f of files" [value]="f">{{ f }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+  <button mat-button (click)="toggleSort()">Sortierung {{ descending ? '↓' : '↑' }}</button>
+</div>
+
+<div *ngFor="let group of groups">
+  <h3>{{ group.date }}</h3>
+  <table mat-table [dataSource]="group.items" class="mat-elevation-z8 log-table">
+    <ng-container matColumnDef="timestamp">
+      <th mat-header-cell *matHeaderCellDef>Zeit</th>
+      <td mat-cell *matCellDef="let row">{{ row.timestamp || (row.date | date:'short') }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="level">
+      <th mat-header-cell *matHeaderCellDef>Level</th>
+      <td mat-cell *matCellDef="let row">{{ row.level }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="message">
+      <th mat-header-cell *matHeaderCellDef>Nachricht</th>
+      <td mat-cell *matCellDef="let row"><pre>{{ row.message || row.stack || row.raw }}</pre></td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="['timestamp','level','message']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['timestamp','level','message']"></tr>
+  </table>
+</div>

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.scss
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.scss
@@ -1,0 +1,11 @@
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.log-table pre {
+  margin: 0;
+  white-space: pre-wrap;
+}

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.ts
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from 'src/app/core/services/api.service';
+
+interface LogGroup { date: string; items: any[]; }
+
+@Component({
+  selector: 'app-log-viewer',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './log-viewer.component.html',
+  styleUrls: ['./log-viewer.component.scss']
+})
+export class LogViewerComponent implements OnInit {
+  files: string[] = [];
+  selected = '';
+  entries: any[] = [];
+  groups: LogGroup[] = [];
+  descending = true;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.loadFiles();
+  }
+
+  loadFiles(): void {
+    this.api.listLogs().subscribe(f => this.files = f);
+  }
+
+  loadLog(): void {
+    if (!this.selected) return;
+    this.api.getLog(this.selected).subscribe(data => {
+      this.entries = data;
+      this.groupEntries();
+    });
+  }
+
+  toggleSort(): void {
+    this.descending = !this.descending;
+    this.groupEntries();
+  }
+
+  private groupEntries(): void {
+    const map = new Map<string, any[]>();
+    for (const e of this.entries) {
+      const ts: string = e.timestamp || e.date || '';
+      const day = ts.slice(0, 10);
+      if (!map.has(day)) map.set(day, []);
+      map.get(day)!.push(e);
+    }
+    const array: LogGroup[] = Array.from(map.entries()).map(([date, items]) => ({ date, items }));
+    array.sort((a,b) => this.descending ? (a.date < b.date ? 1 : -1) : (a.date > b.date ? 1 : -1));
+    this.groups = array;
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -199,6 +199,10 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
           {
             displayName: 'Login-Protokoll',
             route: '/admin/login-attempts',
+          },
+          {
+            displayName: 'Logs',
+            route: '/admin/logs',
           }
         ]
       }


### PR DESCRIPTION
## Summary
- add log viewer component with selectable logs
- expose log API functions in frontend services
- link log viewer from admin menu and routing

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6864d5e118388320a78afb6e250a308a