### PR TITLE
Adjust Deploy.ps1 password handling

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -36,17 +36,22 @@ if (-not $sshUseSshpass -and -not $sshUseAgent) {
 
 
 $Password = $null
-if (Test-Path $PasswordFile) {
-    $Password = (Get-Content $PasswordFile -Raw).Trim()
-} else {
-    $create = Read-Host "Password file $PasswordFile not found. Create it? (y/N)"
-    if ($create -match '^[Yy]') {
-        $Password = Read-Host "SSH password for $Remote"
-        Set-Content -Path $PasswordFile -Value $Password
+if (-not $sshUseAgent) {
+    if (Test-Path $PasswordFile) {
+        $Password = (Get-Content $PasswordFile -Raw).Trim()
+        if ($Password) {
+            Write-Host "Using password from $PasswordFile."
+        }
+    } else {
+        $create = Read-Host "Password file $PasswordFile not found. Create it? (y/N)"
+        if ($create -match '^[Yy]') {
+            $Password = Read-Host "SSH password for $Remote"
+            Set-Content -Path $PasswordFile -Value $Password
+        }
     }
-}
-if (-not $Password) {
-    $Password = Read-Host "SSH password for $Remote"
+    if (-not $Password) {
+        $Password = Read-Host "SSH password for $Remote"
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- prevent password prompt when ssh-agent is used
- display message when password is read from file

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686967ee93ec8320afcfa43a14553d3c