### PR TITLE
Add notation preview on hover

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -164,7 +164,10 @@
 
             <!-- Define the header and data rows -->
             <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+                (mouseenter)="onRowMouseEnter($event, row)"
+                (mousemove)="onRowMouseMove($event)"
+                (mouseleave)="onRowMouseLeave()"></tr>
 
             <!-- Row shown when there is no matching data. -->
             <tr class="mat-row" *matNoDataRow>
@@ -182,6 +185,10 @@
                        showFirstLastButtons>
         </mat-paginator>
       </div>
+    </div>
+    <div class="hover-image" *ngIf="hoverImage"
+         [style.top.px]="hoverY + 10" [style.left.px]="hoverX + 10">
+      <img [src]="hoverImage" alt="Notenbild" />
     </div>
   </mat-drawer-content>
 </mat-drawer-container>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -128,3 +128,20 @@ table-container {
         border-color: #555;
     }
 }
+
+.hover-image {
+  position: fixed;
+  z-index: 1000;
+  pointer-events: none;
+  max-width: 200px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: white;
+  padding: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+.hover-image img {
+  display: block;
+  max-width: 100%;
+  max-height: 200px;
+}

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -67,6 +67,13 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   isChoirAdmin = false;
   isAdmin = false;
 
+  // --- Hover Image Preview ---
+  hoverImage: string | null = null;
+  hoverX = 0;
+  hoverY = 0;
+  private hoverTimeout: any;
+  private imageCache = new Map<number, string>();
+
   // --- Bulletproof @ViewChild Setters ---
   private _sort!: MatSort;
   @ViewChild(MatSort) set sort(sort: MatSort) {
@@ -481,6 +488,36 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         this.loadPresets();
       });
     }
+  }
+
+  // ------- Hover Image Helpers -------
+  onRowMouseEnter(event: MouseEvent, piece: Piece): void {
+    if (!piece.imageIdentifier) {
+      return;
+    }
+    this.hoverX = event.clientX;
+    this.hoverY = event.clientY;
+    this.hoverTimeout = setTimeout(() => {
+      const cached = this.imageCache.get(piece.id);
+      if (cached !== undefined) {
+        this.hoverImage = cached;
+        return;
+      }
+      this.apiService.getPieceImage(piece.id).subscribe(img => {
+        this.imageCache.set(piece.id, img);
+        this.hoverImage = img;
+      });
+    }, 2000);
+  }
+
+  onRowMouseMove(event: MouseEvent): void {
+    this.hoverX = event.clientX;
+    this.hoverY = event.clientY;
+  }
+
+  onRowMouseLeave(): void {
+    clearTimeout(this.hoverTimeout);
+    this.hoverImage = null;
   }
 
   private updateDisplayedColumns(): void {


### PR DESCRIPTION
## Summary
- show notation image preview if cursor rests on a piece for 2 seconds
- style floating preview panel

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a396ae288320bbb7a0cfa0010af8