### PR TITLE
Add organist flag for members

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -79,7 +79,7 @@ exports.create = async (req, res) => {
             type: type,
             notes: notes,
             choirId: choirId,
-            directorId: directorId || creatorId,
+            directorId: directorId !== undefined ? directorId : creatorId,
             organistId: organistId || null,
             finalized: finalized || false,
             version: version || 1,
@@ -272,7 +272,7 @@ exports.update = async (req, res) => {
             return res.status(200).send(full);
         }
 
-        await event.update({ date, type, notes, directorId: directorId || req.userId, organistId, finalized, version, monthlyPlanId });
+        await event.update({ date, type, notes, directorId: directorId !== undefined ? directorId : req.userId, organistId, finalized, version, monthlyPlanId });
 
         if (Array.isArray(pieceIds)) {
             await event.setPieces(pieceIds);

--- a/choir-app-backend/src/controllers/invitation.controller.js
+++ b/choir-app-backend/src/controllers/invitation.controller.js
@@ -31,7 +31,7 @@ exports.getInvitation = async (req, res) => {
 
 exports.completeRegistration = async (req, res) => {
   const token = req.params.token;
-  const { name, password } = req.body;
+  const { name, password, isOrganist } = req.body;
   if (!name || !password) {
     return res.status(400).send({ message: 'Name and password are required.' });
   }
@@ -41,7 +41,7 @@ exports.completeRegistration = async (req, res) => {
       return res.status(404).send({ message: 'Invitation not found or expired.' });
     }
     await db.user.update({ name, password: bcrypt.hashSync(password, 8) }, { where: { id: entry.user.id } });
-    await entry.update({ registrationStatus: 'REGISTERED', inviteToken: null, inviteExpiry: null });
+    await entry.update({ registrationStatus: 'REGISTERED', inviteToken: null, inviteExpiry: null, isOrganist: !!isOrganist });
     res.status(200).send({ message: 'Registration completed.' });
   } catch (err) {
     res.status(500).send({ message: err.message });

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -378,7 +378,7 @@ export class ApiService {
     return this.userService.resetPassword(token, password);
   }
 
-  completeRegistration(token: string, data: { name: string; password: string }): Observable<any> {
+  completeRegistration(token: string, data: { name: string; password: string; isOrganist?: boolean }): Observable<any> {
     return this.userService.completeRegistration(token, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -30,7 +30,7 @@ export class UserService {
     return this.http.post(`${this.apiUrl}/password-reset/reset/${token}`, { password });
   }
 
-  completeRegistration(token: string, data: { name: string; password: string }): Observable<any> {
+  completeRegistration(token: string, data: { name: string; password: string; isOrganist?: boolean }): Observable<any> {
     return this.http.post(`${this.apiUrl}/invitations/${token}`, data);
   }
 

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -24,7 +24,8 @@
       <th mat-header-cell *matHeaderCellDef>Chorleiter</th>
       <td mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan?.finalized; else directorText">
-          <mat-select [value]="ev.director?.id" (selectionChange)="updateDirector(ev, $event.value)">
+          <mat-select [value]="ev.director?.id || null" (selectionChange)="updateDirector(ev, $event.value)">
+            <mat-option [value]="null">--</mat-option>
             <mat-option *ngFor="let m of directors" [value]="m.id">{{ m.name }}</mat-option>
           </mat-select>
         </ng-container>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -64,14 +64,14 @@ export class MonthlyPlanComponent implements OnInit {
     this.loadPlan(this.selectedYear, this.selectedMonth);
   }
 
-  updateDirector(ev: Event, userId: number): void {
+  updateDirector(ev: Event, userId: number | null): void {
     this.api.updateEvent(ev.id, { date: ev.date, type: ev.type, notes: ev.notes || '', directorId: userId, organistId: ev.organist?.id || undefined, finalized: ev.finalized, version: ev.version, monthlyPlanId: this.plan?.id }).subscribe(updated => {
       ev.director = updated.director;
     });
   }
 
   updateOrganist(ev: Event, userId: number | null): void {
-    this.api.updateEvent(ev.id, { date: ev.date, type: ev.type, notes: ev.notes || '', directorId: ev.director?.id, organistId: userId || undefined, finalized: ev.finalized, version: ev.version, monthlyPlanId: this.plan?.id }).subscribe(updated => {
+    this.api.updateEvent(ev.id, { date: ev.date, type: ev.type, notes: ev.notes || '', directorId: ev.director?.id, organistId: userId, finalized: ev.finalized, version: ev.version, monthlyPlanId: this.plan?.id }).subscribe(updated => {
       ev.organist = updated.organist;
     });
   }

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.html
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.html
@@ -9,5 +9,6 @@
     <mat-label>Passwort</mat-label>
     <input matInput type="password" formControlName="password">
   </mat-form-field>
+  <mat-checkbox formControlName="isOrganist">Ich bin Organist</mat-checkbox>
   <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid">Registrieren</button>
 </form>

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.spec.ts
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.spec.ts
@@ -52,11 +52,11 @@ describe('InviteRegistrationComponent', () => {
     spyOn(router, 'navigate');
 
     component.token = 'abc';
-    component.form.setValue({ name: 'Test', password: 'secret' });
+    component.form.setValue({ name: 'Test', password: 'secret', isOrganist: false });
 
     component.submit();
 
-    expect(api.completeRegistration).toHaveBeenCalledWith('abc', { name: 'Test', password: 'secret' });
+    expect(api.completeRegistration).toHaveBeenCalledWith('abc', { name: 'Test', password: 'secret', isOrganist: false });
     expect(router.navigate).toHaveBeenCalledWith(['/login']);
   });
 });

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.ts
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.ts
@@ -22,7 +22,8 @@ export class InviteRegistrationComponent implements OnInit {
   constructor(private route: ActivatedRoute, private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar, private router: Router) {
     this.form = this.fb.group({
       name: ['', Validators.required],
-      password: ['', Validators.required]
+      password: ['', Validators.required],
+      isOrganist: [false]
     });
   }
 
@@ -36,7 +37,8 @@ export class InviteRegistrationComponent implements OnInit {
 
   submit(): void {
     if (this.form.invalid) return;
-    this.api.completeRegistration(this.token, this.form.value).subscribe({
+    const payload = this.form.value;
+    this.api.completeRegistration(this.token, payload).subscribe({
       next: () => {
         this.snack.open('Registrierung abgeschlossen. Du kannst dich jetzt anmelden.', 'OK');
         this.router.navigate(['/login']);


### PR DESCRIPTION
## Summary
- let invitation completion mark a member as organist
- expose organist flag in choir management controllers
- allow clearing the director field in the monthly plan
- add organist field to invite registration form

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677c3a123c8320a7ab11f6897d2cbb