### PR TITLE
Fix ssh-agent handling in deploy script

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -30,6 +30,15 @@ if (Get-Command sshpass -ErrorAction SilentlyContinue) {
     }
 }
 
+if ($sshUseAgent) {
+    Write-Host "Verifying ssh-agent access..."
+    & ssh -o BatchMode=yes -o StrictHostKeyChecking=no $Remote exit 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ssh-agent authentication failed, falling back to password." -ForegroundColor Yellow
+        $sshUseAgent = $false
+    }
+}
+
 if (-not $sshUseSshpass -and -not $sshUseAgent) {
     Write-Host "sshpass not found and no ssh-agent keys loaded. You will be prompted for the password." -ForegroundColor Yellow
 }


### PR DESCRIPTION
## Summary
- prevent repeated password prompts when an ssh-agent is running but doesn't work
- if agent authentication fails, fall back to password mode

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696cc9d2cc83209fc50c456486ef8b