### PR TITLE
Add reload button for repertoire list

### DIFF
--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -83,6 +83,9 @@
             <span>Anzahl geprobt</span>
           </button>
         </mat-menu>
+        <button mat-icon-button (click)="reloadList()" aria-label="Neu laden" matTooltip="Tabelle neu laden">
+          <mat-icon>refresh</mat-icon>
+        </button>
       </div>
 
       <div class="table-wrapper mat-elevation-z8">

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -542,6 +542,11 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     }
   }
 
+  reloadList(): void {
+    this.pageCache.clear();
+    this.refresh$.next();
+  }
+
   // ------- Hover Image Helpers -------
   onRowMouseEnter(event: MouseEvent, piece: Piece): void {
     if (!piece.imageIdentifier) {


### PR DESCRIPTION
## Summary
- add a reload button to the repertoire table filter bar
- implement `reloadList` method to refresh data

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c00f262e8832083ed6e6ac3b62a2b