### PR TITLE
Ignore build info path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 choir-app-frontend/src/environments/build-info.ts
+src/environment/build-info.ts


### PR DESCRIPTION
## Summary
- ignore `src/environment/build-info.ts` in `.gitignore`

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869116ce7e48320ac05f5043ee1ce91