### PR TITLE
Add shared date utilities

### DIFF
--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -1,20 +1,6 @@
 const db = require('../models');
 const { Op } = db.Sequelize;
-
-function datesForRule(year, month, rule) {
-    const dates = [];
-    const d = new Date(Date.UTC(year, month - 1, 1));
-    while (d.getUTCMonth() === month - 1) {
-        if (d.getUTCDay() === rule.dayOfWeek) {
-            const week = Math.floor((d.getUTCDate() - 1) / 7) + 1;
-            if (!Array.isArray(rule.weeks) || rule.weeks.length === 0 || rule.weeks.includes(week)) {
-                dates.push(new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())));
-            }
-        }
-        d.setUTCDate(d.getUTCDate() + 1);
-    }
-    return dates;
-}
+const { datesForRule, isoDateString } = require('../utils/date.utils');
 
 exports.findByMonth = async (req, res) => {
     const { year, month } = req.params;
@@ -23,7 +9,7 @@ exports.findByMonth = async (req, res) => {
         const dateSet = new Set();
         for (const rule of rules) {
             for (const d of datesForRule(year, month, rule)) {
-                dateSet.add(d.toISOString().split('T')[0]);
+                dateSet.add(isoDateString(d));
             }
         }
         const dates = Array.from(dateSet).sort();

--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -7,6 +7,7 @@ const CollectionPiece = db.collection_piece;
 const User = db.user;
 const logger = require("../config/logger");
 const { Op, fn, col, where } = require("sequelize");
+const { isoDateString } = require('../utils/date.utils');
 
 async function autoUpdatePieceStatuses(eventType, choirId, pieceIds) {
     if (!Array.isArray(pieceIds) || pieceIds.length === 0) return;
@@ -47,7 +48,7 @@ exports.create = async (req, res) => {
 
     try {
         const targetDate = new Date(date);
-        const dateOnly = targetDate.toISOString().split('T')[0];
+        const dateOnly = isoDateString(targetDate);
 
         // Prüfen, ob für diesen Chor an diesem Tag bereits Events existieren
         const eventsSameDay = await db.event.findAll({

--- a/choir-app-backend/src/controllers/import.controller.js
+++ b/choir-app-backend/src/controllers/import.controller.js
@@ -2,6 +2,7 @@ const { parse } = require('csv-parse');
 const db = require("../models");
 const crypto = require('crypto');
 const jobs = require('../services/import-jobs.service');
+const { isoDateString } = require('../utils/date.utils');
 
 const findOrCreate = async (model, where, defaults, jobId, entityName) => {
     const [instance, created] = await model.findOrCreate({ where, defaults });
@@ -164,7 +165,7 @@ const processEventImport = async (job, eventType, records, choirId, userId) => {
             }
 
             const targetDate = parseGermanDate(dateStr);
-            const dateOnly = targetDate.toISOString().split('T')[0];
+            const dateOnly = isoDateString(targetDate);
 
             let event = await db.event.findOne({
                 where: {

--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -1,20 +1,6 @@
 const db = require('../models');
 const MonthlyPlan = db.monthly_plan;
-
-function datesForRule(year, month, rule) {
-    const dates = [];
-    const d = new Date(Date.UTC(year, month - 1, 1));
-    while (d.getUTCMonth() === month - 1) {
-        if (d.getUTCDay() === rule.dayOfWeek) {
-            const week = Math.floor((d.getUTCDate() - 1) / 7) + 1;
-            if (!Array.isArray(rule.weeks) || rule.weeks.length === 0 || rule.weeks.includes(week)) {
-                dates.push(new Date(d));
-            }
-        }
-        d.setUTCDate(d.getUTCDate() + 1);
-    }
-    return dates;
-}
+const { datesForRule } = require('../utils/date.utils');
 
 async function createEntriesFromRules(plan) {
     const rules = await db.plan_rule.findAll({ where: { choirId: plan.choirId } });

--- a/choir-app-backend/src/utils/date.utils.js
+++ b/choir-app-backend/src/utils/date.utils.js
@@ -1,0 +1,20 @@
+function isoDateString(date) {
+    return date.toISOString().split('T')[0];
+}
+
+function datesForRule(year, month, rule) {
+    const dates = [];
+    const d = new Date(Date.UTC(year, month - 1, 1));
+    while (d.getUTCMonth() === month - 1) {
+        if (d.getUTCDay() === rule.dayOfWeek) {
+            const week = Math.floor((d.getUTCDate() - 1) / 7) + 1;
+            if (!Array.isArray(rule.weeks) || rule.weeks.length === 0 || rule.weeks.includes(week)) {
+                dates.push(new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())));
+            }
+        }
+        d.setUTCDate(d.getUTCDate() + 1);
+    }
+    return dates;
+}
+
+module.exports = { isoDateString, datesForRule };


### PR DESCRIPTION
## Summary
- centralize `datesForRule` and date formatting helpers in `date.utils.js`
- use new utilities in availability, import, monthly plan and event controllers

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2ef6103c8320a76d25ee395585d2