### PR TITLE
Show user name near avatar

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -18,6 +18,7 @@
     <button mat-icon-button [matMenuTriggerFor]="userMenu" matTooltip="Benutzerprofil">
       <mat-icon style="color:white"><img src="./../../assets/icons/user-filled.svg"></mat-icon>
     </button>
+    <span class="user-name">{{ userName$ | async }}</span>
     <mat-menu #userMenu="matMenu">
       <a mat-menu-item routerLink="/profile">
         <mat-icon><img src="./../../assets/icons/user-filled.svg"></mat-icon>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
@@ -76,6 +76,12 @@
   padding: 0.5rem;
 }
 
+.user-name {
+  margin-left: 0.5rem;
+  color: white;
+  font-weight: 500;
+}
+
 @media (max-width: 599px) {
   .appDrawer {
     width: 70vw;

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -44,6 +44,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
   isLoggedIn$: Observable<boolean>;
   isAdmin$: Observable<boolean>;
   donatedRecently$: Observable<boolean>;
+  userName$: Observable<string | undefined>;
   currentTheme: Theme;
   showAdminSubmenu: boolean = true;
   isExpanded = true;
@@ -76,6 +77,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
   ) {
     this.isLoggedIn$ = this.authService.isLoggedIn$;
     this.isAdmin$ = this.authService.isAdmin$;
+    this.userName$ = this.authService.currentUser$.pipe(map(u => u?.name));
     this.donatedRecently$ = this.authService.currentUser$.pipe(
       map(u => {
         if (!u?.lastDonation) return false;


### PR DESCRIPTION
## Summary
- display the current user's name next to the profile icon in the toolbar

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf91dce1c8320aeea6c7342c299fd