### PR TITLE
Implement singleton logger

### DIFF
--- a/choir-app-backend/src/config/logger.js
+++ b/choir-app-backend/src/config/logger.js
@@ -1,92 +1,81 @@
 const winston = require('winston');
+const fs = require('fs');
+const path = require('path');
 
 // Destrukturieren der benötigten Formatierungs-Funktionen von winston
 const { combine, timestamp, printf, colorize, align, splat } = winston.format;
 
 /**
- * Definiert ein benutzerdefiniertes Format für die Log-Ausgaben in der Konsole.
- * - `colorize()`: Färbt die Ausgabe je nach Log-Level (info: grün, warn: gelb, error: rot).
- * - `timestamp()`: Fügt einen Zeitstempel hinzu.
- * - `align()`: Richtet die Log-Nachrichten untereinander aus.
- * - `printf()`: Ermöglicht die vollständige Kontrolle über das Ausgabeformat.
- * - `splat()`: Ermöglicht das Loggen von Objekten (z.B. logger.info("User object:", user)).
+ * Erstellt eine neue Winston-Loggerinstanz mit allen gewünschten
+ * Einstellungen. Diese Funktion wird nur einmal pro Prozess ausgeführt.
  */
-const consoleLogFormat = combine(
-  colorize(),
-  timestamp({
-    format: 'YYYY-MM-DD HH:mm:ss.SSS' // Detailliertes Format für die Konsole
-  }),
-  align(),
-  splat(),
-  printf((info) => `[${info.timestamp}] ${info.level}: ${info.message}`)
-);
+function buildLogger() {
+  const logsDir = path.join(__dirname, '..', '..', 'logs');
+  if (!fs.existsSync(logsDir)) {
+    fs.mkdirSync(logsDir, { recursive: true });
+  }
 
-/**
- * Definiert ein benutzerdefiniertes Format für die Log-Ausgaben in Dateien.
- * Dieses Format ist einfacher gehalten, da es keine Farben benötigt.
- */
-const fileLogFormat = combine(
-    timestamp({
-        format: 'YYYY-MM-DD HH:mm:ss'
-    }),
+  const consoleLogFormat = combine(
+    colorize(),
+    timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
+    align(),
+    splat(),
+    printf((info) => `[${info.timestamp}] ${info.level}: ${info.message}`)
+  );
+
+  const fileLogFormat = combine(
+    timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
     splat(),
     printf((info) => `${info.timestamp} [${info.level.toUpperCase()}]: ${info.message}`)
-);
+  );
 
-// Erstellen der zentralen Logger-Instanz
-const logger = winston.createLogger({
-  // Legt das niedrigste Log-Level fest, das verarbeitet wird.
-  // In der Entwicklung ('development') loggen wir alles ab 'info' aufwärts.
-  // In der Produktion ('production') loggen wir nur 'warn' und 'error', um die Logs nicht zu überfluten.
-  level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',
-
-  // Definieren der "Transports" (d.h. der Ausgabeziele für die Logs)
-  transports: [
-    // 1. Transport: Die Entwicklerkonsole
-    // Dieser Transport wird nur aktiviert, wenn wir NICHT in Produktion sind.
-    // In Produktion wollen wir die Konsole oft sauber halten.
-    new winston.transports.Console({
-      format: consoleLogFormat
-    }),
-
-    // 2. Transport: Eine Datei für alle Fehler
-    new winston.transports.File({
-        filename: 'logs/error.log',
-        level: 'error', // Nur 'error'-Level-Logs kommen in diese Datei
+  const loggerInstance = winston.createLogger({
+    level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',
+    transports: [
+      new winston.transports.Console({ format: consoleLogFormat }),
+      new winston.transports.File({
+        filename: path.join(logsDir, 'error.log'),
+        level: 'error',
         format: fileLogFormat,
-        maxsize: 5242880, // 5MB
+        maxsize: 5 * 1024 * 1024,
         maxFiles: 5,
-    }),
-
-    // 3. Transport: Eine Datei für alle Logs (kombiniert)
-    new winston.transports.File({
-        filename: 'logs/combined.log',
+      }),
+      new winston.transports.File({
+        filename: path.join(logsDir, 'combined.log'),
         format: fileLogFormat,
-        maxsize: 5242880, // 5MB
+        maxsize: 5 * 1024 * 1024,
         maxFiles: 5,
-    })
-  ],
+      }),
+    ],
+    exceptionHandlers: [
+      new winston.transports.File({ filename: path.join(logsDir, 'exceptions.log') })
+    ],
+    rejectionHandlers: [
+      new winston.transports.File({ filename: path.join(logsDir, 'rejections.log') })
+    ],
+    exitOnError: false,
+  });
 
-  // Fängt unbehandelte Ausnahmen (uncaught exceptions) ab und loggt sie,
-  // bevor der Prozess beendet wird.
-  exceptionHandlers: [
-    new winston.transports.File({ filename: 'logs/exceptions.log' })
-  ],
+  loggerInstance.stream = {
+    write: (message) => {
+      loggerInstance.info(message.substring(0, message.lastIndexOf('\n')));
+    },
+  };
 
-  // Fängt unbehandelte Promise-Ablehnungen (unhandled rejections) ab.
-  rejectionHandlers: [
-    new winston.transports.File({ filename: 'logs/rejections.log' })
-  ],
+  return loggerInstance;
+}
 
-  // Beendet den Prozess nicht nach einer unbehandelten Ausnahme
-  exitOnError: false
-});
+let logger;
 
-// Fügen Sie einen Stream hinzu, der von anderen Loggern wie 'morgan' verwendet werden kann
-logger.stream = {
-  write: (message) => {
-    logger.info(message.substring(0, message.lastIndexOf('\n')));
-  },
-};
+/**
+ * Gibt die Singleton-Instanz des Loggers zurück.
+ * Da Node.js Module gecacht werden, genügt ein einfacher Lazy-Init.
+ */
+function getLogger() {
+  if (!logger) {
+    logger = buildLogger();
+  }
+  return logger;
+}
 
-module.exports = logger;
+module.exports = getLogger();


### PR DESCRIPTION
## Summary
- refactor logger setup
- build logger instance lazily so it behaves explicitly as a singleton

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686c27f5af248320bcfcab8f124d3a93