### PR TITLE
Remove type field from plan entries

### DIFF
--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -24,7 +24,6 @@ async function createEntriesFromRules(plan) {
             await db.plan_entry.create({
                 monthlyPlanId: plan.id,
                 date,
-                type: rule.type,
                 notes: rule.notes || null
             });
         }

--- a/choir-app-backend/src/controllers/planEntry.controller.js
+++ b/choir-app-backend/src/controllers/planEntry.controller.js
@@ -3,12 +3,12 @@ const PlanEntry = db.plan_entry;
 const User = db.user;
 
 exports.create = async (req, res) => {
-    const { monthlyPlanId, date, type, notes, directorId, organistId } = req.body;
-    if (!monthlyPlanId || !date || !type) {
-        return res.status(400).send({ message: 'monthlyPlanId, date and type are required.' });
+    const { monthlyPlanId, date, notes, directorId, organistId } = req.body;
+    if (!monthlyPlanId || !date) {
+        return res.status(400).send({ message: 'monthlyPlanId and date are required.' });
     }
     try {
-        const entry = await PlanEntry.create({ monthlyPlanId, date, type, notes, directorId, organistId });
+        const entry = await PlanEntry.create({ monthlyPlanId, date, notes, directorId, organistId });
         const full = await PlanEntry.findByPk(entry.id, {
             include: [
                 { model: User, as: 'director', attributes: ['id', 'name'] },

--- a/choir-app-backend/src/controllers/planRule.controller.js
+++ b/choir-app-backend/src/controllers/planRule.controller.js
@@ -11,14 +11,13 @@ exports.findAll = async (req, res) => {
 };
 
 exports.create = async (req, res) => {
-  const { type, dayOfWeek, weeks, notes } = req.body;
-  if (typeof dayOfWeek !== 'number' || !type) {
-    return res.status(400).send({ message: 'type and dayOfWeek required' });
+  const { dayOfWeek, weeks, notes } = req.body;
+  if (typeof dayOfWeek !== 'number') {
+    return res.status(400).send({ message: 'dayOfWeek required' });
   }
   try {
     const rule = await PlanRule.create({
       choirId: req.activeChoirId,
-      type,
       dayOfWeek,
       weeks,
       notes
@@ -31,11 +30,11 @@ exports.create = async (req, res) => {
 
 exports.update = async (req, res) => {
   const id = req.params.id;
-  const { type, dayOfWeek, weeks, notes } = req.body;
+  const { dayOfWeek, weeks, notes } = req.body;
   try {
     const rule = await PlanRule.findOne({ where: { id, choirId: req.activeChoirId } });
     if (!rule) return res.status(404).send({ message: 'Rule not found.' });
-    await rule.update({ type, dayOfWeek, weeks, notes });
+    await rule.update({ dayOfWeek, weeks, notes });
     res.status(200).send(rule);
   } catch (err) {
     res.status(500).send({ message: err.message || 'Could not update rule.' });

--- a/choir-app-backend/src/models/plan_entry.model.js
+++ b/choir-app-backend/src/models/plan_entry.model.js
@@ -4,10 +4,6 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.DATE,
             allowNull: false
         },
-        type: {
-            type: DataTypes.ENUM('REHEARSAL', 'SERVICE'),
-            allowNull: false
-        },
         notes: {
             type: DataTypes.TEXT,
             allowNull: true

--- a/choir-app-backend/src/models/plan_rule.model.js
+++ b/choir-app-backend/src/models/plan_rule.model.js
@@ -1,9 +1,5 @@
 module.exports = (sequelize, DataTypes) => {
     const PlanRule = sequelize.define('plan_rule', {
-        type: {
-            type: DataTypes.ENUM('REHEARSAL', 'SERVICE'),
-            allowNull: false
-        },
         dayOfWeek: {
             type: DataTypes.INTEGER,
             allowNull: false

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -30,7 +30,7 @@ const db = require('../src/models');
     checkFields(db.piece_change, ['data']);
     checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'fromAddress']);
-    checkFields(db.plan_rule, ['type', 'dayOfWeek', 'weeks', 'notes']);
+    checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
 
     // Basic association checks
     assert(db.user.associations.choirs, 'User should have choirs association');

--- a/choir-app-backend/tests/monthlyPlan.controller.test.js
+++ b/choir-app-backend/tests/monthlyPlan.controller.test.js
@@ -10,7 +10,7 @@ const controller = require('../src/controllers/monthlyPlan.controller');
   try {
     await db.sequelize.sync({ force: true });
     const choir = await db.choir.create({ name: 'Test Choir', modules: { dienstplan: true } });
-    await db.plan_rule.create({ choirId: choir.id, type: 'SERVICE', dayOfWeek: 0 });
+    await db.plan_rule.create({ choirId: choir.id, dayOfWeek: 0 });
     const baseReq = { activeChoirId: choir.id };
     const res = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
 

--- a/choir-app-frontend/src/app/core/models/plan-entry.ts
+++ b/choir-app-frontend/src/app/core/models/plan-entry.ts
@@ -1,7 +1,6 @@
 export interface PlanEntry {
   id: number;
   date: string;
-  type: 'REHEARSAL' | 'SERVICE';
   notes?: string;
   director?: { id: number; name: string };
   organist?: { id: number; name: string } | null;

--- a/choir-app-frontend/src/app/core/models/plan-rule.ts
+++ b/choir-app-frontend/src/app/core/models/plan-rule.ts
@@ -1,7 +1,6 @@
 export interface PlanRule {
     id: number;
     choirId: number;
-    type: 'REHEARSAL' | 'SERVICE';
     dayOfWeek: number;
     weeks: number[] | null;
     notes?: string | null;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -295,11 +295,11 @@ export class ApiService {
   }
 
   // --- Plan Entry Methods ---
-  createPlanEntry(data: { monthlyPlanId: number; date: string; type: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  createPlanEntry(data: { monthlyPlanId: number; date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
     return this.planEntryService.createPlanEntry(data);
   }
 
-  updatePlanEntry(id: number, data: { date: string; type: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  updatePlanEntry(id: number, data: { date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
     return this.planEntryService.updatePlanEntry(id, data);
   }
 
@@ -329,11 +329,11 @@ export class ApiService {
     return this.planRuleService.getPlanRules();
   }
 
-  createPlanRule(data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+  createPlanRule(data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
     return this.planRuleService.createPlanRule(data);
   }
 
-  updatePlanRule(id: number, data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+  updatePlanRule(id: number, data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
     return this.planRuleService.updatePlanRule(id, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/plan-entry.service.ts
+++ b/choir-app-frontend/src/app/core/services/plan-entry.service.ts
@@ -10,11 +10,11 @@ export class PlanEntryService {
 
   constructor(private http: HttpClient) {}
 
-  createPlanEntry(data: { monthlyPlanId: number; date: string; type: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  createPlanEntry(data: { monthlyPlanId: number; date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
     return this.http.post<PlanEntry>(`${this.apiUrl}/plan-entries`, data);
   }
 
-  updatePlanEntry(id: number, data: { date: string; type: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  updatePlanEntry(id: number, data: { date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
     return this.http.put<PlanEntry>(`${this.apiUrl}/plan-entries/${id}`, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/plan-rule.service.ts
+++ b/choir-app-frontend/src/app/core/services/plan-rule.service.ts
@@ -14,11 +14,11 @@ export class PlanRuleService {
     return this.http.get<PlanRule[]>(`${this.apiUrl}/plan-rules`);
   }
 
-  createPlanRule(data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+  createPlanRule(data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
     return this.http.post<PlanRule>(`${this.apiUrl}/plan-rules`, data);
   }
 
-  updatePlanRule(id: number, data: { type: string; dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
+  updatePlanRule(id: number, data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
     return this.http.put<PlanRule>(`${this.apiUrl}/plan-rules/${id}`, data);
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -228,13 +228,13 @@ export class ManageChoirComponent implements OnInit {
     const ops = [] as Observable<any>[];
 
     if (this.sundayRuleId) {
-      ops.push(this.apiService.updatePlanRule(this.sundayRuleId, { type: 'SERVICE', dayOfWeek: 0, weeks: sundayWeeks }));
+      ops.push(this.apiService.updatePlanRule(this.sundayRuleId, { dayOfWeek: 0, weeks: sundayWeeks }));
     } else {
-      ops.push(this.apiService.createPlanRule({ type: 'SERVICE', dayOfWeek: 0, weeks: sundayWeeks }));
+      ops.push(this.apiService.createPlanRule({ dayOfWeek: 0, weeks: sundayWeeks }));
     }
 
     if (this.weekdayDay !== null) {
-      const data = { type: 'SERVICE', dayOfWeek: this.weekdayDay, weeks: weekdayWeeks };
+      const data = { dayOfWeek: this.weekdayDay, weeks: weekdayWeeks };
       if (this.weekdayRuleId) {
         ops.push(this.apiService.updatePlanRule(this.weekdayRuleId, data));
       } else {

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -16,10 +16,6 @@
       <th mat-header-cell *matHeaderCellDef>Datum</th>
       <td mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</td>
     </ng-container>
-    <ng-container matColumnDef="type">
-      <th mat-header-cell *matHeaderCellDef>Typ</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.type }}</td>
-    </ng-container>
     <ng-container matColumnDef="director">
       <th mat-header-cell *matHeaderCellDef>Chorleiter</th>
       <td mat-cell *matCellDef="let ev">

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -24,7 +24,7 @@ import { AvailabilityTableComponent } from './availability-table/availability-ta
 export class MonthlyPlanComponent implements OnInit, OnDestroy {
   plan: MonthlyPlan | null = null;
   entries: PlanEntry[] = [];
-  displayedColumns = ['date', 'type', 'director', 'organist', 'notes'];
+  displayedColumns = ['date', 'director', 'organist', 'notes'];
   isChoirAdmin = false;
   selectedYear!: number;
   selectedMonth!: number;
@@ -38,7 +38,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   private userSub?: Subscription;
 
   private updateDisplayedColumns(): void {
-    const base = ['date', 'type', 'director', 'organist', 'notes'];
+    const base = ['date', 'director', 'organist', 'notes'];
     this.displayedColumns = (this.isChoirAdmin && !this.plan?.finalized) ? [...base, 'actions'] : base;
   }
 
@@ -120,7 +120,6 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   updateDirector(ev: PlanEntry, userId: number | null): void {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
-      type: ev.type,
       notes: ev.notes || '',
       directorId: userId ?? undefined,
       organistId: ev.organist?.id || undefined
@@ -133,7 +132,6 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   updateOrganist(ev: PlanEntry, userId: number | null): void {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
-      type: ev.type,
       notes: ev.notes || '',
       directorId: ev.director?.id,
       organistId: userId ?? undefined

--- a/choir-app-frontend/src/app/features/monthly-plan/plan-entry-dialog/plan-entry-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/plan-entry-dialog/plan-entry-dialog.component.html
@@ -8,13 +8,6 @@
         <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>
       </mat-form-field>
-      <mat-form-field appearance="outline">
-        <mat-label>Typ</mat-label>
-        <mat-select formControlName="type">
-          <mat-option value="SERVICE">Gottesdienst</mat-option>
-          <mat-option value="REHEARSAL">Probe</mat-option>
-        </mat-select>
-      </mat-form-field>
     </div>
     <mat-form-field appearance="outline" class="full-width">
       <mat-label>Notizen</mat-label>

--- a/choir-app-frontend/src/app/features/monthly-plan/plan-entry-dialog/plan-entry-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/plan-entry-dialog/plan-entry-dialog.component.ts
@@ -18,7 +18,6 @@ export class PlanEntryDialogComponent {
               public dialogRef: MatDialogRef<PlanEntryDialogComponent>) {
     this.form = this.fb.group({
       date: [new Date(), Validators.required],
-      type: ['SERVICE', Validators.required],
       notes: ['']
     });
   }


### PR DESCRIPTION
## Summary
- simplify plan entry by removing `type`
- adjust plan rules accordingly
- drop type column from schedule UI

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab63ad5e48320973d10c6592c7586