### PR TITLE
Add log deletion feature

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -343,6 +343,17 @@ exports.getLog = async (req, res) => {
     }
 };
 
+exports.deleteLog = async (req, res) => {
+    const { filename } = req.params;
+    try {
+        const deleted = await logService.deleteLogFile(filename);
+        if (!deleted) return res.status(404).send({ message: 'Log file not found' });
+        res.status(200).send({ message: 'Deleted' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
 exports.getMailSettings = async (req, res) => {
     try {
         const settings = await db.mail_setting.findByPk(1);

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -34,6 +34,7 @@ router.get("/login-attempts", controller.getLoginAttempts);
 
 router.get('/logs', controller.listLogs);
 router.get('/logs/:filename', controller.getLog);
+router.delete('/logs/:filename', controller.deleteLog);
 router.get('/mail-settings', controller.getMailSettings);
 router.put('/mail-settings', controller.updateMailSettings);
 

--- a/choir-app-backend/src/services/log.service.js
+++ b/choir-app-backend/src/services/log.service.js
@@ -57,4 +57,16 @@ async function readLogFile(filename) {
     }
 }
 
-module.exports = { listLogFiles, readLogFile };
+async function deleteLogFile(filename) {
+    const safe = path.basename(filename);
+    const filePath = path.join(LOG_DIR, safe);
+    try {
+        await fs.promises.unlink(filePath);
+        return true;
+    } catch (err) {
+        if (err.code === 'ENOENT') return false;
+        throw err;
+    }
+}
+
+module.exports = { listLogFiles, readLogFile, deleteLogFile };

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -79,6 +79,10 @@ export class AdminService {
     return this.http.get<any[]>(`${this.apiUrl}/admin/logs/${encodeURIComponent(filename)}`);
   }
 
+  deleteLog(filename: string): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/admin/logs/${encodeURIComponent(filename)}`);
+  }
+
   downloadBackup(): Observable<Blob> {
     return this.http.get(`${this.apiUrl}/backup/export`, { responseType: 'blob' });
   }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -476,6 +476,10 @@ export class ApiService {
     return this.adminService.getLog(filename);
   }
 
+  deleteLog(filename: string): Observable<any> {
+    return this.adminService.deleteLog(filename);
+  }
+
   downloadBackup(): Observable<Blob> {
     return this.adminService.downloadBackup();
   }

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
@@ -6,6 +6,7 @@
     </mat-select>
   </mat-form-field>
   <button mat-button (click)="toggleSort()">Sortierung {{ descending ? '↓' : '↑' }}</button>
+  <button mat-flat-button color="warn" (click)="deleteLog()" [disabled]="!selected">Löschen</button>
 </div>
 
 <div *ngFor="let group of groups">

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.ts
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.ts
@@ -37,6 +37,16 @@ export class LogViewerComponent implements OnInit {
     });
   }
 
+  deleteLog(): void {
+    if (!this.selected) return;
+    this.api.deleteLog(this.selected).subscribe(() => {
+      this.selected = '';
+      this.entries = [];
+      this.groups = [];
+      this.loadFiles();
+    });
+  }
+
   toggleSort(): void {
     this.descending = !this.descending;
     this.groupEntries();


### PR DESCRIPTION
## Summary
- extend backend log service to delete log files
- add DELETE endpoint and controller logic for logs
- update admin frontend services to call new endpoint
- enhance log viewer with delete button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868dd78bda0832081a7568f80441db3