### PR TITLE
Add service schedule settings

### DIFF
--- a/choir-app-frontend/src/app/core/models/plan-rule.ts
+++ b/choir-app-frontend/src/app/core/models/plan-rule.ts
@@ -1,0 +1,8 @@
+export interface PlanRule {
+    id: number;
+    choirId: number;
+    type: 'REHEARSAL' | 'SERVICE';
+    dayOfWeek: number;
+    weeks: number[] | null;
+    notes?: string | null;
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -17,6 +17,7 @@ import { Collection } from '../models/collection';
 import { LookupPiece } from '@core/models/lookup-piece';
 import { Author } from '@core/models/author';
 import { Choir } from '@core/models/choir';
+import { PlanRule } from '@core/models/plan-rule';
 import { PieceChange } from '../models/piece-change';
 import { PieceService } from './piece.service';
 import { ComposerService } from './composer.service';
@@ -30,6 +31,7 @@ import { UserService } from './user.service';
 import { ImportService } from './import.service';
 import { AdminService } from './admin.service';
 import { SystemService } from './system.service';
+import { PlanRuleService } from './plan-rule.service';
 import { StatsSummary } from '../models/stats-summary';
 import { RepertoireFilter } from '../models/repertoire-filter';
 import { MailSettings } from '../models/mail-settings';
@@ -54,7 +56,8 @@ export class ApiService {
               private importService: ImportService,
               private adminService: AdminService,
               private systemService: SystemService,
-              private filterPresetService: FilterPresetService) {
+              private filterPresetService: FilterPresetService,
+              private planRuleService: PlanRuleService) {
 
   }
 
@@ -316,6 +319,23 @@ export class ApiService {
 
   reopenMonthlyPlan(id: number): Observable<MonthlyPlan> {
     return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/reopen`, {});
+  }
+
+  // --- Plan Rule Methods ---
+  getPlanRules(): Observable<PlanRule[]> {
+    return this.planRuleService.getPlanRules();
+  }
+
+  createPlanRule(data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+    return this.planRuleService.createPlanRule(data);
+  }
+
+  updatePlanRule(id: number, data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+    return this.planRuleService.updatePlanRule(id, data);
+  }
+
+  deletePlanRule(id: number): Observable<any> {
+    return this.planRuleService.deletePlanRule(id);
   }
 
 

--- a/choir-app-frontend/src/app/core/services/plan-rule.service.ts
+++ b/choir-app-frontend/src/app/core/services/plan-rule.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { PlanRule } from '../models/plan-rule';
+
+@Injectable({ providedIn: 'root' })
+export class PlanRuleService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getPlanRules(): Observable<PlanRule[]> {
+    return this.http.get<PlanRule[]>(`${this.apiUrl}/plan-rules`);
+  }
+
+  createPlanRule(data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+    return this.http.post<PlanRule>(`${this.apiUrl}/plan-rules`, data);
+  }
+
+  updatePlanRule(id: number, data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+    return this.http.put<PlanRule>(`${this.apiUrl}/plan-rules/${id}`, data);
+  }
+
+  deletePlanRule(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/plan-rules/${id}`);
+  }
+}

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -25,11 +25,13 @@ export class ManageChoirResolver implements Resolve<any> {
       switchMap(isAdmin => {
         const choirDetails$ = this.apiService.getMyChoirDetails();
         const collections$ = this.apiService.getChoirCollections();
+        const planRules$ = this.apiService.getPlanRules();
         if (isAdmin) {
           return forkJoin({
             choirDetails: choirDetails$,
             members: this.apiService.getChoirMembers(),
             collections: collections$,
+            planRules: planRules$,
             isChoirAdmin: of(true)
           });
         }
@@ -40,6 +42,7 @@ export class ManageChoirResolver implements Resolve<any> {
                 choirDetails: choirDetails$,
                 members: this.apiService.getChoirMembers(),
                 collections: collections$,
+                planRules: planRules$,
                 isChoirAdmin: of(true)
               });
             } else {
@@ -47,6 +50,7 @@ export class ManageChoirResolver implements Resolve<any> {
                 choirDetails: choirDetails$,
                 members: of([]),
                 collections: collections$,
+                planRules: planRules$,
                 isChoirAdmin: of(false)
               });
             }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -42,6 +42,40 @@
       <mat-checkbox [(ngModel)]="dienstplanEnabled" (change)="onToggleDienstplan()">
         Dienstplan anzeigen
       </mat-checkbox>
