### PR TITLE
Add availability schedule

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -64,6 +64,7 @@ const repertoireFilterRoutes = require("./routes/repertoire-filter.routes");
 const monthlyPlanRoutes = require("./routes/monthlyPlan.routes");
 const planRuleRoutes = require("./routes/planRule.routes");
 const planEntryRoutes = require("./routes/planEntry.routes");
+const availabilityRoutes = require("./routes/availability.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -86,6 +87,7 @@ app.use("/api/repertoire-filters", repertoireFilterRoutes);
 app.use("/api/monthly-plans", monthlyPlanRoutes);
 app.use("/api/plan-rules", planRuleRoutes);
 app.use("/api/plan-entries", planEntryRoutes);
+app.use("/api/availabilities", availabilityRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -1,0 +1,58 @@
+const db = require('../models');
+const { Op } = db.Sequelize;
+
+function datesForRule(year, month, rule) {
+    const dates = [];
+    const d = new Date(Date.UTC(year, month - 1, 1));
+    while (d.getUTCMonth() === month - 1) {
+        if (d.getUTCDay() === rule.dayOfWeek) {
+            const week = Math.floor((d.getUTCDate() - 1) / 7) + 1;
+            if (!Array.isArray(rule.weeks) || rule.weeks.length === 0 || rule.weeks.includes(week)) {
+                dates.push(new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())));
+            }
+        }
+        d.setUTCDate(d.getUTCDate() + 1);
+    }
+    return dates;
+}
+
+exports.findByMonth = async (req, res) => {
+    const { year, month } = req.params;
+    try {
+        const rules = await db.plan_rule.findAll({ where: { choirId: req.activeChoirId } });
+        const dateSet = new Set();
+        for (const rule of rules) {
+            for (const d of datesForRule(year, month, rule)) {
+                dateSet.add(d.toISOString().split('T')[0]);
+            }
+        }
+        const dates = Array.from(dateSet).sort();
+        const avail = await db.user_availability.findAll({
+            where: {
+                userId: req.userId,
+                choirId: req.activeChoirId,
+                date: { [Op.between]: [ `${year}-${String(month).padStart(2,'0')}-01`, `${year}-${String(month).padStart(2,'0')}-31` ] }
+            }
+        });
+        const map = Object.fromEntries(avail.map(a => [a.date, a]));
+        const result = dates.map(d => map[d] ? map[d] : { date: d, status: 'AVAILABLE' });
+        res.status(200).send(result);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not fetch availability.' });
+    }
+};
+
+exports.setAvailability = async (req, res) => {
+    const { date, status } = req.body;
+    if (!date || !status) return res.status(400).send({ message: 'date and status required' });
+    try {
+        const [avail] = await db.user_availability.findOrCreate({
+            where: { userId: req.userId, choirId: req.activeChoirId, date },
+            defaults: { status }
+        });
+        if (avail.status !== status) await avail.update({ status });
+        res.status(200).send(avail);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not save availability.' });
+    }
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -20,6 +20,7 @@ db.event = require("./event.model.js")(sequelize, Sequelize);
 db.monthly_plan = require("./monthly_plan.model.js")(sequelize, Sequelize);
 db.plan_rule = require("./plan_rule.model.js")(sequelize, Sequelize);
 db.plan_entry = require("./plan_entry.model.js")(sequelize, Sequelize);
+db.user_availability = require("./user_availability.model.js")(sequelize, Sequelize);
 db.event_pieces = require("./event_pieces.model.js")(sequelize, Sequelize);
 db.composer = require("./composer.model.js")(sequelize, Sequelize);
 db.category = require("./category.model.js")(sequelize, Sequelize);
@@ -67,6 +68,11 @@ db.monthly_plan.hasMany(db.plan_entry, { as: "entries" });
 db.plan_entry.belongsTo(db.monthly_plan, { foreignKey: "monthlyPlanId", as: "monthlyPlan" });
 db.choir.hasMany(db.plan_rule, { as: "planRules" });
 db.plan_rule.belongsTo(db.choir, { foreignKey: "choirId", as: "choir" });
+
+db.user.hasMany(db.user_availability, { as: 'availabilities' });
+db.user_availability.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
+db.choir.hasMany(db.user_availability, { as: 'availabilities' });
+db.user_availability.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 
 // A User (director) created a Piece
 db.user.hasMany(db.piece, { as: "createdPieces"});

--- a/choir-app-backend/src/models/user_availability.model.js
+++ b/choir-app-backend/src/models/user_availability.model.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+    const UserAvailability = sequelize.define('user_availability', {
+        date: {
+            type: DataTypes.DATEONLY,
+            allowNull: false
+        },
+        status: {
+            type: DataTypes.ENUM('AVAILABLE', 'MAYBE', 'UNAVAILABLE'),
+            allowNull: false,
+            defaultValue: 'AVAILABLE'
+        }
+    });
+    return UserAvailability;
+};

--- a/choir-app-backend/src/routes/availability.routes.js
+++ b/choir-app-backend/src/routes/availability.routes.js
@@ -1,0 +1,10 @@
+const auth = require("../middleware/auth.middleware");
+const controller = require("../controllers/availability.controller");
+const router = require("express").Router();
+
+router.use(auth.verifyToken);
+
+router.get("/:year/:month", controller.findByMonth);
+router.put("/", controller.setAvailability);
+
+module.exports = router;

