### PR TITLE
Implement lazy loading for admin routes

### DIFF
--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -12,13 +12,6 @@ import { AuthGuard } from './core/guards/auth-guard'; // Stellen Sie sicher, das
 import { ImprintComponent } from '@features/legal/imprint/imprint.component';
 import { PrivacyComponent } from '@features/legal/privacy/privacy.component';
 import { AdminGuard } from '@core/guards/admin-guard';
-import { ManageComposersComponent } from '@features/admin/manage-composers/manage-composers.component';
-import { ManageAuthorsComponent } from '@features/admin/manage-authors/manage-authors.component';
-import { ManageChoirsComponent } from '@features/admin/manage-choirs/manage-choirs.component';
-import { ManageUsersComponent } from '@features/admin/manage-users/manage-users.component';
-import { BackupComponent } from '@features/admin/backup/backup.component';
-import { ProtocolsComponent } from '@features/admin/protocols/protocols.component';
-import { MailSettingsComponent } from '@features/admin/mail-settings/mail-settings.component';
 import { LoginGuard } from '@core/guards/login.guard';
 import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
@@ -129,18 +122,8 @@ export const routes: Routes = [
     },
     {
         path: 'admin',
-        component: MainLayoutComponent,
         canActivate: [AuthGuard, AdminGuard], // Muss eingeloggt UND Admin sein
-        children: [
-            { path: '', redirectTo: 'composers', pathMatch: 'full' },
-            { path: 'composers', component: ManageComposersComponent },
-            { path: 'authors', component: ManageAuthorsComponent },
-            { path: 'choirs', component: ManageChoirsComponent },
-            { path: 'users', component: ManageUsersComponent },
-            { path: 'backup', component: BackupComponent },
-            { path: 'protocols', component: ProtocolsComponent },
-            { path: 'mail-settings', component: MailSettingsComponent },
-        ],
+        loadChildren: () => import('./features/admin/admin.routes').then(m => m.adminRoutes),
     },
 
     // Fallback für unbekannte Routen

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -1,0 +1,19 @@
+import { Routes } from '@angular/router';
+import { MainLayoutComponent } from '../../layout/main-layout/main-layout.component';
+
+export const adminRoutes: Routes = [
+  {
+    path: '',
+    component: MainLayoutComponent,
+    children: [
+      { path: '', redirectTo: 'composers', pathMatch: 'full' },
+      { path: 'composers', loadComponent: () => import('./manage-composers/manage-composers.component').then(m => m.ManageComposersComponent) },
+      { path: 'authors', loadComponent: () => import('./manage-authors/manage-authors.component').then(m => m.ManageAuthorsComponent) },
+      { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent) },
+      { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent) },
+      { path: 'backup', loadComponent: () => import('./backup/backup.component').then(m => m.BackupComponent) },
+      { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent) },
+      { path: 'mail-settings', loadComponent: () => import('./mail-settings/mail-settings.component').then(m => m.MailSettingsComponent) },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- use a separate admin route configuration
- lazy load admin routes from the main router

## Testing
- `npm test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6868de2b5f5883208f4eed362a80a757