+
+      <div class="service-settings">
+        <h3>Gottesdienste</h3>
+        <mat-form-field appearance="outline">
+          <mat-label>Sonntags</mat-label>
+          <mat-select multiple [(ngModel)]="sundayWeeks">
+            <mat-option [value]="0">jeden</mat-option>
+            <mat-option *ngFor="let w of [1,2,3,4,5]" [value]="w">{{w}}.</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <div class="weekday-row">
+          <mat-form-field appearance="outline">
+            <mat-label>Wochentag</mat-label>
+            <mat-select [(ngModel)]="weekdayDay">
+              <mat-option [value]="null">-</mat-option>
+              <mat-option [value]="3">Mittwoch</mat-option>
+              <mat-option [value]="4">Donnerstag</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field appearance="outline" *ngIf="weekdayDay !== null">
+            <mat-label>Wochen</mat-label>
+            <mat-select multiple [(ngModel)]="weekdayWeeks">
+              <mat-option [value]="0">jeden</mat-option>
+              <mat-option *ngFor="let w of [1,2,3,4,5]" [value]="w">{{w}}.</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div class="actions-footer">
+          <button mat-flat-button color="primary" (click)="saveServiceRules()">Speichern</button>
+        </div>
+      </div>
+
     </mat-card-content>
   </mat-card>
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
@@ -51,6 +51,17 @@ mat-card-content form {
   text-align: right;
 }
 
+.service-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.weekday-row {
+  display: flex;
+  gap: 1rem;
+}
+
 .loading-overlay {
   position: absolute;
   top: 0;

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, FormsModule } 
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableDataSource } from '@angular/material/table';
-import { Observable } from 'rxjs';
+import { Observable, forkJoin } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 import { MaterialModule } from '@modules/material.module';
@@ -30,6 +30,12 @@ export class ManageChoirComponent implements OnInit {
 
   isChoirAdmin = false;
   dienstplanEnabled = false;
+
+  sundayWeeks: number[] = [];
+  weekdayDay: number | null = null;
+  weekdayWeeks: number[] = [];
+  private sundayRuleId: number | null = null;
+  private weekdayRuleId: number | null = null;
 
 
   choirInfoExpanded = true;
@@ -66,6 +72,18 @@ export class ManageChoirComponent implements OnInit {
         this.choirForm.patchValue(pageData.choirDetails);
         this.isChoirAdmin = pageData.isChoirAdmin;
         this.dienstplanEnabled = !!pageData.choirDetails.modules?.dienstplan;
+        const rules = pageData.planRules as any[] || [];
+        const sundayRule = rules.find(r => r.type === 'SERVICE' && r.dayOfWeek === 0);
+        if (sundayRule) {
+          this.sundayRuleId = sundayRule.id;
+          this.sundayWeeks = sundayRule.weeks && sundayRule.weeks.length ? sundayRule.weeks : [0];
+        }
+        const weekdayRule = rules.find(r => r.type === 'SERVICE' && (r.dayOfWeek === 3 || r.dayOfWeek === 4));
+        if (weekdayRule) {
+          this.weekdayRuleId = weekdayRule.id;
+          this.weekdayDay = weekdayRule.dayOfWeek;
+          this.weekdayWeeks = weekdayRule.weeks && weekdayRule.weeks.length ? weekdayRule.weeks : [0];
+        }
         const choir = this.authService.activeChoir$.value;
         if (choir) {
           const updated = { ...choir, modules: pageData.choirDetails.modules } as Choir;
@@ -197,6 +215,37 @@ export class ManageChoirComponent implements OnInit {
           });
         }
       },
+      error: () => this.snackBar.open('Fehler beim Speichern der Einstellungen.', 'Schließen')
+    });
+  }
+
+  saveServiceRules(): void {
+    if (!this.isChoirAdmin) return;
+
+    const sundayWeeks = (this.sundayWeeks.includes(0) || this.sundayWeeks.length === 0) ? null : this.sundayWeeks;
+    const weekdayWeeks = (this.weekdayWeeks.includes(0) || this.weekdayWeeks.length === 0) ? null : this.weekdayWeeks;
+
+    const ops = [] as Observable<any>[];
+
+    if (this.sundayRuleId) {
+      ops.push(this.apiService.updatePlanRule(this.sundayRuleId, { type: 'SERVICE', dayOfWeek: 0, weeks: sundayWeeks }));
+    } else {
+      ops.push(this.apiService.createPlanRule({ type: 'SERVICE', dayOfWeek: 0, weeks: sundayWeeks }));
+    }
+
+    if (this.weekdayDay !== null) {
+      const data = { type: 'SERVICE', dayOfWeek: this.weekdayDay, weeks: weekdayWeeks };
+      if (this.weekdayRuleId) {
+        ops.push(this.apiService.updatePlanRule(this.weekdayRuleId, data));
+      } else {
+        ops.push(this.apiService.createPlanRule(data));
+      }
+    } else if (this.weekdayRuleId) {
+      ops.push(this.apiService.deletePlanRule(this.weekdayRuleId));
+    }
+
+    forkJoin(ops).subscribe({
+      next: () => this.snackBar.open('Einstellungen aktualisiert.', 'OK', { duration: 3000 }),
       error: () => this.snackBar.open('Fehler beim Speichern der Einstellungen.', 'Schließen')
     });
   }


### PR DESCRIPTION
## Summary
- allow frontend to edit service schedule
- fetch plan rules for choir settings
- add PlanRule model and service

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: missing module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68696fec49c4832092d6fca1ba951b08