### PR TITLE
Fix build info dialog to use generated info

### DIFF
--- a/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.html
@@ -1,12 +1,8 @@
-<h2 mat-dialog-title>Build &amp; Installationsinfo</h2>
+<h2 mat-dialog-title>Buildinformationen</h2>
 <div mat-dialog-content>
-  <ng-container *ngIf="info; else loading">
-    <p><strong>Build von:</strong> {{ info.buildUser }}</p>
-    <p><strong>Build-Datum:</strong> {{ info.buildDate | date:'short' }}</p>
-    <p><strong>Installiert von:</strong> {{ info.installUser }}</p>
-    <p><strong>Installations-Datum:</strong> {{ info.installDate | date:'short' }}</p>
-  </ng-container>
-  <ng-template #loading>Informationen werden geladen...</ng-template>
+  <p><strong>Version:</strong> {{ info.version }}</p>
+  <p><strong>Commit:</strong> {{ info.commit }}</p>
+  <p><strong>Build-Datum:</strong> {{ info.date | date:'short' }}</p>
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button (click)="close()">Schließen</button>

--- a/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/build-info-dialog/build-info-dialog.component.ts
@@ -1,14 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
+import { buildInfo } from '@env/build-info';
 
 interface BuildInfo {
-  buildUser: string;
-  buildDate: string;
-  installUser: string;
-  installDate: string;
+  version: string;
+  commit: string;
+  date: string;
 }
 
 @Component({
@@ -18,14 +17,10 @@ interface BuildInfo {
   templateUrl: './build-info-dialog.component.html',
   styleUrls: ['./build-info-dialog.component.scss']
 })
-export class BuildInfoDialogComponent implements OnInit {
-  info: BuildInfo | null = null;
+export class BuildInfoDialogComponent {
+  info: BuildInfo = buildInfo;
 
-  constructor(private http: HttpClient, private dialogRef: MatDialogRef<BuildInfoDialogComponent>) {}
-
-  ngOnInit(): void {
-    this.http.get<BuildInfo>('assets/build-info.json').subscribe(data => this.info = data);
-  }
+  constructor(private dialogRef: MatDialogRef<BuildInfoDialogComponent>) {}
 
   close(): void {
     this.dialogRef.close();


### PR DESCRIPTION
## Summary
- update build-info dialog to use `buildInfo` from environment
- show version, commit and build date instead of unused JSON

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693742a93083209d8f4aaa4cf113fe