--- a/choir-app-frontend/src/app/core/models/user-availability.ts
+++ b/choir-app-frontend/src/app/core/models/user-availability.ts
@@ -1,0 +1,4 @@
+export interface UserAvailability {
+  date: string;
+  status: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE';
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -36,6 +36,8 @@ import { StatsSummary } from '../models/stats-summary';
 import { RepertoireFilter } from '../models/repertoire-filter';
 import { MailSettings } from '../models/mail-settings';
 import { FilterPresetService } from './filter-preset.service';
+import { UserAvailability } from '../models/user-availability';
+import { AvailabilityService } from './availability.service';
 
 @Injectable({
   providedIn: 'root'
@@ -57,7 +59,8 @@ export class ApiService {
               private adminService: AdminService,
               private systemService: SystemService,
               private filterPresetService: FilterPresetService,
-              private planRuleService: PlanRuleService) {
+              private planRuleService: PlanRuleService,
+              private availabilityService: AvailabilityService) {
 
   }
 
@@ -336,6 +339,15 @@ export class ApiService {
 
   deletePlanRule(id: number): Observable<any> {
     return this.planRuleService.deletePlanRule(id);
+  }
+
+  // --- Availability Methods ---
+  getAvailabilities(year: number, month: number): Observable<UserAvailability[]> {
+    return this.availabilityService.getAvailabilities(year, month);
+  }
+
+  setAvailability(date: string, status: string): Observable<UserAvailability> {
+    return this.availabilityService.setAvailability(date, status);
   }
 
 

--- a/choir-app-frontend/src/app/core/services/availability.service.ts
+++ b/choir-app-frontend/src/app/core/services/availability.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { UserAvailability } from '../models/user-availability';
+
+@Injectable({ providedIn: 'root' })
+export class AvailabilityService {
+  private apiUrl = environment.apiUrl;
+  constructor(private http: HttpClient) {}
+
+  getAvailabilities(year: number, month: number): Observable<UserAvailability[]> {
+    return this.http.get<UserAvailability[]>(`${this.apiUrl}/availabilities/${year}/${month}`);
+  }
+
+  setAvailability(date: string, status: string): Observable<UserAvailability> {
+    return this.http.put<UserAvailability>(`${this.apiUrl}/availabilities`, { date, status });
+  }
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -1,0 +1,18 @@
+<table mat-table [dataSource]="availabilities" class="mat-elevation-z2">
+  <ng-container matColumnDef="date">
+    <th mat-header-cell *matHeaderCellDef>Datum</th>
+    <td mat-cell *matCellDef="let a">{{ a.date | date:'shortDate' }}</td>
+  </ng-container>
+  <ng-container matColumnDef="status">
+    <th mat-header-cell *matHeaderCellDef>Status</th>
+    <td mat-cell *matCellDef="let a" [ngClass]="cellClass(a.status)">
+      <mat-select [value]="a.status" (selectionChange)="setStatus(a.date, $event.value)">
+        <mat-option value="AVAILABLE">verfügbar</mat-option>
+        <mat-option value="MAYBE">verfügbar nach Absprache</mat-option>
+        <mat-option value="UNAVAILABLE">nicht verfügbar</mat-option>
+      </mat-select>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.scss
@@ -1,0 +1,16 @@
+:host {
+  display: block;
+  margin-top: 1em;
+}
+
+.available {
+  background-color: #c8e6c9;
+}
+
+.maybe {
+  background-color: #fff9c4;
+}
+
+.unavailable {
+  background-color: #ffcdd2;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
@@ -1,0 +1,46 @@
+import { Component, Input, OnInit, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { UserAvailability } from '@core/models/user-availability';
+
+@Component({
+  selector: 'app-availability-table',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './availability-table.component.html',
+  styleUrls: ['./availability-table.component.scss']
+})
+export class AvailabilityTableComponent implements OnInit, OnChanges {
+  @Input() year!: number;
+  @Input() month!: number;
+  availabilities: UserAvailability[] = [];
+  displayedColumns = ['date', 'status'];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void { this.load(); }
+  ngOnChanges(): void { this.load(); }
+
+  load(): void {
+    if (!this.year || !this.month) return;
+    this.api.getAvailabilities(this.year, this.month)
+      .subscribe(a => this.availabilities = a);
+  }
+
+  setStatus(date: string, status: string): void {
+    this.api.setAvailability(date, status).subscribe(updated => {
+      const i = this.availabilities.findIndex(v => v.date === updated.date);
+      if (i >= 0) this.availabilities[i] = updated;
+    });
+  }
+
+  cellClass(status: string): string {
+    switch (status) {
+      case 'AVAILABLE': return 'available';
+      case 'MAYBE': return 'maybe';
+      case 'UNAVAILABLE': return 'unavailable';
+      default: return '';
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -65,6 +65,8 @@
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
     <button *ngIf="isChoirAdmin && plan.finalized" mat-raised-button color="primary" (click)="reopenPlan()">Plan erneut öffnen</button>
   </div>
+  <h3>Meine Verfügbarkeiten</h3>
+  <app-availability-table [year]="selectedYear" [month]="selectedMonth"></app-availability-table>
 </div>
 <ng-template #noPlan>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -12,11 +12,12 @@ import { AuthService } from '@core/services/auth.service';
 import { Subscription } from 'rxjs';
 import { PlanEntryDialogComponent } from './plan-entry-dialog/plan-entry-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { AvailabilityTableComponent } from './availability-table/availability-table.component';
 
 @Component({
   selector: 'app-monthly-plan',
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule],
+  imports: [CommonModule, FormsModule, MaterialModule, AvailabilityTableComponent],
   templateUrl: './monthly-plan.component.html',
   styleUrls: ['./monthly-plan.component.scss']
 })


### PR DESCRIPTION
## Summary
- track user availability with new backend routes and model
- expose availability APIs to the Angular frontend
- allow editing personal availability in monthly plan

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686a98a8c0e883208721e1b3a5801fac