### PR TITLE
Reload monthly plan after adding entry

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -102,7 +102,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     dialogRef.afterClosed().subscribe(result => {
       if (result && this.plan) {
         this.api.createPlanEntry({ ...result, monthlyPlanId: this.plan.id }).subscribe({
-          next: entry => { this.entries.push(entry); this.snackBar.open('Eintrag angelegt.', 'OK', { duration: 3000 }); },
+          next: () => {
+            this.snackBar.open('Eintrag angelegt.', 'OK', { duration: 3000 });
+            this.loadPlan(this.selectedYear, this.selectedMonth);
+          },
           error: () => this.snackBar.open('Fehler beim Anlegen des Eintrags.', 'Schließen', { duration: 4000 })
         });
       }


### PR DESCRIPTION
## Summary
- reload the monthly plan after creating a new plan entry so the table updates instantly

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6868dd9460cc8320a544fc5303efe41e