### PR TITLE
Add tabs for schedule and availabilities

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -9,7 +9,9 @@
   </mat-form-field>
 </div>
 
-<div class="plan" *ngIf="plan; else noPlan">
+<mat-tab-group>
+  <mat-tab label="Dienstplan">
+    <div class="plan" *ngIf="plan; else noPlan">
   <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
   <table mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">
@@ -80,13 +82,16 @@
     </table>
   </div>
 
-</div>
+    </div>
+  </mat-tab>
+  <mat-tab label="Verfügbarkeiten">
+    <div>
+      <h3>Meine Verfügbarkeiten</h3>
+      <app-availability-table [year]="selectedYear" [month]="selectedMonth"></app-availability-table>
+    </div>
+  </mat-tab>
+</mat-tab-group>
 <ng-template #noPlan>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>
   <button *ngIf="isChoirAdmin" mat-raised-button color="primary" (click)="createPlan()">Plan erstellen</button>
 </ng-template>
-
-<div>
-  <h3>Meine Verfügbarkeiten</h3>
-  <app-availability-table [year]="selectedYear" [month]="selectedMonth"></app-availability-table>
-</div>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -19,3 +19,12 @@
     text-align: center;
   }
 }
+
+:host {
+  display: block;
+  padding: 16px;
+}
+
+mat-tab-group {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- split monthly plan into two tabs: Dienstplan and Verfügbarkeiten
- adjust styling for new tab layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf79828288320b97a0aa7d743931e