### PR TITLE
Add counter plan view

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -65,6 +65,23 @@
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
     <button *ngIf="isChoirAdmin && plan.finalized" mat-raised-button color="primary" (click)="reopenPlan()">Plan erneut öffnen</button>
   </div>
+  <div class="counter-plan" *ngIf="counterPlanDates.length > 0">
+    <h3>Gegenplan</h3>
+    <table class="counter-plan-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th *ngFor="let d of counterPlanDates">{{ d | date:'dd.MM.' }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let row of counterPlanRows">
+          <td>{{ row.user.name }}</td>
+          <td *ngFor="let key of counterPlanDateKeys">{{ row.assignments[key] }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 <ng-template #noPlan>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -8,3 +8,14 @@
 .assigned td {
   font-weight: 600;
 }
+
+.counter-plan-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th, td {
+    border: 1px solid #ddd;
+    padding: 4px;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- show a counter plan in Monthly Plan page
- compute assignments per member and date
- style counter plan table

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a993bd8c883209e0135078453cfd2