### PR TITLE
Fix duplicate Angular Material styles

### DIFF
--- a/choir-app-frontend/src/styles.scss
+++ b/choir-app-frontend/src/styles.scss
@@ -1,9 +1,16 @@
 @use '@angular/material' as mat;
 @use 'themes/_nak-theme' as nak;
 
-// Apply the light theme by default.
-// This will render all Angular Material components with the NAK colors.
-@include mat.all-component-themes(nak.$nak-theme);
+// Include Angular Material core styles once.
+@include mat.core();
+
+// Set up typography and density for the application. These are only included
+// once to avoid duplicated styles.
+@include mat.all-component-typographies(nak.$nak-theme);
+@include mat.all-component-densities(nak.$nak-theme);
+
+// Apply the light theme colors by default.
+@include mat.all-component-colors(nak.$nak-theme);
 
 
 /* You can keep your other global styles here */
@@ -33,7 +40,9 @@ mat-card-header {
 // Definieren Sie die Styles für das dunkle Theme unter einer spezifischen Klasse.
 // Diese Regeln werden nur aktiv, wenn der body-Tag die Klasse '.dark-theme' hat.
 .dark-theme {
-  @include mat.all-component-themes(nak.$nak-dark-theme);
+  // Only include the color styles for the dark theme to avoid duplicating
+  // typography and density rules.
+  @include mat.all-component-colors(nak.$nak-dark-theme);
 
   // Fügen Sie hier alle Ihre anderen Dark-Mode-Anpassungen hinzu
   body {

--- a/choir-app-frontend/src/themes/_nak-theme.scss
+++ b/choir-app-frontend/src/themes/_nak-theme.scss
@@ -1,8 +1,7 @@
 // Import the theming functions from Angular Material
 @use '@angular/material' as mat;
 
-// This is a required part of every custom theme.
-@include mat.core();
+// The core mixin is included in the global styles to avoid duplication.
 
 // ----------------------------------------------------------------------------------
 // Custom NAK Color Palettes


### PR DESCRIPTION
## Summary
- avoid generating Material theme styles multiple times by splitting theme mixins
- include `mat.core` in global styles and remove from theme file

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c029fefa883209315254ad2875328