### PR TITLE
Unify error handling

### DIFF
--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpErrorResponse } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
-import { catchError, switchMap } from 'rxjs/operators';
-import { MatDialog } from '@angular/material/dialog';
-import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { catchError } from 'rxjs/operators';
 import { ErrorService } from '../services/error.service';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
-  constructor(private dialog: MatDialog, private errorService: ErrorService) {}
+  constructor(private errorService: ErrorService) {}
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
@@ -24,21 +22,7 @@ export class ErrorInterceptor implements HttpInterceptor {
         });
         console.error('HTTP Error:', error);
 
-        const data: ConfirmDialogData = {
-          title: 'Fehler',
-          message,
-          confirmButtonText: 'Erneut versuchen',
-          cancelButtonText: 'Abbrechen'
-        };
-
-        return this.dialog.open(ConfirmDialogComponent, { data }).afterClosed().pipe(
-          switchMap(retry => {
-            if (retry) {
-              return next.handle(req);
-            }
-            return throwError(() => error);
-          })
-        );
+        return throwError(() => error);
       })
     );
   }


### PR DESCRIPTION
## Summary
- simplify `ErrorInterceptor` to show a single error overlay

## Testing
- `npm test` *(fails: ng not found)*
- `npx -y --prefix choir-app-frontend tsc -p choir-app-frontend/tsconfig.json` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68699197e74c832098b7e9b2a4b4c023