### PR TITLE
Add direct link to piece detail

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -192,7 +192,9 @@
         <table mat-table [dataSource]="rehearsalDataSource">
           <ng-container matColumnDef="title">
             <th mat-header-cell *matHeaderCellDef> Titel </th>
-            <td mat-cell *matCellDef="let piece">{{ piece.title }}</td>
+            <td mat-cell *matCellDef="let piece">
+              <a href="#" (click)="openPieceDetailDialog(piece.id); $event.preventDefault()" class="title-link">{{ piece.title }}</a>
+            </td>
           </ng-container>
           <ng-container matColumnDef="composer">
             <th mat-header-cell *matHeaderCellDef> Komponist </th>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
@@ -85,6 +85,12 @@ mat-card-content form {
   align-items: center;
 }
 
+.title-link {
+  cursor: pointer;
+  color: #3f51b5;
+  text-decoration: underline;
+}
+
 @media (prefers-color-scheme: dark) {
   .loading-overlay {
     background: rgba(0, 0, 0, 0.5);

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -17,6 +17,7 @@ import { Piece } from 'src/app/core/models/piece';
 import { InviteUserDialogComponent } from '../invite-user-dialog/invite-user-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { ActivatedRoute } from '@angular/router';
+import { PieceDetailDialogComponent } from '@features/literature/piece-detail-dialog/piece-detail-dialog.component';
 
 
 @Component({
@@ -276,6 +277,13 @@ export class ManageChoirComponent implements OnInit {
           error: () => this.snackBar.open('Fehler beim Entfernen der Sammlung.', 'Schließen')
         });
       }
+    });
+  }
+
+  openPieceDetailDialog(pieceId: number): void {
+    this.dialog.open(PieceDetailDialogComponent, {
+      width: '600px',
+      data: { pieceId }
     });
   }
 


### PR DESCRIPTION
## Summary
- allow navigation to piece detail from rehearsal list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c002666e88320a88a5e940de44efb