### PR TITLE
Improve sshpass handling in PowerShell deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ When [`sshpass`](https://www.gnu.org/software/sshpass/) is available, the
 password can be read from a file named `.chorleiter_deploy_pw` in your home
 directory to perform a fully non‑interactive deployment. Without `sshpass`, the
 password still needs to be entered once when the connection is initiated.
+On Windows you can install `sshpass` with Chocolatey (`choco install sshpass`) or another package manager so that the deployment script can use it automatically.

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -20,14 +20,21 @@ if (Get-Command sshpass -ErrorAction SilentlyContinue) {
     $install = Read-Host "sshpass is not installed. Install it now? (y/N)"
     if ($install -match '^[Yy]') {
         try {
-            & sudo apt-get install sshpass
-            $sshUseSshpass = $true
+            if (Get-Command apt-get -ErrorAction SilentlyContinue) {
+                & sudo apt-get install sshpass
+                $sshUseSshpass = $true
+            } elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+                & choco install -y sshpass
+                $sshUseSshpass = $true
+            } else {
+                Write-Host "No supported package manager found. Install sshpass manually." -ForegroundColor Yellow
+            }
         } catch {
             Write-Host "Failed to install sshpass." -ForegroundColor Red
         }
     }
     if (-not $sshUseSshpass) {
-        Write-Host "Hint: install sshpass with: sudo apt-get install sshpass"
+        Write-Host "Hint: install sshpass manually (e.g. 'choco install sshpass')"
     }
 }
 


### PR DESCRIPTION
## Summary
- support Windows package managers when installing `sshpass`
- document installation of `sshpass` on Windows

## Testing
- `npm test --silent --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test --silent --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6869141c098883209cdffd879f633a5d