### PR TITLE
Fix calendar selection null argument

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -39,8 +39,10 @@ export class MyCalendarComponent implements OnInit {
     return this.eventMap[key] ? 'has-event' : '';
   };
 
-  onSelectedChange(date: Date): void {
-    this.selectedDate = date;
+  onSelectedChange(date: Date | null): void {
+    if (date) {
+      this.selectedDate = date;
+    }
   }
 
   get eventsForSelectedDate(): Event[] {


### PR DESCRIPTION
## Summary
- handle `Date | null` in calendar component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c028adb2c8320a6e4a089c9b05aab