### PR TITLE
Add weekday to availability dates

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -1,7 +1,7 @@
 <table mat-table [dataSource]="availabilities" class="mat-elevation-z2">
   <ng-container matColumnDef="date">
     <th mat-header-cell *matHeaderCellDef>Datum</th>
-    <td mat-cell *matCellDef="let a">{{ a.date | date:'shortDate' }}</td>
+    <td mat-cell *matCellDef="let a">{{ a.date | date:'EEE dd.MM.yyyy' }}</td>
   </ng-container>
   <ng-container matColumnDef="status">
     <th mat-header-cell *matHeaderCellDef>Status</th>


### PR DESCRIPTION
## Summary
- show the short weekday name together with the date in the availability table

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686b56268ec08320a65514511fe88966