### PR TITLE
Highlight user's events in schedule

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -56,7 +56,8 @@
       </td>
     </ng-container>
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+        [class.assigned]="plan?.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></tr>
   </table>
   <div class="actions">
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEventDialog()">Event hinzufügen</button>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -4,3 +4,7 @@
   display: flex;
   gap: 1rem;
 }
+
+.assigned td {
+  font-weight: 600;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
@@ -9,6 +9,7 @@ import { MonthlyPlan } from '@core/models/monthly-plan';
 import { Event } from '@core/models/event';
 import { UserInChoir } from '@core/models/user';
 import { AuthService } from '@core/services/auth.service';
+import { Subscription } from 'rxjs';
 import { EventDialogComponent } from '../events/event-dialog/event-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 
@@ -19,7 +20,7 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/co
   templateUrl: './monthly-plan.component.html',
   styleUrls: ['./monthly-plan.component.scss']
 })
-export class MonthlyPlanComponent implements OnInit {
+export class MonthlyPlanComponent implements OnInit, OnDestroy {
   plan: MonthlyPlan | null = null;
   events: Event[] = [];
   displayedColumns = ['date', 'type', 'director', 'organist', 'notes'];
@@ -29,6 +30,8 @@ export class MonthlyPlanComponent implements OnInit {
   members: UserInChoir[] = [];
   directors: UserInChoir[] = [];
   organists: UserInChoir[] = [];
+  currentUserId: number | null = null;
+  private userSub?: Subscription;
 
   private updateDisplayedColumns(): void {
     const base = ['date', 'type', 'director', 'organist', 'notes'];
@@ -45,6 +48,7 @@ export class MonthlyPlanComponent implements OnInit {
     this.selectedYear = now.getFullYear();
     this.selectedMonth = now.getMonth() + 1;
     this.loadPlan(this.selectedYear, this.selectedMonth);
+    this.userSub = this.auth.currentUser$.subscribe(u => this.currentUserId = u?.id || null);
     this.api.checkChoirAdminStatus().subscribe(r => { this.isChoirAdmin = r.isChoirAdmin; this.updateDisplayedColumns(); });
     this.api.getChoirMembers().subscribe(m => {
       this.members = m;
@@ -119,5 +123,9 @@ export class MonthlyPlanComponent implements OnInit {
       this.plan = plan;
       this.loadPlan(plan.year, plan.month);
     });
+  }
+
+  ngOnDestroy(): void {
+    if (this.userSub) this.userSub.unsubscribe();
   }
 }


### PR DESCRIPTION
## Summary
- highlight rows assigned to the current user in finalized monthly plans

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68677c6f51208320a456445c8213d76e