### PR TITLE
Add availability filtering for monthly plan

### DIFF
--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -56,3 +56,19 @@ exports.setAvailability = async (req, res) => {
         res.status(500).send({ message: err.message || 'Could not save availability.' });
     }
 };
+
+exports.findAllByMonth = async (req, res) => {
+    const { year, month } = req.params;
+    try {
+        const avail = await db.user_availability.findAll({
+            where: {
+                choirId: req.activeChoirId,
+                date: { [Op.between]: [ `${year}-${String(month).padStart(2,'0')}-01`, `${year}-${String(month).padStart(2,'0')}-31` ] }
+            },
+            attributes: ['userId', 'date', 'status']
+        });
+        res.status(200).send(avail);
+    } catch (err) {
+        res.status(500).send({ message: err.message || 'Could not fetch availability.' });
+    }
+};

--- a/choir-app-backend/src/routes/availability.routes.js
+++ b/choir-app-backend/src/routes/availability.routes.js
@@ -4,6 +4,7 @@ const router = require("express").Router();
 
 router.use(auth.verifyToken);
 
+router.get("/:year/:month/all", auth.isChoirAdminOrAdmin, controller.findAllByMonth);
 router.get("/:year/:month", controller.findByMonth);
 router.put("/", controller.setAvailability);
 

--- a/choir-app-frontend/src/app/core/models/member-availability.ts
+++ b/choir-app-frontend/src/app/core/models/member-availability.ts
@@ -1,0 +1,5 @@
+export interface MemberAvailability {
+  userId: number;
+  date: string;
+  status: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE';
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -37,6 +37,7 @@ import { RepertoireFilter } from '../models/repertoire-filter';
 import { MailSettings } from '../models/mail-settings';
 import { FilterPresetService } from './filter-preset.service';
 import { UserAvailability } from '../models/user-availability';
+import { MemberAvailability } from '../models/member-availability';
 import { AvailabilityService } from './availability.service';
 
 @Injectable({
@@ -348,6 +349,10 @@ export class ApiService {
 
   setAvailability(date: string, status: string): Observable<UserAvailability> {
     return this.availabilityService.setAvailability(date, status);
+  }
+
+  getMemberAvailabilities(year: number, month: number): Observable<MemberAvailability[]> {
+    return this.availabilityService.getMemberAvailabilities(year, month);
   }
 
 

--- a/choir-app-frontend/src/app/core/services/availability.service.ts
+++ b/choir-app-frontend/src/app/core/services/availability.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { UserAvailability } from '../models/user-availability';
+import { MemberAvailability } from '../models/member-availability';
 
 @Injectable({ providedIn: 'root' })
 export class AvailabilityService {
@@ -15,5 +16,9 @@ export class AvailabilityService {
 
   setAvailability(date: string, status: string): Observable<UserAvailability> {
     return this.http.put<UserAvailability>(`${this.apiUrl}/availabilities`, { date, status });
+  }
+
+  getMemberAvailabilities(year: number, month: number): Observable<MemberAvailability[]> {
+    return this.http.get<MemberAvailability[]>(`${this.apiUrl}/availabilities/${year}/${month}/all`);
   }
 }

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -26,7 +26,7 @@
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else directorText">
           <mat-select [value]="ev.director?.id || null" (selectionChange)="updateDirector(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
-            <mat-option *ngFor="let m of directors" [value]="m.id">{{ m.name }}</mat-option>
+            <mat-option *ngFor="let m of availableForDate(directors, ev.date)" [value]="m.id">{{ m.name }}</mat-option>
           </mat-select>
         </ng-container>
         <ng-template #directorText>{{ ev.director?.name }}</ng-template>
@@ -38,7 +38,7 @@
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else organistText">
           <mat-select [value]="ev.organist?.id || null" (selectionChange)="updateOrganist(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
-            <mat-option *ngFor="let m of organists" [value]="m.id">{{ m.name }}</mat-option>
+            <mat-option *ngFor="let m of availableForDate(organists, ev.date)" [value]="m.id">{{ m.name }}</mat-option>
           </mat-select>
         </ng-container>
         <ng-template #organistText>{{ ev.organist?.name }}</ng-template>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -8,6 +8,7 @@ import { ApiService } from '@core/services/api.service';
 import { MonthlyPlan } from '@core/models/monthly-plan';
 import { PlanEntry } from '@core/models/plan-entry';
 import { UserInChoir } from '@core/models/user';
+import { MemberAvailability } from '@core/models/member-availability';
 import { AuthService } from '@core/services/auth.service';
 import { Subscription } from 'rxjs';
 import { PlanEntryDialogComponent } from './plan-entry-dialog/plan-entry-dialog.component';
@@ -32,6 +33,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   directors: UserInChoir[] = [];
   organists: UserInChoir[] = [];
   currentUserId: number | null = null;
+  availabilityMap: { [userId: number]: { [date: string]: string } } = {};
   private userSub?: Subscription;
 
   private updateDisplayedColumns(): void {
@@ -41,6 +43,25 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
 
   private sortEntries(): void {
     this.entries.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }
+
+  private loadAvailabilities(year: number, month: number): void {
+    this.api.getMemberAvailabilities(year, month).subscribe(av => {
+      this.availabilityMap = {};
+      for (const a of av) {
+        if (!this.availabilityMap[a.userId]) this.availabilityMap[a.userId] = {};
+        this.availabilityMap[a.userId][a.date] = a.status;
+      }
+    });
+  }
+
+  isAvailable(userId: number, date: string): boolean {
+    const status = this.availabilityMap[userId]?.[date];
+    return !status || status === 'AVAILABLE' || status === 'MAYBE';
+  }
+
+  availableForDate(list: UserInChoir[], date: string): UserInChoir[] {
+    return list.filter(u => this.isAvailable(u.id, date));
   }
 
   constructor(private api: ApiService,
@@ -53,6 +74,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.selectedYear = now.getFullYear();
     this.selectedMonth = now.getMonth() + 1;
     this.loadPlan(this.selectedYear, this.selectedMonth);
+    this.loadAvailabilities(this.selectedYear, this.selectedMonth);
     this.userSub = this.auth.currentUser$.subscribe(u => this.currentUserId = u?.id || null);
     this.api.checkChoirAdminStatus().subscribe(r => { this.isChoirAdmin = r.isChoirAdmin; this.updateDisplayedColumns(); });
     this.api.getChoirMembers().subscribe(m => {
@@ -72,10 +94,12 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
       },
       error: () => { this.plan = null; this.entries = []; this.updateDisplayedColumns(); }
     });
+    this.loadAvailabilities(year, month);
   }
 
   monthChanged(): void {
     this.loadPlan(this.selectedYear, this.selectedMonth);
+    this.loadAvailabilities(this.selectedYear, this.selectedMonth);
   }
 
   updateDirector(ev: PlanEntry, userId: number | null): void {


### PR DESCRIPTION
## Summary
- expose new choir-wide availability endpoint in the backend
- provide API method for fetching member availability
- filter the director and organist selection lists based on availability

## Testing
- `npm test --silent --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686aabc185d88320bde1f03499f55eb8