### PR TITLE
Add dialog for piece details

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -97,7 +97,9 @@
             <ng-container matColumnDef="title">
               <!-- mat-sort-header tells the table this column is sortable. 'title' must match the column name. -->
               <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
-              <td mat-cell *matCellDef="let piece"> {{piece.title}} </td>
+              <td mat-cell *matCellDef="let piece">
+                <a href="#" (click)="openPieceDetailDialog(piece.id); $event.preventDefault()" class="title-link">{{ piece.title }}</a>
+              </td>
             </ng-container>
 
             <!-- Composer Column -->

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -157,3 +157,9 @@ table-container {
   max-width: 100%;
   max-height: 200px;
 }
+
+.title-link {
+  cursor: pointer;
+  color: #3f51b5;
+  text-decoration: underline;
+}

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -17,6 +17,7 @@ import { Piece } from 'src/app/core/models/piece';
 import { Collection } from 'src/app/core/models/collection';
 import { Category } from 'src/app/core/models/category';
 import { PieceDialogComponent } from '../piece-dialog/piece-dialog.component';
+import { PieceDetailDialogComponent } from '../piece-detail-dialog/piece-detail-dialog.component';
 import { RepertoireFilter } from '@core/models/repertoire-filter';
 import { FilterPresetService } from '@core/services/filter-preset.service';
 import { AuthService } from '@core/services/auth.service';
@@ -366,6 +367,13 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         // Trigger a refresh of the repertoire list to show the new piece.
         this.refresh$.next();
       }
+    });
+  }
+
+  openPieceDetailDialog(pieceId: number): void {
+    this.dialog.open(PieceDetailDialogComponent, {
+      width: '600px',
+      data: { pieceId }
     });
   }
 

--- a/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.html
@@ -1,0 +1,26 @@
+<h1 mat-dialog-title>{{ piece?.title }}</h1>
+<div mat-dialog-content *ngIf="piece">
+  <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
+  <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
+  <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
+  <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>
+
+  <h3>Geprobt bei</h3>
+  <mat-list *ngIf="piece.events?.length; else noEvents">
+    <mat-list-item *ngFor="let ev of piece.events">
+      <div matLine>
+        <a [routerLink]="['/events']" [queryParams]="{ eventId: ev.id }">
+          {{ ev.date | date:'mediumDate' }}
+        </a>
+        - {{ ev.type | eventTypeLabel }}
+      </div>
+      <div matLine>{{ ev.notes }}</div>
+    </mat-list-item>
+  </mat-list>
+  <ng-template #noEvents>
+    <p>Keine Einträge</p>
+  </ng-template>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Schließen</button>
+</div>

--- a/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.scss
@@ -1,0 +1,3 @@
+.piece-detail-dialog {
+  max-width: 600px;
+}

--- a/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.ts
@@ -1,0 +1,29 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Piece } from '@core/models/piece';
+import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
+import { PieceStatusLabelPipe } from '@shared/pipes/piece-status-label.pipe';
+
+@Component({
+  selector: 'app-piece-detail-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, EventTypeLabelPipe, PieceStatusLabelPipe],
+  templateUrl: './piece-detail-dialog.component.html',
+  styleUrls: ['./piece-detail-dialog.component.scss']
+})
+export class PieceDetailDialogComponent implements OnInit {
+  piece?: Piece;
+
+  constructor(
+    private apiService: ApiService,
+    public dialogRef: MatDialogRef<PieceDetailDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { pieceId: number }
+  ) {}
+
+  ngOnInit(): void {
+    this.apiService.getRepertoirePiece(this.data.pieceId).subscribe(p => this.piece = p);
+  }
+}


### PR DESCRIPTION
## Summary
- add PieceDetailDialog component
- link titles in the repertoire table to open the detail dialog

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb02a7fbc8320b32752d6ce8624e7