### PR TITLE
Fix missing Event type import

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -7,6 +7,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { ApiService } from '@core/services/api.service';
 import { MonthlyPlan } from '@core/models/monthly-plan';
 import { PlanEntry } from '@core/models/plan-entry';
+import { Event } from '@core/models/event';
 import { UserInChoir } from '@core/models/user';
 import { AuthService } from '@core/services/auth.service';
 import { Subscription } from 'rxjs';


### PR DESCRIPTION
## Summary
- resolve TypeScript compile errors in monthly plan component by importing Event model

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fe78b9ac832085ca97945af3e226