### PR TITLE
Add collection management to choir page

### DIFF
--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -13,5 +13,7 @@ router.put("/", isChoirAdminOrAdmin, controller.updateMyChoir);
 router.get("/members", isChoirAdminOrAdmin, controller.getChoirMembers);
 router.post("/members", isChoirAdminOrAdmin, controller.inviteUserToChoir);
 router.delete("/members", isChoirAdminOrAdmin, controller.removeUserFromChoir);
+router.get("/collections", isChoirAdminOrAdmin, controller.getChoirCollections);
+router.delete("/collections/:id", isChoirAdminOrAdmin, controller.removeCollectionFromChoir);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -385,6 +385,14 @@ export class ApiService {
     return this.choirService.removeUserFromChoir(userId);
   }
 
+  getChoirCollections(): Observable<Collection[]> {
+    return this.choirService.getChoirCollections();
+  }
+
+  removeCollectionFromChoir(collectionId: number): Observable<any> {
+    return this.choirService.removeCollectionFromChoir(collectionId);
+  }
+
   // --- Admin Methods ---
 
   getAdminChoirs(): Observable<Choir[]> {

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { Choir } from '../models/choir';
 import { UserInChoir } from '../models/user';
+import { Collection } from '../models/collection';
 
 @Injectable({ providedIn: 'root' })
 export class ChoirService {
@@ -30,5 +31,13 @@ export class ChoirService {
   removeUserFromChoir(userId: number): Observable<any> {
     const options = { body: { userId } };
     return this.http.delete(`${this.apiUrl}/choir-management/members`, options);
+  }
+
+  getChoirCollections(): Observable<Collection[]> {
+    return this.http.get<Collection[]>(`${this.apiUrl}/choir-management/collections`);
+  }
+
+  removeCollectionFromChoir(collectionId: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/choir-management/collections/${collectionId}`);
   }
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -24,10 +24,12 @@ export class ManageChoirResolver implements Resolve<any> {
     return this.authService.isAdmin$.pipe(
       switchMap(isAdmin => {
         const choirDetails$ = this.apiService.getMyChoirDetails();
+        const collections$ = this.apiService.getChoirCollections();
         if (isAdmin) {
           return forkJoin({
             choirDetails: choirDetails$,
             members: this.apiService.getChoirMembers(),
+            collections: collections$,
             isChoirAdmin: of(true)
           });
         }
@@ -37,12 +39,14 @@ export class ManageChoirResolver implements Resolve<any> {
               return forkJoin({
                 choirDetails: choirDetails$,
                 members: this.apiService.getChoirMembers(),
+                collections: collections$,
                 isChoirAdmin: of(true)
               });
             } else {
               return forkJoin({
                 choirDetails: choirDetails$,
                 members: of([]),
+                collections: collections$,
                 isChoirAdmin: of(false)
               });
             }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -88,4 +88,39 @@
     </mat-card-content>
   </mat-card>
 
+  <mat-card class="table-card">
+    <mat-card-header>
+      <mat-card-title>Sammlungen im Chor</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="table-wrapper mat-elevation-z4">
+        <table mat-table [dataSource]="collectionDataSource">
+          <ng-container matColumnDef="title">
+            <th mat-header-cell *matHeaderCellDef> Titel </th>
+            <td mat-cell *matCellDef="let col">{{ col.title }}</td>
+          </ng-container>
+          <ng-container matColumnDef="publisher">
+            <th mat-header-cell *matHeaderCellDef> Verlag </th>
+            <td mat-cell *matCellDef="let col">{{ col.publisher || '-' }}</td>
+          </ng-container>
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let col" class="actions-cell">
+              <button *ngIf="isChoirAdmin" mat-icon-button color="warn" (click)="removeCollection(col)" matTooltip="Sammlung entfernen">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+          <tr mat-header-row *matHeaderRowDef="displayedCollectionColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedCollectionColumns;"></tr>
+          <tr class="mat-row" *matNoDataRow>
+            <td class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
+              Keine Sammlungen vorhanden.
+            </td>
+          </tr>
+        </table>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
 </div>


### PR DESCRIPTION
## Summary
- expose choir collection routes in backend
- implement API methods to fetch and remove choir collections
- show current collections on "Mein Chor" page
- allow choir admins to remove collections

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686515ebcfc883209e374138becabd11