### PR TITLE
Ensure monthly plan sorting

### DIFF
--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -39,12 +39,12 @@ exports.findByMonth = async (req, res) => {
             include: [{
                 model: db.plan_entry,
                 as: 'entries',
-                order: [['date', 'ASC']],
                 include: [
                     { model: db.user, as: 'director', attributes: ['id', 'name'] },
                     { model: db.user, as: 'organist', attributes: ['id', 'name'], required: false }
                 ]
-            }]
+            }],
+            order: [[{ model: db.plan_entry, as: 'entries' }, 'date', 'ASC']]
         });
         if (!plan) return res.status(204).send();
         res.status(200).send(plan);

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -40,6 +40,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.displayedColumns = (this.isChoirAdmin && !this.plan?.finalized) ? [...base, 'actions'] : base;
   }
 
+  private sortEntries(): void {
+    this.entries.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }
+
   constructor(private api: ApiService,
               private auth: AuthService,
               private dialog: MatDialog,
@@ -61,7 +65,12 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
 
   loadPlan(year: number, month: number): void {
     this.api.getMonthlyPlan(year, month).subscribe({
-      next: plan => { this.plan = plan; this.entries = plan?.entries || []; this.updateDisplayedColumns(); },
+      next: plan => {
+        this.plan = plan;
+        this.entries = plan?.entries || [];
+        this.sortEntries();
+        this.updateDisplayedColumns();
+      },
       error: () => { this.plan = null; this.entries = []; this.updateDisplayedColumns(); }
     });
   }
@@ -118,7 +127,11 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     ref.afterClosed().subscribe(confirmed => {
       if (confirmed) {
         this.api.deletePlanEntry(ev.id).subscribe({
-          next: () => { this.entries = this.entries.filter(e => e.id !== ev.id); this.snackBar.open('Eintrag gelöscht.', 'OK', { duration: 3000 }); },
+          next: () => {
+            this.entries = this.entries.filter(e => e.id !== ev.id);
+            this.sortEntries();
+            this.snackBar.open('Eintrag gelöscht.', 'OK', { duration: 3000 });
+          },
           error: () => this.snackBar.open('Fehler beim Löschen des Eintrags.', 'Schließen', { duration: 4000 })
         });
       }


### PR DESCRIPTION
## Summary
- sort monthly plan entries by date on backend and frontend

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6869694342fc83209a6d86b19d224c0c