### PR TITLE
Enable status editing in piece detail view

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -3,7 +3,14 @@
   <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
-  <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>
+  <p>
+    <strong>Status im Chor:</strong>
+    <mat-select [value]="piece.choir_repertoire?.status" (selectionChange)="onStatusChange($event.value)">
+      <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>
+      <mat-option value="IN_REHEARSAL">Wird geprobt</mat-option>
+      <mat-option value="NOT_READY">Nicht im Repertoire</mat-option>
+    </mat-select>
+  </p>
 
   <h3>Notizen</h3>
   <div class="note" *ngFor="let n of piece.notes">

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -46,6 +46,15 @@ export class PieceDetailComponent implements OnInit {
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
   }
 
+  onStatusChange(newStatus: string): void {
+    if (!this.piece) return;
+    this.apiService.updatePieceStatus(this.piece.id, newStatus).subscribe(() => {
+      if (!this.piece) return;
+      this.piece.choir_repertoire = this.piece.choir_repertoire || { status: 'CAN_BE_SUNG' };
+      this.piece.choir_repertoire.status = newStatus as any;
+    });
+  }
+
   canEdit(note: PieceNote): boolean {
     return note.author.id === this.userId || this.isAdmin;
   }


### PR DESCRIPTION
## Summary
- add mat-select for repertoire status in `PieceDetailComponent`
- implement `onStatusChange` method to update status via API

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2fe0ab7c8320bb668c22ce4e9eec