### PR TITLE
Fix sshpass detection in deploy.ps1

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -22,15 +22,19 @@ if (Get-Command sshpass -ErrorAction SilentlyContinue) {
         try {
             if (Get-Command apt-get -ErrorAction SilentlyContinue) {
                 & sudo apt-get install sshpass
-                $sshUseSshpass = $true
             } elseif (Get-Command choco -ErrorAction SilentlyContinue) {
                 & choco install -y sshpass
-                $sshUseSshpass = $true
             } else {
                 Write-Host "No supported package manager found. Install sshpass manually." -ForegroundColor Yellow
             }
         } catch {
             Write-Host "Failed to install sshpass." -ForegroundColor Red
+        }
+        # Re-check after attempted installation
+        if (Get-Command sshpass -ErrorAction SilentlyContinue) {
+            $sshUseSshpass = $true
+        } else {
+            Write-Host "sshpass installation failed or command not found." -ForegroundColor Red
         }
     }
     if (-not $sshUseSshpass) {


### PR DESCRIPTION
## Summary
- improve sshpass installation checks so the script falls back to plain `ssh` if installation fails

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68692408f9f48320957e0cf51da3d4ca