### PR TITLE
Fix duplicate method and param order

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -582,9 +582,4 @@ export class ApiService {
   deleteRepertoireFilter(id: number): Observable<any> {
     return this.filterPresetService.deletePreset(id);
   }
-
-  searchAll(term: string): Observable<any[]> {
-    const params = new HttpParams().set('q', term);
-    return this.http.get<any[]>(`${this.apiUrl}/search`, { params });
-  }
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -281,7 +281,7 @@ export class ManageChoirComponent implements OnInit {
 
   private loadRehearsalPieces(): void {
     this.apiService
-      .getMyRepertoire(undefined, undefined, undefined, undefined, 100, ['IN_REHEARSAL'])
+      .getMyRepertoire(undefined, undefined, undefined, undefined, undefined, 100, ['IN_REHEARSAL'])
       .subscribe(res => (this.rehearsalDataSource.data = res.data));
   }
 }


### PR DESCRIPTION
## Summary
- remove duplicated `searchAll` method
- fix `getMyRepertoire` call parameter order

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfe850e8c8320a5227ca1fa972e62