### PR TITLE
Add multi-status filter for repertoire

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -74,6 +74,10 @@ exports.lookup = async (req, res) => {
 
 exports.findMyRepertoire = async (req, res) => {
     const { composerId, categoryId, categoryIds, collectionId, sortBy, sortDir = 'ASC', status, page = 1, limit = 25, voicing, key, search } = req.query;
+    let parsedStatuses = [];
+    if (status) {
+        parsedStatuses = Array.isArray(status) ? status : String(status).split(',');
+    }
     let parsedCategoryIds = [];
     if (categoryIds) {
         parsedCategoryIds = Array.isArray(categoryIds) ? categoryIds : String(categoryIds).split(',');
@@ -88,7 +92,10 @@ exports.findMyRepertoire = async (req, res) => {
         // --- SCHRITT 1: Holen Sie die Basis-Repertoire-Daten des Chors ---
         // Wir holen nur die pieceId und den zugehörigen Status.
         const repertoireLinks = await db.choir_repertoire.findAll({
-            where: { choirId: req.activeChoirId, ...(status && { status }) },
+            where: {
+                choirId: req.activeChoirId,
+                ...(parsedStatuses.length && { status: { [Op.in]: parsedStatuses } })
+            },
             raw: true // Gibt uns einfache Objekte statt Sequelize-Instanzen
         });
 

--- a/choir-app-frontend/src/app/core/models/repertoire-filter.ts
+++ b/choir-app-frontend/src/app/core/models/repertoire-filter.ts
@@ -6,7 +6,16 @@ export interface RepertoireFilter {
     collectionId?: number | null;
     categoryIds?: number[];
     onlySingable?: boolean;
+    /**
+     * Legacy single-status field. Kept for backwards compatibility when
+     * loading older presets or local storage state.
+     */
     status?: 'CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY' | null;
+    /**
+     * New multi status selection. When set, this takes precedence over the
+     * legacy `status` property.
+     */
+    statuses?: ('CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY')[];
     search?: string;
   };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -77,11 +77,19 @@ export class ApiService {
     composerId?: number,
     categoryIds?: number[],
     collectionId?: number,
-    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection' |
-            'lastSung' | 'lastRehearsed' | 'timesSung' | 'timesRehearsed',
+    sortBy?:
+      | 'title'
+      | 'reference'
+      | 'composer'
+      | 'category'
+      | 'collection'
+      | 'lastSung'
+      | 'lastRehearsed'
+      | 'timesSung'
+      | 'timesRehearsed',
     page: number = 1,
     limit: number = 25,
-    status?: string,
+    statuses?: string[],
     sortDir: 'ASC' | 'DESC' = 'ASC',
     search?: string
   ): Observable<{ data: Piece[]; total: number }> {
@@ -92,7 +100,7 @@ export class ApiService {
       sortBy,
       page,
       limit,
-      status,
+      statuses,
       sortDir,
       search
     );

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -17,11 +17,19 @@ export class PieceService {
   getMyRepertoire(
     categoryIds?: number[],
     collectionId?: number,
-    sortBy?: 'title' | 'reference' | 'composer' | 'category' | 'collection' |
-             'lastSung' | 'lastRehearsed' | 'timesSung' | 'timesRehearsed',
+    sortBy?:
+      | 'title'
+      | 'reference'
+      | 'composer'
+      | 'category'
+      | 'collection'
+      | 'lastSung'
+      | 'lastRehearsed'
+      | 'timesSung'
+      | 'timesRehearsed',
     page = 1,
     limit = 25,
-    status?: string,
+    statuses?: string[],
     sortDir: 'ASC' | 'DESC' = 'ASC',
     search?: string
   ): Observable<{ data: Piece[]; total: number }> {
@@ -35,7 +43,7 @@ export class PieceService {
     params = params.set('limit', limit.toString());
     // Avoid sending empty sortDir which causes an empty query parameter
     params = params.set('sortDir', sortDir || 'ASC');
-    if (status) params = params.set('status', status);
+    if (statuses && statuses.length) params = params.set('status', statuses.join(','));
     if (search) params = params.set('search', search);
 
     return this.http.get<{ data: Piece[]; total: number }>(`${this.apiUrl}/repertoire`, { params });

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -29,8 +29,7 @@
       </mat-checkbox>
       <mat-form-field appearance="outline">
         <mat-label>Status</mat-label>
-        <mat-select [value]="status$.value" (selectionChange)="onStatusFilterChange($event.value)">
-          <mat-option [value]="null">Alle</mat-option>
+        <mat-select multiple [value]="status$.value" (selectionChange)="onStatusFilterChange($event.value)">
           <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>
           <mat-option value="IN_REHEARSAL">Wird geprobt</mat-option>
           <mat-option value="NOT_READY">Nicht im Repertoire</mat-option>


### PR DESCRIPTION
## Summary
- update frontend filter model to support multiple statuses
- allow selecting several statuses in repertoire list filter and save them
- handle multi-status presets and local storage
- pass status array to API and backend
- update backend to accept comma-separated status filter

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686bd95e52e883209a5b97d1232bf182