### PR TITLE
Fix log file deletion

### DIFF
--- a/choir-app-backend/src/services/log.service.js
+++ b/choir-app-backend/src/services/log.service.js
@@ -65,6 +65,11 @@ async function deleteLogFile(filename) {
         return true;
     } catch (err) {
         if (err.code === 'ENOENT') return false;
+        if (err.code === 'EPERM') {
+            // On Windows the file might still be locked by the logger
+            await fs.promises.truncate(filePath, 0);
+            return true;
+        }
         throw err;
     }
 }


### PR DESCRIPTION
## Summary
- fix log deletion on Windows by truncating when unlink fails

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: module 'sequelize' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8c45ff8c83209dbd49c76122fcda