### PR TITLE
Fix 403 for directors on choir collections

### DIFF
--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -8,13 +8,14 @@ router.use(verifyToken);
 // Chor-Informationen können von allen Mitgliedern gelesen werden
 router.get("/", controller.getMyChoirDetails);
 
-// Alle folgenden Routen erfordern Choir-Admin-Rechte
+// Ab hier: Member-Management und Einstellungen nur für Choir-Admins
 router.put("/", isChoirAdminOrAdmin, controller.updateMyChoir);
 router.get("/members", isChoirAdminOrAdmin, controller.getChoirMembers);
 router.post("/members", isChoirAdminOrAdmin, controller.inviteUserToChoir);
 router.put("/members/:userId", isChoirAdminOrAdmin, controller.updateMember);
 router.delete("/members", isChoirAdminOrAdmin, controller.removeUserFromChoir);
-router.get("/collections", isChoirAdminOrAdmin, controller.getChoirCollections);
+// Sammlungen können von allen Mitgliedern eingesehen werden
+router.get("/collections", controller.getChoirCollections);
 router.delete("/collections/:id", isChoirAdminOrAdmin, controller.removeCollectionFromChoir);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- relax permissions for `/api/choir-management/collections`

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1fe5dd648320ad7115b52764fafc