### PR TITLE
Add lyrics source option for pieces

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -20,7 +20,7 @@ exports.create = async (req, res) => {
     }
      const {
         title, composerId, categoryId, voicing,
-        key, timeSignature, lyrics, imageIdentifier, license, opus,
+        key, timeSignature, lyrics, imageIdentifier, license, opus, lyricsSource,
         authorName, authorId,
         arrangerIds, // e.g., [12, 15]
         links        // e.g., [{ description: 'YouTube', url: '...' }]
@@ -39,7 +39,9 @@ exports.create = async (req, res) => {
 
         const newPiece = await db.piece.create({
             title, composerId, categoryId, voicing, key, timeSignature,
-            lyrics, imageIdentifier, license, opus, authorId: resolvedAuthorId
+            lyrics, imageIdentifier, license, opus,
+            lyricsSource,
+            authorId: resolvedAuthorId
         });
 
         if (arrangerIds && arrangerIds.length > 0) {

--- a/choir-app-backend/src/models/piece.model.js
+++ b/choir-app-backend/src/models/piece.model.js
@@ -31,6 +31,10 @@ module.exports = (sequelize, DataTypes) => {
         opus: { // Opus- / Verzeichniszahl
             type: DataTypes.STRING,
             allowNull: true
+        },
+        lyricsSource: { // Sonstige Quelle für den Text
+            type: DataTypes.STRING,
+            allowNull: true
         }
     });
     return Piece;

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -30,6 +30,7 @@ export interface Piece {
   imageIdentifier?: string;
   license?: string;
   opus?: string;
+  lyricsSource?: string;
   author?: Author;
   arrangers?: Composer[];
   links?: PieceLink[];

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.ts
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.ts
@@ -32,7 +32,9 @@ export class EventCardComponent {
     if (!piece) {
       return '';
     }
-    return piece.composer?.name || '';
+    const composer = piece.composer?.name || '';
+    const author = piece.author?.name || piece.lyricsSource || '';
+    return author ? `${composer} - ${author}` : composer;
   }
 
   getPieceReference(piece: Piece): string {

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -1,6 +1,7 @@
 <div class="piece-detail" *ngIf="piece">
   <h2>{{ piece.title }}</h2>
   <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
+  <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
   <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>
 

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -86,6 +86,11 @@
                 </mat-select>
               </mat-form-field>
 
+              <mat-form-field appearance="outline">
+                <mat-label>Sonstige Quelle</mat-label>
+                <input matInput formControlName="lyricsSource" placeholder="z.B. Joh 3,16" />
+              </mat-form-field>
+
               <mat-form-field appearance="outline" class="lyrics-field">
                 <mat-label>Text</mat-label>
                 <textarea matInput formControlName="lyrics"></textarea>

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -6,6 +6,9 @@ import {
     FormGroup,
     Validators,
     FormArray,
+    ValidatorFn,
+    AbstractControl,
+    ValidationErrors
 } from '@angular/forms';
 import {
     MAT_DIALOG_DATA,
@@ -24,6 +27,14 @@ import { Author } from '@core/models/author';
 import { Piece } from '@core/models/piece';
 import { AuthService } from '@core/services/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+
+export function authorOrSourceValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+        const authorId = control.get('authorId')?.value;
+        const source = control.get('lyricsSource')?.value;
+        return !authorId && !source ? { authorOrSourceRequired: true } : null;
+    };
+}
 
 @Component({
     selector: 'app-piece-dialog',
@@ -72,15 +83,16 @@ export class PieceDialogComponent implements OnInit {
             title: ['', Validators.required],
             voicing: [''],
             lyrics: [''],
+            lyricsSource: [''],
             links: this.fb.array([]),
             opus: [''],
             key: [''],
             timeSignature: [''],
             license: [''],
             composerId: [null, Validators.required],
-            authorId: [null, Validators.required],
+            authorId: [null],
             categoryId: [null],
-        });
+        }, { validators: authorOrSourceValidator() });
     }
 
     ngOnInit(): void {
@@ -259,6 +271,7 @@ export class PieceDialogComponent implements OnInit {
             categoryId: piece.category?.id,
             arrangerIds: piece.arrangers?.map((a) => a.id) || [],
             lyrics: piece.lyrics,
+            lyricsSource: piece.lyricsSource,
         });
 
         if (piece.imageIdentifier) {


### PR DESCRIPTION
## Summary
- allow storing a `lyricsSource` for a piece
- keep piece form valid when either author or source is provided
- show the source in details and event views when no author exists

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*
- `npm test` in frontend *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867596967408320a37e25ba496bb05f