### PR TITLE
Add reopen monthly plan action

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -61,6 +61,7 @@
   <div class="actions">
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEventDialog()">Event hinzufügen</button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
+    <button *ngIf="isChoirAdmin && plan.finalized" mat-raised-button color="primary" (click)="reopenPlan()">Plan erneut öffnen</button>
   </div>
 </div>
 <ng-template #noPlan>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -82,6 +82,12 @@ export class MonthlyPlanComponent implements OnInit {
     }
   }
 
+  reopenPlan(): void {
+    if (this.plan) {
+      this.api.reopenMonthlyPlan(this.plan.id).subscribe(p => { this.plan = p; this.updateDisplayedColumns(); });
+    }
+  }
+
   openAddEventDialog(): void {
     const dialogRef = this.dialog.open(EventDialogComponent, { width: '600px', disableClose: true });
     dialogRef.afterClosed().subscribe(result => {


### PR DESCRIPTION
## Summary
- implement reopen monthly plan on the frontend
- display a button to reopen a finalized plan

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675a1d81c8832099852dfc6429f773