### PR TITLE
Add organist management

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -198,6 +198,39 @@ exports.removeUserFromChoir = async (req, res, next) => {
     }
 };
 
+// Mitgliedsdaten aktualisieren (z.B. Organistenstatus)
+exports.updateMember = async (req, res, next) => {
+    const { userId } = req.params;
+    const { isOrganist, roleInChoir } = req.body;
+    const choirId = req.activeChoirId;
+
+    if (req.userRole === 'demo') {
+        return res.status(403).send({ message: 'Demo user cannot manage members.' });
+    }
+
+    try {
+        const association = await db.user_choir.findOne({ where: { userId, choirId } });
+        if (!association) return res.status(404).send({ message: 'User is not a member of this choir.' });
+
+        if (roleInChoir && association.roleInChoir === 'choir_admin' && roleInChoir !== 'choir_admin') {
+            const admins = await db.user_choir.findAll({ where: { choirId, roleInChoir: 'choir_admin' } });
+            if (admins.length <= 1) {
+                return res.status(403).send({ message: 'You cannot remove the last Choir Admin.' });
+            }
+        }
+
+        await association.update({
+            ...(roleInChoir ? { roleInChoir } : {}),
+            ...(isOrganist !== undefined ? { isOrganist: !!isOrganist } : {})
+        });
+
+        res.status(200).send({ message: 'Membership updated.' });
+    } catch (err) {
+        err.message = `Error updating member ${userId} for choirId ${choirId}: ${err.message}`;
+        next(err);
+    }
+};
+
 exports.getChoirCollections = async (req, res, next) => {
     try {
         const choir = await db.choir.findByPk(req.activeChoirId);

--- a/choir-app-backend/src/models/user_choir.model.js
+++ b/choir-app-backend/src/models/user_choir.model.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
         },
         // Diese Rolle ist spezifisch für die Beziehung zwischen User und Choir
         roleInChoir: {
-            type: DataTypes.ENUM('director', 'choir_admin'),
+            type: DataTypes.ENUM('director', 'choir_admin', 'organist'),
             defaultValue: 'director'
         },
         isOrganist: {

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -21,6 +21,7 @@ router.put("/choirs/:id", controller.update(db.choir));
 router.delete("/choirs/:id", controller.remove(db.choir));
 router.get("/choirs/:id/members", controller.getChoirMembers);
 router.post("/choirs/:id/members", controller.addUserToChoir);
+router.put("/choirs/:id/members/:userId", controller.updateChoirMember);
 router.delete("/choirs/:id/members", controller.removeUserFromChoir);
 
 // Routen für Benutzer

--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -12,6 +12,7 @@ router.get("/", controller.getMyChoirDetails);
 router.put("/", isChoirAdminOrAdmin, controller.updateMyChoir);
 router.get("/members", isChoirAdminOrAdmin, controller.getChoirMembers);
 router.post("/members", isChoirAdminOrAdmin, controller.inviteUserToChoir);
+router.put("/members/:userId", isChoirAdminOrAdmin, controller.updateMember);
 router.delete("/members", isChoirAdminOrAdmin, controller.removeUserFromChoir);
 router.get("/collections", isChoirAdminOrAdmin, controller.getChoirCollections);
 router.delete("/collections/:id", isChoirAdminOrAdmin, controller.removeCollectionFromChoir);

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -37,7 +37,7 @@ export interface User {
 
 export interface UserInChoir extends User {
     membership?: { // Daten aus der Junction-Tabelle
-        roleInChoir: 'director' | 'choir_admin';
+        roleInChoir: 'director' | 'choir_admin' | 'organist';
         registrationStatus: 'REGISTERED' | 'PENDING';
         isOrganist: boolean;
     }

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -38,6 +38,10 @@ export class AdminService {
     return this.http.post<{ message: string }>(`${this.apiUrl}/admin/choirs/${id}/members`, { email, roleInChoir, isOrganist });
   }
 
+  updateChoirMemberAdmin(id: number, userId: number, data: { roleInChoir?: string; isOrganist?: boolean }): Observable<any> {
+    return this.http.put(`${this.apiUrl}/admin/choirs/${id}/members/${userId}`, data);
+  }
+
   removeUserFromChoirAdmin(id: number, userId: number): Observable<any> {
     const options = { body: { userId } };
     return this.http.delete(`${this.apiUrl}/admin/choirs/${id}/members`, options);

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -382,6 +382,10 @@ export class ApiService {
     return this.choirService.inviteUserToChoir(email, roleInChoir, isOrganist);
   }
 
+  updateChoirMember(userId: number, data: { roleInChoir?: string; isOrganist?: boolean }): Observable<any> {
+    return this.choirService.updateMember(userId, data);
+  }
+
   getInvitation(token: string): Observable<any> {
     return this.userService.getInvitation(token);
   }
@@ -434,6 +438,10 @@ export class ApiService {
 
   inviteUserToChoirAdmin(id: number, email: string, roleInChoir: string, isOrganist?: boolean): Observable<{ message: string }> {
     return this.adminService.inviteUserToChoirAdmin(id, email, roleInChoir, isOrganist);
+  }
+
+  updateChoirMemberAdmin(id: number, userId: number, data: { roleInChoir?: string; isOrganist?: boolean }): Observable<any> {
+    return this.adminService.updateChoirMemberAdmin(id, userId, data);
   }
 
   removeUserFromChoirAdmin(id: number, userId: number): Observable<any> {

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -28,6 +28,10 @@ export class ChoirService {
     return this.http.post<{ message: string }>(`${this.apiUrl}/choir-management/members`, { email, roleInChoir, isOrganist });
   }
 
+  updateMember(userId: number, data: { roleInChoir?: string; isOrganist?: boolean }): Observable<any> {
+    return this.http.put(`${this.apiUrl}/choir-management/members/${userId}`, data);
+  }
+
   removeUserFromChoir(userId: number): Observable<any> {
     const options = { body: { userId } };
     return this.http.delete(`${this.apiUrl}/choir-management/members`, options);

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
@@ -15,6 +15,7 @@
       <mat-select formControlName="role">
         <mat-option value="director">Dirigent</mat-option>
         <mat-option value="choir_admin">Chor-Admin</mat-option>
+        <mat-option value="organist">Organist</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-checkbox formControlName="isOrganist">Organist</mat-checkbox>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -34,6 +34,12 @@
         <th mat-header-cell *matHeaderCellDef>Rolle</th>
         <td mat-cell *matCellDef="let user">{{user.membership?.roleInChoir | titlecase}}</td>
       </ng-container>
+      <ng-container matColumnDef="organist">
+        <th mat-header-cell *matHeaderCellDef>Organist</th>
+        <td mat-cell *matCellDef="let user">
+          <mat-checkbox [checked]="user.membership?.isOrganist" (change)="toggleOrganist(user, $event.checked)"></mat-checkbox>
+        </td>
+      </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>Status</th>
         <td mat-cell *matCellDef="let user">{{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}}</td>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -21,7 +21,7 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/co
 export class ChoirDialogComponent implements OnInit {
   form: FormGroup;
   title = 'Chor hinzufügen';
-  displayedColumns: string[] = ['name', 'email', 'role', 'status', 'actions'];
+  displayedColumns: string[] = ['name', 'email', 'role', 'organist', 'status', 'actions'];
   dataSource = new MatTableDataSource<UserInChoir>();
 
   constructor(
@@ -84,6 +84,14 @@ export class ChoirDialogComponent implements OnInit {
           error: err => this.snackBar.open('Fehler beim Entfernen des Mitglieds', 'Schließen')
         });
       }
+    });
+  }
+
+  toggleOrganist(user: UserInChoir, checked: boolean): void {
+    if (!this.data?.id) return;
+    this.api.updateChoirMemberAdmin(this.data.id, user.id, { isOrganist: checked }).subscribe({
+      next: () => user.membership!.isOrganist = checked,
+      error: () => this.snackBar.open('Fehler beim Aktualisieren', 'Schließen')
     });
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.html
@@ -11,6 +11,7 @@
       <mat-select formControlName="role">
         <mat-option value="director">Dirigent</mat-option>
         <mat-option value="choir_admin">Chor-Admin</mat-option>
+        <mat-option value="organist">Organist</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-checkbox formControlName="isOrganist">Organist</mat-checkbox>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -77,6 +77,12 @@
             <th mat-header-cell *matHeaderCellDef> Rolle </th>
             <td mat-cell *matCellDef="let user"> {{user.membership?.roleInChoir | titlecase}} </td>
           </ng-container>
+          <ng-container matColumnDef="organist">
+            <th mat-header-cell *matHeaderCellDef>Organist</th>
+            <td mat-cell *matCellDef="let user">
+              <mat-checkbox [checked]="user.membership?.isOrganist" (change)="toggleOrganist(user, $event.checked)" [disabled]="!isChoirAdmin"></mat-checkbox>
+            </td>
+          </ng-container>
           <ng-container matColumnDef="status">
             <th mat-header-cell *matHeaderCellDef> Status </th>
             <td mat-cell *matCellDef="let user"> {{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}} </td>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -40,7 +40,7 @@ export class ManageChoirComponent implements OnInit {
 
 
   // Für die Mitglieder-Tabelle
-  displayedColumns: string[] = ['name', 'email', 'role', 'status', 'actions'];
+  displayedColumns: string[] = ['name', 'email', 'role', 'organist', 'status', 'actions'];
   dataSource = new MatTableDataSource<UserInChoir>();
 
   constructor(
@@ -164,6 +164,14 @@ export class ManageChoirComponent implements OnInit {
           error: (err) => this.snackBar.open('Fehler beim Entfernen des Mitglieds.', 'Schließen')
         });
       }
+    });
+  }
+
+  toggleOrganist(user: UserInChoir, checked: boolean): void {
+    if (!this.isChoirAdmin) return;
+    this.apiService.updateChoirMember(user.id, { isOrganist: checked }).subscribe({
+      next: () => user.membership!.isOrganist = checked,
+      error: () => this.snackBar.open('Fehler beim Aktualisieren.', 'Schließen')
     });
   }
 


### PR DESCRIPTION
## Summary
- allow organist-only role in membership model
- expose API endpoints for editing a member's organist flag
- add service helpers for updating choir members
- extend admin and choir management UIs with organist column and checkbox
- support inviting organist-only members

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6868db592b3883209db49630c0450d73