### PR TITLE
Fix monthly plan creation for selected date

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -217,8 +217,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   createPlan(): void {
-    const now = new Date();
-    this.api.createMonthlyPlan(now.getFullYear(), now.getMonth() + 1).subscribe(plan => {
+    this.api.createMonthlyPlan(this.selectedYear, this.selectedMonth).subscribe(plan => {
       this.plan = plan;
       this.loadPlan(plan.year, plan.month);
     });


### PR DESCRIPTION
## Summary
- ensure `createPlan()` uses the selected month and year

## Testing
- `npx ng test` *(fails: 403 Forbidden)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686c236bfa9c832082b5300a6896429f