### PR TITLE
Handle public holidays for availability

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js"
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -1,5 +1,6 @@
 const db = require('../models');
 const { Op } = db.Sequelize;
+const { isPublicHoliday } = require('../services/holiday.service');
 
 function datesForRule(year, month, rule) {
     const dates = [];
@@ -23,6 +24,7 @@ exports.findByMonth = async (req, res) => {
         const dateSet = new Set();
         for (const rule of rules) {
             for (const d of datesForRule(year, month, rule)) {
+                if (isPublicHoliday(d) && d.getUTCDay() !== 0) continue;
                 dateSet.add(d.toISOString().split('T')[0]);
             }
         }

--- a/choir-app-backend/src/services/holiday.service.js
+++ b/choir-app-backend/src/services/holiday.service.js
@@ -1,0 +1,34 @@
+function easterSunday(year) {
+  const f = Math.floor;
+  const G = year % 19;
+  const C = f(year / 100);
+  const H = (C - f(C / 4) - f((8 * C + 13) / 25) + 19 * G + 15) % 30;
+  const I = H - f(H / 28) * (1 - f(29 / (H + 1)) * f((21 - G) / 11));
+  const J = (year + f(year / 4) + I + 2 - C + f(C / 4)) % 7;
+  const L = I - J;
+  const month = 3 + f((L + 40) / 44);
+  const day = L + 28 - 31 * f(month / 4);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function publicHolidays(year) {
+  const easter = easterSunday(year);
+  const goodFriday = new Date(easter);
+  goodFriday.setUTCDate(goodFriday.getUTCDate() - 2);
+  const ascensionDay = new Date(easter);
+  ascensionDay.setUTCDate(ascensionDay.getUTCDate() + 39);
+
+  const christmas1 = new Date(Date.UTC(year, 11, 25));
+  const christmas2 = new Date(Date.UTC(year, 11, 26));
+
+  return [goodFriday, ascensionDay, christmas1, christmas2];
+}
+
+function isPublicHoliday(date) {
+  const iso = date.toISOString().split('T')[0];
+  return publicHolidays(date.getUTCFullYear())
+    .map(d => d.toISOString().split('T')[0])
+    .includes(iso);
+}
+
+module.exports = { easterSunday, publicHolidays, isPublicHoliday };

--- a/choir-app-backend/tests/availability.controller.test.js
+++ b/choir-app-backend/tests/availability.controller.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/availability.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+    const choir = await db.choir.create({ name: 'Test Choir' });
+    const user = await db.user.create({ email: 't@example.com' });
+    await db.plan_rule.create({ choirId: choir.id, dayOfWeek: 5 }); // Fridays
+    await db.plan_rule.create({ choirId: choir.id, dayOfWeek: 4 }); // Thursdays
+
+    const baseReq = { activeChoirId: choir.id, userId: user.id };
+    const res = { status(code) { this.statusCode = code; return this; }, send(d) { this.data = d; } };
+
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 4 } }, res);
+    assert.strictEqual(res.statusCode, 200);
+    const aprilDates = res.data.map(a => a.date);
+    assert.ok(!aprilDates.includes('2025-04-18'));
+
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 5 } }, res);
+    const mayDates = res.data.map(a => a.date);
+    assert.ok(!mayDates.includes('2025-05-29'));
+
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 12 } }, res);
+    const decDates = res.data.map(a => a.date);
+    assert.ok(!decDates.includes('2025-12-25'));
+    assert.ok(!decDates.includes('2025-12-26'));
+
+    console.log('availability.controller tests passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();

--- a/choir-app-backend/tests/holiday.service.test.js
+++ b/choir-app-backend/tests/holiday.service.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const { isPublicHoliday } = require('../src/services/holiday.service');
+
+(async () => {
+  try {
+    const gf = new Date('2025-04-18T00:00:00Z');
+    const asc = new Date('2025-05-29T00:00:00Z');
+    const xmas = new Date('2025-12-25T00:00:00Z');
+    assert.ok(isPublicHoliday(gf));
+    assert.ok(isPublicHoliday(asc));
+    assert.ok(isPublicHoliday(xmas));
+    console.log('holiday.service tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add `holiday.service` with date calculation helpers
- skip public holidays when creating availability dates
- test holiday helper and availability filtering
- run these tests via npm script

## Testing
- `npm test --silent --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --silent --prefix choir-app-frontend` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c302bacf4832099cba5a95325a614