### PR TITLE
Add monthly plan editing with director/organist assignment

### DIFF
--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -11,8 +11,8 @@ exports.findByMonth = async (req, res) => {
                 as: 'events',
                 order: [['date', 'ASC']],
                 include: [
-                    { model: db.user, as: 'director', attributes: ['name'] },
-                    { model: db.user, as: 'organist', attributes: ['name'], required: false }
+                    { model: db.user, as: 'director', attributes: ['id', 'name'] },
+                    { model: db.user, as: 'organist', attributes: ['id', 'name'], required: false }
                 ]
             }]
         });

--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -7,8 +7,8 @@ export interface Event {
   notes?: string;
   createdAt: string;
   updatedAt: string;
-  director?: { name: string };
-  organist?: { name: string } | null;
+  director?: { id: number; name: string };
+  organist?: { id: number; name: string } | null;
   finalized?: boolean;
   version?: number;
   monthlyPlan?: { year: number; month: number; finalized: boolean; version: number } | null;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -272,7 +272,7 @@ export class ApiService {
     return this.eventService.getEventById(id);
   }
 
-  updateEvent(id: number, data: { date: string, type: string, notes?: string, pieceIds: number[] }): Observable<Event> {
+  updateEvent(id: number, data: { date: string, type: string, notes?: string, pieceIds?: number[]; directorId?: number; organistId?: number; finalized?: boolean; version?: number; monthlyPlanId?: number }): Observable<Event> {
     return this.eventService.updateEvent(id, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/event.service.ts
+++ b/choir-app-frontend/src/app/core/services/event.service.ts
@@ -30,7 +30,7 @@ export class EventService {
     return this.http.get<Event>(`${this.apiUrl}/events/${id}`);
   }
 
-  updateEvent(id: number, data: { date: string; type: string; notes?: string; pieceIds: number[] }): Observable<Event> {
+  updateEvent(id: number, data: { date: string; type: string; notes?: string; pieceIds?: number[]; directorId?: number; organistId?: number; finalized?: boolean; version?: number; monthlyPlanId?: number }): Observable<Event> {
     return this.http.put<Event>(`${this.apiUrl}/events/${id}`, data);
   }
 

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -1,3 +1,14 @@
+<div>
+  <mat-form-field appearance="fill">
+    <mat-label>Monat</mat-label>
+    <input matInput type="number" [(ngModel)]="selectedMonth" min="1" max="12" (change)="monthChanged()" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Jahr</mat-label>
+    <input matInput type="number" [(ngModel)]="selectedYear" (change)="monthChanged()" />
+  </mat-form-field>
+</div>
+
 <div class="plan" *ngIf="plan; else noPlan">
   <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
   <table mat-table [dataSource]="events" class="mat-elevation-z2">
@@ -11,11 +22,26 @@
     </ng-container>
     <ng-container matColumnDef="director">
       <th mat-header-cell *matHeaderCellDef>Chorleiter</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.director?.name }}</td>
+      <td mat-cell *matCellDef="let ev">
+        <ng-container *ngIf="isChoirAdmin && !plan?.finalized; else directorText">
+          <mat-select [value]="ev.director?.id" (selectionChange)="updateDirector(ev, $event.value)">
+            <mat-option *ngFor="let m of directors" [value]="m.id">{{ m.name }}</mat-option>
+          </mat-select>
+        </ng-container>
+        <ng-template #directorText>{{ ev.director?.name }}</ng-template>
+      </td>
     </ng-container>
     <ng-container matColumnDef="organist">
       <th mat-header-cell *matHeaderCellDef>Organist</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.organist?.name }}</td>
+      <td mat-cell *matCellDef="let ev">
+        <ng-container *ngIf="isChoirAdmin && !plan?.finalized; else organistText">
+          <mat-select [value]="ev.organist?.id || null" (selectionChange)="updateOrganist(ev, $event.value)">
+            <mat-option [value]="null">--</mat-option>
+            <mat-option *ngFor="let m of organists" [value]="m.id">{{ m.name }}</mat-option>
+          </mat-select>
+        </ng-container>
+        <ng-template #organistText>{{ ev.organist?.name }}</ng-template>
+      </td>
     </ng-container>
     <ng-container matColumnDef="notes">
       <th mat-header-cell *matHeaderCellDef>Notizen</th>
@@ -24,6 +50,7 @@
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
+  <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
 </div>
 <ng-template #noPlan>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -1,15 +1,17 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { MonthlyPlan } from '@core/models/monthly-plan';
 import { Event } from '@core/models/event';
+import { UserInChoir } from '@core/models/user';
 import { AuthService } from '@core/services/auth.service';
 
 @Component({
   selector: 'app-monthly-plan',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [CommonModule, FormsModule, MaterialModule],
   templateUrl: './monthly-plan.component.html',
   styleUrls: ['./monthly-plan.component.scss']
 })
@@ -18,15 +20,25 @@ export class MonthlyPlanComponent implements OnInit {
   events: Event[] = [];
   displayedColumns = ['date', 'type', 'director', 'organist', 'notes'];
   isChoirAdmin = false;
+  selectedYear!: number;
+  selectedMonth!: number;
+  members: UserInChoir[] = [];
+  directors: UserInChoir[] = [];
+  organists: UserInChoir[] = [];
 
   constructor(private api: ApiService, private auth: AuthService) {}
 
   ngOnInit(): void {
     const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
-    this.loadPlan(year, month);
+    this.selectedYear = now.getFullYear();
+    this.selectedMonth = now.getMonth() + 1;
+    this.loadPlan(this.selectedYear, this.selectedMonth);
     this.api.checkChoirAdminStatus().subscribe(r => this.isChoirAdmin = r.isChoirAdmin);
+    this.api.getChoirMembers().subscribe(m => {
+      this.members = m;
+      this.directors = m.filter(u => u.membership?.roleInChoir === 'director' || u.membership?.roleInChoir === 'choir_admin');
+      this.organists = m.filter(u => u.membership?.isOrganist);
+    });
   }
 
   loadPlan(year: number, month: number): void {
@@ -34,6 +46,28 @@ export class MonthlyPlanComponent implements OnInit {
       next: plan => { this.plan = plan; this.events = plan?.events || []; },
       error: () => { this.plan = null; this.events = []; }
     });
+  }
+
+  monthChanged(): void {
+    this.loadPlan(this.selectedYear, this.selectedMonth);
+  }
+
+  updateDirector(ev: Event, userId: number): void {
+    this.api.updateEvent(ev.id, { date: ev.date, type: ev.type, notes: ev.notes || '', directorId: userId, organistId: ev.organist?.id || undefined, finalized: ev.finalized, version: ev.version, monthlyPlanId: this.plan?.id }).subscribe(updated => {
+      ev.director = updated.director;
+    });
+  }
+
+  updateOrganist(ev: Event, userId: number | null): void {
+    this.api.updateEvent(ev.id, { date: ev.date, type: ev.type, notes: ev.notes || '', directorId: ev.director?.id, organistId: userId || undefined, finalized: ev.finalized, version: ev.version, monthlyPlanId: this.plan?.id }).subscribe(updated => {
+      ev.organist = updated.organist;
+    });
+  }
+
+  finalizePlan(): void {
+    if (this.plan) {
+      this.api.finalizeMonthlyPlan(this.plan.id).subscribe(p => this.plan = p);
+    }
   }
 
   createPlan(): void {


### PR DESCRIPTION
## Summary
- allow supplying directorId on event create/update
- expose director and organist ids in event responses
- include ids when fetching monthly plans
- extend frontend event model and API for director/organist editing
- implement basic monthly plan editor with member dropdowns and finalize button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e58a3cfc8320a2f6d217a8b607e8