### PR TITLE
Fix availability color update

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -6,7 +6,7 @@
   <ng-container matColumnDef="status">
     <th mat-header-cell *matHeaderCellDef>Status</th>
     <td mat-cell *matCellDef="let a" [ngClass]="cellClass(a.status)">
-      <mat-select [value]="a.status" (selectionChange)="setStatus(a.date, $event.value)">
+      <mat-select [value]="a.status" (selectionChange)="setStatus(a.date, $any($event.value))">
         <mat-option value="AVAILABLE">verfügbar</mat-option>
         <mat-option value="MAYBE">verfügbar nach Absprache</mat-option>
         <mat-option value="UNAVAILABLE">nicht verfügbar</mat-option>

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
@@ -28,7 +28,7 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
       .subscribe(a => this.availabilities = a);
   }
 
-  setStatus(date: string, status: string): void {
+  setStatus(date: string, status: UserAvailability['status']): void {
     const i = this.availabilities.findIndex(v => v.date === date);
     if (i >= 0) this.availabilities[i].status = status;
 


### PR DESCRIPTION
## Summary
- ensure availability entry updates immediately on change

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: missing module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686b55fc9614832083ae519615fd6901