### PR TITLE
Filter available users when adding choir members

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { AddMemberDialogComponent } from './add-member-dialog.component';
 import { ApiService } from 'src/app/core/services/api.service';
@@ -15,7 +15,8 @@ describe('AddMemberDialogComponent', () => {
       imports: [AddMemberDialogComponent, HttpClientTestingModule, RouterTestingModule],
       providers: [
         { provide: MatDialogRef, useValue: {} },
-        { provide: ApiService, useValue: { getUsers: () => ({ subscribe: () => {} }) } }
+        { provide: ApiService, useValue: { getUsers: () => ({ subscribe: () => {} }) } },
+        { provide: MAT_DIALOG_DATA, useValue: [] }
       ]
     }).compileComponents();
 

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from 'src/app/core/services/api.service';
 import { User } from 'src/app/core/models/user';
@@ -22,7 +22,8 @@ export class AddMemberDialogComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<AddMemberDialogComponent>,
-    private api: ApiService
+    private api: ApiService,
+    @Inject(MAT_DIALOG_DATA) public existingMemberIds: number[] = []
   ) {
     this.form = this.fb.group({
       user: ['', Validators.required],
@@ -33,7 +34,7 @@ export class AddMemberDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.api.getUsers().subscribe(users => {
-      this.users = users;
+      this.users = users.filter(u => !this.existingMemberIds.includes(u.id));
       this.filteredUsers = this.form.controls['user'].valueChanges.pipe(
         startWith(''),
         map(value => typeof value === 'string' ? value : value?.email),

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -53,7 +53,8 @@ export class ChoirDialogComponent implements OnInit {
 
   openInviteDialog(): void {
     if (!this.data?.id) return;
-    const ref = this.dialog.open(AddMemberDialogComponent, { width: '450px' });
+    const memberIds = this.dataSource.data.map(m => m.id);
+    const ref = this.dialog.open(AddMemberDialogComponent, { width: '450px', data: memberIds });
     ref.afterClosed().subscribe(result => {
       if (result && result.email && result.role) {
         this.api.inviteUserToChoirAdmin(this.data!.id, result.email, result.role, result.isOrganist).subscribe({


### PR DESCRIPTION
## Summary
- pass current choir member IDs to `AddMemberDialog`
- filter out these IDs when retrieving users in the dialog
- update unit test setup to inject dialog data

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686c1a94799c832088923b63e7b93d4e