### PR TITLE
Add event management to monthly plan

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -261,7 +261,7 @@ export class ApiService {
    * Creates a new event (service or rehearsal) for the current choir.
    * @param eventData - The details of the event, including the IDs of the pieces performed.
    */
-  createEvent(eventData: { date: string, type: string, notes?: string, pieceIds: number[] }): Observable<CreateEventResponse> {
+  createEvent(eventData: { date: string, type: string, notes?: string, pieceIds?: number[], directorId?: number, organistId?: number, finalized?: boolean, version?: number, monthlyPlanId?: number }): Observable<CreateEventResponse> {
     return this.eventService.createEvent(eventData);
   }
 

--- a/choir-app-frontend/src/app/core/services/event.service.ts
+++ b/choir-app-frontend/src/app/core/services/event.service.ts
@@ -16,7 +16,7 @@ export class EventService {
     });
   }
 
-  createEvent(eventData: { date: string; type: string; notes?: string; pieceIds: number[] }): Observable<CreateEventResponse> {
+  createEvent(eventData: { date: string; type: string; notes?: string; pieceIds?: number[]; directorId?: number; organistId?: number; finalized?: boolean; version?: number; monthlyPlanId?: number }): Observable<CreateEventResponse> {
     return this.http.post<CreateEventResponse>(`${this.apiUrl}/events`, eventData);
   }
 

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -47,10 +47,21 @@
       <th mat-header-cell *matHeaderCellDef>Notizen</th>
       <td mat-cell *matCellDef="let ev">{{ ev.notes }}</td>
     </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let ev">
+        <button mat-icon-button color="warn" *ngIf="isChoirAdmin && !plan?.finalized" (click)="deleteEvent(ev)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
-  <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
+  <div class="actions">
+    <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEventDialog()">Event hinzufügen</button>
+    <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
+  </div>
 </div>
 <ng-template #noPlan>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -1,0 +1,6 @@
+
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+}


### PR DESCRIPTION
## Summary
- extend event creation API payload to allow optional monthly plan linking
- expose extended payload via `ApiService`
- allow choir admins to add and remove events within the monthly plan

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866036f5a8c8320bcbbe1fff2bd0c5a