### PR TITLE
Add collapsible cards to "Mein Chor"

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -3,10 +3,13 @@
 
   <!-- Card für die Chor-Details -->
   <mat-card class="form-card">
-    <mat-card-header>
+    <mat-card-header class="collapsible-header" (click)="toggleChoirInfo()">
       <mat-card-title>Chorinformationen</mat-card-title>
+      <button mat-icon-button (click)="$event.stopPropagation(); toggleChoirInfo()">
+        <mat-icon>{{ choirInfoExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </button>
     </mat-card-header>
-    <mat-card-content>
+    <mat-card-content *ngIf="choirInfoExpanded">
 
       <form [formGroup]="choirForm" (ngSubmit)="onSaveChoirDetails()">
         <mat-form-field appearance="outline">
@@ -32,14 +35,19 @@
 
   <!-- Card für die Mitglieder-Verwaltung -->
   <mat-card class="table-card" *ngIf="isChoirAdmin">
-    <mat-card-header>
+    <mat-card-header class="collapsible-header" (click)="toggleMembers()">
       <mat-card-title>Chorleiter</mat-card-title>
-      <button mat-flat-button color="accent" (click)="openInviteDialog()">
-        <mat-icon>add</mat-icon>
-        <span>Neues Mitglied einladen</span>
-      </button>
+      <span class="header-controls">
+        <button mat-flat-button color="accent" (click)="openInviteDialog(); $event.stopPropagation()">
+          <mat-icon>add</mat-icon>
+          <span>Neues Mitglied einladen</span>
+        </button>
+        <button mat-icon-button (click)="$event.stopPropagation(); toggleMembers()">
+          <mat-icon>{{ membersExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+        </button>
+      </span>
     </mat-card-header>
-    <mat-card-content>
+    <mat-card-content *ngIf="membersExpanded">
       <div class="table-wrapper mat-elevation-z4">
         <table mat-table [dataSource]="dataSource">
           <!-- Name Column -->

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
@@ -17,6 +17,16 @@ mat-card-header {
   width: 100%;
 }
 
+.collapsible-header {
+  cursor: pointer;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 mat-card-content form {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -27,6 +27,9 @@ export class ManageChoirComponent implements OnInit {
 
   isChoirAdmin = false;
 
+  choirInfoExpanded = true;
+  membersExpanded = true;
+
   // Für die Mitglieder-Tabelle
   displayedColumns: string[] = ['name', 'email', 'role', 'status', 'actions'];
   dataSource = new MatTableDataSource<UserInChoir>();
@@ -68,6 +71,14 @@ export class ManageChoirComponent implements OnInit {
           this.dataSource.data = members;
       });
     }
+  }
+
+  toggleChoirInfo(): void {
+    this.choirInfoExpanded = !this.choirInfoExpanded;
+  }
+
+  toggleMembers(): void {
+    this.membersExpanded = !this.membersExpanded;
   }
 
   onSaveChoirDetails(): void {


### PR DESCRIPTION
## Summary
- allow collapsing choir detail and member management cards
- add toggle logic and styling

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651637332c83208fbebfd537ef4c1e