### PR TITLE
Add general admin settings page

### DIFF
--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -6,13 +6,12 @@ export const adminRoutes: Routes = [
     path: '',
     component: MainLayoutComponent,
     children: [
-      { path: '', redirectTo: 'creators', pathMatch: 'full' },
+      { path: '', redirectTo: 'general', pathMatch: 'full' },
+      { path: 'general', loadComponent: () => import('./general/general-settings.component').then(m => m.GeneralSettingsComponent) },
       { path: 'creators', loadComponent: () => import('./manage-creators/manage-creators.component').then(m => m.ManageCreatorsComponent) },
       { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent) },
       { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent) },
-      { path: 'backup', loadComponent: () => import('./backup/backup.component').then(m => m.BackupComponent) },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent) },
-      { path: 'mail-settings', loadComponent: () => import('./mail-settings/mail-settings.component').then(m => m.MailSettingsComponent) },
     ],
   },
 ];

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.html
@@ -1,0 +1,14 @@
+<mat-accordion>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>Mail-Server</mat-panel-title>
+    </mat-expansion-panel-header>
+    <app-mail-settings></app-mail-settings>
+  </mat-expansion-panel>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>Backup</mat-panel-title>
+    </mat-expansion-panel-header>
+    <app-backup></app-backup>
+  </mat-expansion-panel>
+</mat-accordion>

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.scss
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.scss
@@ -1,0 +1,3 @@
+mat-accordion {
+  width: 100%;
+}

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { MailSettingsComponent } from '../mail-settings/mail-settings.component';
+import { BackupComponent } from '../backup/backup.component';
+
+@Component({
+  selector: 'app-general-settings',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, MailSettingsComponent, BackupComponent],
+  templateUrl: './general-settings.component.html',
+  styleUrls: ['./general-settings.component.scss']
+})
+export class GeneralSettingsComponent { }

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -195,7 +195,11 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
         visibleSubject: this.isAdmin$,
         route: '',
         children: [
-            {
+          {
+            displayName: 'Allgemein',
+            route: '/admin/general',
+          },
+          {
             displayName: 'Chöre',
             route: '/admin/choirs',
           },
@@ -208,16 +212,8 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
             route: '/admin/creators'
           },
           {
-            displayName: 'Backup',
-            route: '/admin/backup',
-          },
-          {
             displayName: 'Protokolle',
             route: '/admin/protocols',
-          },
-          {
-            displayName: 'Mail-Server',
-            route: '/admin/mail-settings',
           }
         ]
       }


### PR DESCRIPTION
## Summary
- add a new `general-settings` admin page
- use expansion panels for Mail-Server and Backup settings
- register the new page in admin routes
- put "Allgemein" as the first item in the admin menu

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8466db8c8320bb3fb86b29cb82b9