### PR TITLE
Enable inline editing of notes in service schedule

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -49,7 +49,12 @@
     </ng-container>
     <ng-container matColumnDef="notes">
       <th mat-header-cell *matHeaderCellDef>Notizen</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.notes }}</td>
+      <td mat-cell *matCellDef="let ev">
+        <ng-container *ngIf="isChoirAdmin && !plan.finalized; else notesText">
+          <input matInput [(ngModel)]="ev.notes" (blur)="updateNotes(ev, ev.notes)" />
+        </ng-container>
+        <ng-template #notesText>{{ ev.notes }}</ng-template>
+      </td>
     </ng-container>
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef></th>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -175,6 +175,17 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     });
   }
 
+  updateNotes(ev: PlanEntry, notes: string): void {
+    this.api.updatePlanEntry(ev.id, {
+      date: ev.date,
+      notes,
+      directorId: ev.director?.id,
+      organistId: ev.organist?.id || undefined
+    }).subscribe(updated => {
+      ev.notes = updated.notes;
+    });
+  }
+
   finalizePlan(): void {
     if (this.plan) {
       this.api.finalizeMonthlyPlan(this.plan.id).subscribe(p => { this.plan = p; this.updateDisplayedColumns(); });


### PR DESCRIPTION
## Summary
- allow editing notes directly in monthly plan table

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c26f4015c83208d4d8992ffc4da07