### PR TITLE
Add module toggle for Dienstplan

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -40,7 +40,7 @@ exports.getMyChoirDetails = async (req, res, next) => {
 
 // Details des aktiven Chors aktualisieren
 exports.updateMyChoir = async (req, res, next) => {
-    const { name, description, location } = req.body;
+    const { name, description, location, modules } = req.body;
 
     try {
         const choir = await db.choir.findByPk(req.activeChoirId);
@@ -54,8 +54,14 @@ exports.updateMyChoir = async (req, res, next) => {
         }
 
         // Führen Sie das Update durch. `update` gibt ein Array mit der Anzahl der betroffenen Zeilen zurück.
+        const updateData = {};
+        if (name !== undefined) updateData.name = name;
+        if (description !== undefined) updateData.description = description;
+        if (location !== undefined) updateData.location = location;
+        if (modules !== undefined) updateData.modules = modules;
+
         const [numberOfAffectedRows] = await db.choir.update(
-            { name, description, location },
+            updateData,
             { where: { id: req.activeChoirId } }
         );
 

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -6,4 +6,7 @@ export interface Choir {
     memberCount?: number;
     eventCount?: number;
     pieceCount?: number;
+    modules?: {
+        dienstplan?: boolean;
+    };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -353,7 +353,7 @@ export class ApiService {
     return this.choirService.getMyChoirDetails();
   }
 
-  updateMyChoir(choirData: { name: string, description: string, location: string }): Observable<any> {
+  updateMyChoir(choirData: Partial<Choir>): Observable<any> {
     return this.choirService.updateMyChoir(choirData);
   }
 

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -15,7 +15,7 @@ export class ChoirService {
     return this.http.get<Choir>(`${this.apiUrl}/choir-management`);
   }
 
-  updateMyChoir(choirData: { name: string; description: string; location: string }): Observable<any> {
+  updateMyChoir(choirData: Partial<Choir>): Observable<any> {
     return this.http.put(`${this.apiUrl}/choir-management`, choirData);
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -30,6 +30,18 @@
     </mat-card-content>
   </mat-card>
 
+  <!-- Einstellungen Card -->
+  <mat-card class="form-card" *ngIf="isChoirAdmin">
+    <mat-card-header>
+      <mat-card-title>Einstellungen</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <mat-checkbox [(ngModel)]="dienstplanEnabled" (change)="onToggleDienstplan()">
+        Dienstplan anzeigen
+      </mat-checkbox>
+    </mat-card-content>
+  </mat-card>
+
   <!-- Card für die Mitglieder-Verwaltung -->
   <mat-card class="table-card" *ngIf="isChoirAdmin">
     <mat-card-header>


### PR DESCRIPTION
## Summary
- extend Choir model with `modules` flag
- allow backend to update modules on choir
- implement settings card in "Mein Chor" to enable Dienstplan
- update services to send partial choir data
- hide/show Dienstplan menu entry based on module state

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651683b4ac8320bf37f20d4297a531