### PR TITLE
Fix CSV import button visibility

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -6,7 +6,7 @@
     </div>
     <!-- Fügen Sie den Button nur im Edit-Modus hinzu -->
     <button
-      *ngIf="isEditMode"
+      *ngIf="isEditMode && isAdmin"
       mat-stroked-button
       color="accent"
       (click)="openImportDialog()">

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.spec.ts
@@ -3,6 +3,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { AuthService } from '@core/services/auth.service';
 
 import { CollectionEditComponent } from './collection-edit.component';
 
@@ -14,6 +16,7 @@ describe('CollectionEditComponent', () => {
     await TestBed.configureTestingModule({
       imports: [CollectionEditComponent, HttpClientTestingModule, RouterTestingModule],
       providers: [
+        { provide: AuthService, useValue: { isAdmin$: of(true) } },
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useValue: {} },

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/material/autocomplete';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
+import { AuthService } from '@core/services/auth.service';
 import { ImportDialogComponent } from '../import-dialog/import-dialog.component';
 
 import { MaterialModule } from '@modules/material.module';
@@ -67,6 +68,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     coverPreview: string | null = null;
     coverFile: File | null = null;
     isDragOver = false;
+    isAdmin = false;
     public readonly addNewPieceOption: Piece = {
         id: -1,
         title: 'Neues Stück anlegen...',
@@ -103,7 +105,8 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
         private router: Router,
         private route: ActivatedRoute,
         public dialog: MatDialog,
-        private paginatorService: PaginatorService
+        private paginatorService: PaginatorService,
+        private authService: AuthService
     ) {
         this.collectionForm = this.fb.group({
             title: ['', Validators.required],
@@ -123,6 +126,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     }
 
     ngOnInit(): void {
+        this.authService.isAdmin$.subscribe(v => (this.isAdmin = v));
         // --- Determine Edit/Create Mode (No Change Here) ---
         this.route.paramMap
             .pipe(


### PR DESCRIPTION
## Summary
- only allow admins to see the "Import aus CSV" button in CollectionEdit
- inject AuthService into CollectionEdit to determine admin state
- update spec with AuthService mock

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686c217eb27c83208b5ac834eab445f6