### PR TITLE
Add search box component and API method

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -577,4 +577,9 @@ export class ApiService {
   deleteRepertoireFilter(id: number): Observable<any> {
     return this.filterPresetService.deletePreset(id);
   }
+
+  searchAll(term: string): Observable<any[]> {
+    const params = new HttpParams().set('q', term);
+    return this.http.get<any[]>(`${this.apiUrl}/search`, { params });
+  }
 }

--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.html
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.html
@@ -1,0 +1,1 @@
+<input type="text" [(ngModel)]="query" (input)="onInput()" />

--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+
+import { SearchBoxComponent } from './search-box.component';
+import { ApiService } from '@core/services/api.service';
+
+describe('SearchBoxComponent', () => {
+  let component: SearchBoxComponent;
+  let fixture: ComponentFixture<SearchBoxComponent>;
+  let api: ApiService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchBoxComponent, HttpClientTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchBoxComponent);
+    component = fixture.componentInstance;
+    api = TestBed.inject(ApiService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should query api on input', () => {
+    spyOn(api, 'searchAll').and.returnValue(of([]));
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'hello';
+    input.dispatchEvent(new Event('input'));
+    expect(api.searchAll).toHaveBeenCalledWith('hello');
+  });
+});

--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.ts
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.ts
@@ -1,0 +1,27 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '@core/services/api.service';
+
+@Component({
+  selector: 'app-search-box',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './search-box.component.html',
+  styleUrls: ['./search-box.component.scss']
+})
+export class SearchBoxComponent {
+  query = '';
+  @Output() results = new EventEmitter<any[]>();
+
+  constructor(private apiService: ApiService) {}
+
+  onInput(): void {
+    const term = this.query.trim();
+    if (!term) {
+      this.results.emit([]);
+      return;
+    }
+    this.apiService.searchAll(term).subscribe(res => this.results.emit(res));
+  }
+}


### PR DESCRIPTION
## Summary
- implement a new `searchAll` method in `ApiService`
- add `SearchBoxComponent` with template, styles and unit tests

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfb206ce08320b6cf0ec071edf3b6