### PR TITLE
Add notes for choir pieces

### DIFF
--- a/choir-app-backend/src/models/choir_repertoire.model.js
+++ b/choir-app-backend/src/models/choir_repertoire.model.js
@@ -9,6 +9,10 @@ module.exports = (sequelize, DataTypes) => {
         status: {
             type: DataTypes.ENUM('CAN_BE_SUNG', 'IN_REHEARSAL', 'NOT_READY'),
             defaultValue: 'NOT_READY'
+        },
+        notes: {
+            type: DataTypes.TEXT,
+            allowNull: true
         }
     });
     return ChoirRepertoire;

--- a/choir-app-backend/src/routes/repertoire.routes.js
+++ b/choir-app-backend/src/routes/repertoire.routes.js
@@ -6,6 +6,7 @@ router.use(authJwt.verifyToken);
 
 router.get("/", controller.findMyRepertoire);
 router.put("/status", controller.updateStatus);
+router.put("/notes", controller.updateNotes);
 router.post("/add-piece", controller.addPieceToRepertoire);
 router.get("/lookup", controller.lookup);
 router.get("/:id", controller.findOne);

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -19,6 +19,7 @@ export interface Piece {
   category?: Category;
   choir_repertoire?: {
     status: 'CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY';
+    notes?: string | null;
   };
   collections?: CollectionReference[];
   collectionPrefix?: string | null;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -120,6 +120,10 @@ export class ApiService {
     return this.pieceService.updatePieceStatus(pieceId, status);
   }
 
+  updatePieceNotes(pieceId: number, notes: string): Observable<any> {
+    return this.pieceService.updatePieceNotes(pieceId, notes);
+  }
+
 
   // --- Global Piece Methods ---
 

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -53,6 +53,10 @@ export class PieceService {
     return this.http.put(`${this.apiUrl}/repertoire/status`, { pieceId, status });
   }
 
+  updatePieceNotes(pieceId: number, notes: string): Observable<any> {
+    return this.http.put(`${this.apiUrl}/repertoire/notes`, { pieceId, notes });
+  }
+
   getGlobalPieces(): Observable<Piece[]> {
     return this.http.get<Piece[]>(`${this.apiUrl}/pieces`);
   }

--- a/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.html
@@ -4,6 +4,7 @@
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
   <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>
+  <p><strong>Notizen:</strong> {{ piece.choir_repertoire?.notes || '-' }}</p>
 
   <h3>Geprobt bei</h3>
   <mat-list *ngIf="piece.events?.length; else noEvents">

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -5,6 +5,19 @@
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
   <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>
 
+  <h3>Meine Notizen</h3>
+  <div *ngIf="!isEditing; else editBlock">
+    <p>{{ piece.choir_repertoire?.notes || 'Keine Notizen' }}</p>
+    <button mat-button (click)="startEdit()">Notizen bearbeiten</button>
+  </div>
+  <ng-template #editBlock>
+    <mat-form-field appearance="outline" class="full-width">
+      <textarea matInput [(ngModel)]="editNotes" rows="3"></textarea>
+    </mat-form-field>
+    <button mat-button (click)="cancelEdit()">Abbrechen</button>
+    <button mat-flat-button color="primary" (click)="saveNotes()">Speichern</button>
+  </ng-template>
+
   <h3>Geprobt bei</h3>
   <mat-list *ngIf="piece.events?.length; else noEvents">
     <mat-list-item *ngFor="let ev of piece.events">

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -7,12 +7,14 @@ import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
 import { PieceStatusLabelPipe } from '@shared/pipes/piece-status-label.pipe';
 import { ApiService } from '@core/services/api.service';
 import { Piece } from '@core/models/piece';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-piece-detail',
   standalone: true,
   imports: [
     CommonModule,
+    FormsModule,
     MaterialModule,
     RouterModule,
     EventTypeLabelPipe,
@@ -23,11 +25,37 @@ import { Piece } from '@core/models/piece';
 })
 export class PieceDetailComponent implements OnInit {
   piece?: Piece;
+  editNotes = '';
+  isEditing = false;
 
   constructor(private route: ActivatedRoute, private apiService: ApiService) {}
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));
-    this.apiService.getRepertoirePiece(id).subscribe(p => this.piece = p);
+    this.apiService.getRepertoirePiece(id).subscribe(p => {
+      this.piece = p;
+      this.editNotes = p.choir_repertoire?.notes || '';
+    });
+  }
+
+  startEdit(): void {
+    this.isEditing = true;
+    this.editNotes = this.piece?.choir_repertoire?.notes || '';
+  }
+
+  cancelEdit(): void {
+    this.isEditing = false;
+  }
+
+  saveNotes(): void {
+    if (!this.piece) { return; }
+    this.apiService.updatePieceNotes(this.piece.id, this.editNotes).subscribe(() => {
+      if (!this.piece!.choir_repertoire) {
+        this.piece!.choir_repertoire = { status: 'NOT_READY', notes: this.editNotes };
+      } else {
+        this.piece!.choir_repertoire.notes = this.editNotes;
+      }
+      this.isEditing = false;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- store optional notes on `choir_repertoire`
- expose new endpoint to update notes
- show and edit notes in piece detail views
- support notes in client models and services

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c255c00208320a17e7280301965eb