### PR TITLE
Fix loading of service plan rules

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -73,12 +73,12 @@ export class ManageChoirComponent implements OnInit {
         this.isChoirAdmin = pageData.isChoirAdmin;
         this.dienstplanEnabled = !!pageData.choirDetails.modules?.dienstplan;
         const rules = pageData.planRules as any[] || [];
-        const sundayRule = rules.find(r => r.type === 'SERVICE' && r.dayOfWeek === 0);
+        const sundayRule = rules.find(r => r.dayOfWeek === 0);
         if (sundayRule) {
           this.sundayRuleId = sundayRule.id;
           this.sundayWeeks = sundayRule.weeks && sundayRule.weeks.length ? sundayRule.weeks : [0];
         }
-        const weekdayRule = rules.find(r => r.type === 'SERVICE' && (r.dayOfWeek === 3 || r.dayOfWeek === 4));
+        const weekdayRule = rules.find(r => r.dayOfWeek === 3 || r.dayOfWeek === 4);
         if (weekdayRule) {
           this.weekdayRuleId = weekdayRule.id;
           this.weekdayDay = weekdayRule.dayOfWeek;


### PR DESCRIPTION
## Summary
- load plan rules by weekday in "Mein Chor" without filtering by non-existent type

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686b73023dbc83209a63ad0e953edaa6