### PR TITLE
Fix Angular warnings

### DIFF
--- a/choir-app-frontend/angular.json
+++ b/choir-app-frontend/angular.json
@@ -31,7 +31,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ]
           },
@@ -104,7 +103,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "karmaConfig": "karma.conf.js"

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -23,7 +23,7 @@
     <ng-container matColumnDef="director">
       <th mat-header-cell *matHeaderCellDef>Chorleiter</th>
       <td mat-cell *matCellDef="let ev">
-        <ng-container *ngIf="isChoirAdmin && !plan?.finalized; else directorText">
+        <ng-container *ngIf="isChoirAdmin && !plan.finalized; else directorText">
           <mat-select [value]="ev.director?.id || null" (selectionChange)="updateDirector(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
             <mat-option *ngFor="let m of directors" [value]="m.id">{{ m.name }}</mat-option>
@@ -35,7 +35,7 @@
     <ng-container matColumnDef="organist">
       <th mat-header-cell *matHeaderCellDef>Organist</th>
       <td mat-cell *matCellDef="let ev">
-        <ng-container *ngIf="isChoirAdmin && !plan?.finalized; else organistText">
+        <ng-container *ngIf="isChoirAdmin && !plan.finalized; else organistText">
           <mat-select [value]="ev.organist?.id || null" (selectionChange)="updateOrganist(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
             <mat-option *ngFor="let m of organists" [value]="m.id">{{ m.name }}</mat-option>
@@ -51,14 +51,14 @@
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let ev">
-        <button mat-icon-button color="warn" *ngIf="isChoirAdmin && !plan?.finalized" (click)="deleteEntry(ev)">
+        <button mat-icon-button color="warn" *ngIf="isChoirAdmin && !plan.finalized" (click)="deleteEntry(ev)">
           <mat-icon>delete</mat-icon>
         </button>
       </td>
     </ng-container>
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"
-        [class.assigned]="plan?.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></tr>
+        [class.assigned]="plan.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></tr>
   </table>
   <div class="actions">
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEntryDialog()">Eintrag hinzufügen</button>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -16,7 +16,7 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/co
 @Component({
   selector: 'app-monthly-plan',
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule, PlanEntryDialogComponent, ConfirmDialogComponent],
+  imports: [CommonModule, FormsModule, MaterialModule],
   templateUrl: './monthly-plan.component.html',
   styleUrls: ['./monthly-plan.component.scss']
 })


### PR DESCRIPTION
## Summary
- clean up optional chaining in monthly-plan
- remove unused dialog components from monthly-plan imports
- rely only on project theme to avoid style duplication

## Testing
- `npm run build --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686990586d9883208da654efccb37323