### PR TITLE
Fix search for event types

### DIFF
--- a/choir-app-backend/src/controllers/search.controller.js
+++ b/choir-app-backend/src/controllers/search.controller.js
@@ -1,5 +1,5 @@
 const db = require('../models');
-const { Op } = require('sequelize');
+const { Op, where, cast, col } = require('sequelize');
 
 exports.search = async (req, res) => {
   const q = req.query.q || req.query.query || '';
@@ -16,7 +16,7 @@ exports.search = async (req, res) => {
         choirId: req.activeChoirId,
         [Op.or]: [
           { notes: like },
-          { type: like }
+          where(cast(col('type'), 'TEXT'), { [Op.iLike]: `%${q}%` })
         ]
       },
       order: [['date', 'DESC']],


### PR DESCRIPTION
## Summary
- fix 500 error in search endpoint by casting event type

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c03baf4f88320b65a1415da74c372