### PR TITLE
Combine admin logs into a unified protocols view

### DIFF
--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -17,8 +17,7 @@ import { ManageAuthorsComponent } from '@features/admin/manage-authors/manage-au
 import { ManageChoirsComponent } from '@features/admin/manage-choirs/manage-choirs.component';
 import { ManageUsersComponent } from '@features/admin/manage-users/manage-users.component';
 import { BackupComponent } from '@features/admin/backup/backup.component';
-import { LoginAttemptsComponent } from '@features/admin/login-attempts/login-attempts.component';
-import { LogViewerComponent } from '@features/admin/log-viewer/log-viewer.component';
+import { ProtocolsComponent } from '@features/admin/protocols/protocols.component';
 import { MailSettingsComponent } from '@features/admin/mail-settings/mail-settings.component';
 import { LoginGuard } from '@core/guards/login.guard';
 import { HomeComponent } from '@features/home/home.component';
@@ -139,8 +138,7 @@ export const routes: Routes = [
             { path: 'choirs', component: ManageChoirsComponent },
             { path: 'users', component: ManageUsersComponent },
             { path: 'backup', component: BackupComponent },
-            { path: 'login-attempts', component: LoginAttemptsComponent },
-            { path: 'logs', component: LogViewerComponent },
+            { path: 'protocols', component: ProtocolsComponent },
             { path: 'mail-settings', component: MailSettingsComponent },
         ],
     },

--- a/choir-app-frontend/src/app/features/admin/protocols/protocols.component.html
+++ b/choir-app-frontend/src/app/features/admin/protocols/protocols.component.html
@@ -1,0 +1,8 @@
+<mat-tab-group>
+  <mat-tab label="Login">
+    <app-login-attempts></app-login-attempts>
+  </mat-tab>
+  <mat-tab label="Logs">
+    <app-log-viewer></app-log-viewer>
+  </mat-tab>
+</mat-tab-group>

--- a/choir-app-frontend/src/app/features/admin/protocols/protocols.component.scss
+++ b/choir-app-frontend/src/app/features/admin/protocols/protocols.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+  padding: 16px;
+}
+
+mat-tab-group {
+  width: 100%;
+}

--- a/choir-app-frontend/src/app/features/admin/protocols/protocols.component.ts
+++ b/choir-app-frontend/src/app/features/admin/protocols/protocols.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { LoginAttemptsComponent } from '../login-attempts/login-attempts.component';
+import { LogViewerComponent } from '../log-viewer/log-viewer.component';
+
+@Component({
+  selector: 'app-protocols',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, LoginAttemptsComponent, LogViewerComponent],
+  templateUrl: './protocols.component.html',
+  styleUrls: ['./protocols.component.scss']
+})
+export class ProtocolsComponent {}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -217,12 +217,8 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
             route: '/admin/backup',
           },
           {
-            displayName: 'Login-Protokoll',
-            route: '/admin/login-attempts',
-          },
-          {
-            displayName: 'Logs',
-            route: '/admin/logs',
+            displayName: 'Protokolle',
+            route: '/admin/protocols',
           },
           {
             displayName: 'Mail-Server',


### PR DESCRIPTION
## Summary
- add `ProtocolsComponent` with tabs for login attempts and log viewer
- route `/admin/protocols` to the new component and update navigation
- replace old menu entries "Login-Protokoll" and "Logs" with single "Protokolle"

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651b382f008320a55017a29e84bed9