### PR TITLE
Allow entering availabilities without monthly plan

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -84,13 +84,13 @@
     </table>
   </div>
 
-  <div>
-    <h3>Meine Verfügbarkeiten</h3>
-  <app-availability-table [year]="selectedYear" [month]="selectedMonth"></app-availability-table>
-  </div>
-  
 </div>
 <ng-template #noPlan>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>
   <button *ngIf="isChoirAdmin" mat-raised-button color="primary" (click)="createPlan()">Plan erstellen</button>
 </ng-template>
+
+<div>
+  <h3>Meine Verfügbarkeiten</h3>
+  <app-availability-table [year]="selectedYear" [month]="selectedMonth"></app-availability-table>
+</div>


### PR DESCRIPTION
## Summary
- show availability input even when no monthly plan exists

## Testing
- `npm test` *(fails: `ng: not found`)*
- `npm test --prefix choir-app-backend` *(fails: `Cannot find module 'sequelize'`)*

------
https://chatgpt.com/codex/tasks/task_e_686ab6650cc8832081c114b06c07fbfe