### PR TITLE
Fix piece image field layout

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -109,7 +109,7 @@
             <mat-divider></mat-divider>
             <div class="form-section">
               <h4>Notenbild</h4>
-              <div class="image-upload">
+              <div class="image-upload full-width">
                 <div
                   class="dropzone"
                   [class.dragover]="isDragOver"


### PR DESCRIPTION
## Summary
- adjust piece dialog to use full dialog width for image upload

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686619afdd708320ae906008bc60e2f1