### PR TITLE
Fix piece detail statistics

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -413,7 +413,7 @@ export class ApiService {
   }
 
   getRepertoirePiece(id: number): Observable<Piece> {
-    return this.pieceService.getPieceById(id); // using pieceService for single piece
+    return this.pieceService.getRepertoirePiece(id);
   }
 
   getMyChoirDetails(): Observable<Choir> {

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -85,6 +85,13 @@ export class PieceService {
     return this.http.get<Piece>(`${this.apiUrl}/pieces/${id}`);
   }
 
+  /**
+   * Load a piece from the choir's repertoire including event history.
+   */
+  getRepertoirePiece(id: number): Observable<Piece> {
+    return this.http.get<Piece>(`${this.apiUrl}/repertoire/${id}`);
+  }
+
   addPieceToMyRepertoire(pieceId: number): Observable<any> {
     return this.http.post(`${this.apiUrl}/repertoire/add-piece`, { pieceId });
   }


### PR DESCRIPTION
## Summary
- add `getRepertoirePiece` to PieceService
- use this method in ApiService so piece details include event history

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c23fcf30883209e8393297e07e2c0