### PR TITLE
Fix: enable global search box

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -5,7 +5,7 @@
 
   <span class="title"><a href="/" class="page-title-link">NAK Chorleiter</a></span>
 
-  <!--<app-search-box *ngIf="isLoggedIn$ | async"></app-search-box>-->
+  <app-search-box *ngIf="isLoggedIn$ | async"></app-search-box>
 
   <span class="spacer"></span>
   <ng-container *ngIf="(isLoggedIn$ | async) && !(donatedRecently$ | async)">


### PR DESCRIPTION
## Summary
- enable global search box in the main layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c267f1b90832093ff6995b17d5b16