### PR TITLE
Fix vertical centering of search box

### DIFF
--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.scss
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.scss
@@ -8,8 +8,9 @@
 
 :host {
   position: absolute;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
 }
 
 :host-context(.light-theme) .search-box {


### PR DESCRIPTION
## Summary
- adjust search-box component styles so the global search box is vertically centered within the toolbar

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca3b86bc08320a44d94bfa63a07cd