### PR TITLE
Adjust header controls layout

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -41,7 +41,14 @@
   </mat-drawer>
   <mat-drawer-content>
     <div class="page">
-      <div class="header-container">
+      <div class="page-header">
+        <h1>Chorrepertoire</h1>
+        <button mat-flat-button color="primary" (click)="openAddPieceDialog()">
+          <mat-icon>add</mat-icon>
+          <span>Stück hinzufügen</span>
+        </button>
+      </div>
+      <div class="filter-bar">
         <button mat-icon-button (click)="drawer.toggle()" aria-label="Filter ein-/ausblenden">
           <mat-icon>filter_list</mat-icon>
         </button>
@@ -77,11 +84,6 @@
             <span>Anzahl geprobt</span>
           </button>
         </mat-menu>
-        <h1>Chorrepertoire</h1>
-        <button mat-flat-button color="primary" (click)="openAddPieceDialog()">
-          <mat-icon>add</mat-icon>
-          <span>Stück hinzufügen</span>
-        </button>
       </div>
 
       <div class="table-wrapper mat-elevation-z8">

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -19,11 +19,21 @@
 }
 
 // Header der Seite (Titel und Button)
-.list-page-header {
+.page-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  // Dieser Bereich hat eine feste Höhe und wächst nicht.
+  margin-bottom: 0.5rem;
+  flex-shrink: 0;
+}
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background-color: rgba(0, 0, 0, 0.04);
+  margin-bottom: 0.5rem;
   flex-shrink: 0;
 }
 
@@ -48,6 +58,8 @@
 .preset-select {
   width: 200px;
   margin: 0 1rem;
+  background-color: rgba(0, 0, 0, 0.04);
+  height: 100%;
 }
 
 .filter-panel {


### PR DESCRIPTION
## Summary
- place page heading separate from filter bar
- add filter bar above the repertoire table
- style new filter bar and preset select

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661a3cb51c83208f404710f2e9c514