### PR TITLE
Add holiday hints for plan entries

### DIFF
--- a/choir-app-frontend/src/app/core/models/plan-entry.ts
+++ b/choir-app-frontend/src/app/core/models/plan-entry.ts
@@ -2,6 +2,8 @@ export interface PlanEntry {
   id: number;
   date: string;
   notes?: string;
+  /** Automatically generated note for church holidays */
+  holidayHint?: string;
   director?: { id: number; name: string };
   organist?: { id: number; name: string } | null;
 }

--- a/choir-app-frontend/src/app/core/models/user-availability.ts
+++ b/choir-app-frontend/src/app/core/models/user-availability.ts
@@ -1,4 +1,6 @@
 export interface UserAvailability {
   date: string;
   status: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE';
+  /** Automatically generated note for church holidays */
+  holidayHint?: string;
 }

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -1,7 +1,10 @@
 <table mat-table [dataSource]="availabilities" class="mat-elevation-z2">
   <ng-container matColumnDef="date">
     <th mat-header-cell *matHeaderCellDef>Datum</th>
-    <td mat-cell *matCellDef="let a">{{ a.date | date:'EEE dd.MM.yyyy' }}</td>
+    <td mat-cell *matCellDef="let a">
+      {{ a.date | date:'EEE dd.MM.yyyy' }}
+      <span class="holiday" *ngIf="a.holidayHint"> ({{ a.holidayHint }})</span>
+    </td>
   </ng-container>
   <ng-container matColumnDef="status">
     <th mat-header-cell *matHeaderCellDef>Status</th>

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.scss
@@ -14,3 +14,8 @@
 .unavailable {
   background-color: #ffcdd2;
 }
+
+.holiday {
+  font-style: italic;
+  color: #555;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { UserAvailability } from '@core/models/user-availability';
+import { getHolidayName } from '@shared/util/holiday';
 
 @Component({
   selector: 'app-availability-table',
@@ -25,7 +26,10 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
   load(): void {
     if (!this.year || !this.month) return;
     this.api.getAvailabilities(this.year, this.month)
-      .subscribe(a => this.availabilities = a);
+      .subscribe(a => this.availabilities = a.map(v => ({
+        ...v,
+        holidayHint: getHolidayName(new Date(v.date)) || undefined
+      })));
   }
 
   setStatus(date: string, status: UserAvailability['status']): void {
@@ -33,7 +37,10 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
     if (i >= 0) this.availabilities[i].status = status;
 
     this.api.setAvailability(date, status).subscribe(updated => {
-      if (i >= 0) this.availabilities[i] = updated;
+      if (i >= 0) this.availabilities[i] = {
+        ...updated,
+        holidayHint: getHolidayName(new Date(updated.date)) || undefined
+      };
     });
   }
 

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -21,7 +21,10 @@
   <table mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">
       <th mat-header-cell *matHeaderCellDef>Datum</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</td>
+      <td mat-cell *matCellDef="let ev">
+        {{ ev.date | date:'shortDate' }}
+        <span class="holiday" *ngIf="ev.holidayHint"> ({{ ev.holidayHint }})</span>
+      </td>
     </ng-container>
     <ng-container matColumnDef="director">
       <th mat-header-cell *matHeaderCellDef>Chorleiter</th>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -28,3 +28,8 @@
 mat-tab-group {
   width: 100%;
 }
+
+.holiday {
+  font-style: italic;
+  color: #555;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -14,6 +14,7 @@ import { Subscription } from 'rxjs';
 import { PlanEntryDialogComponent } from './plan-entry-dialog/plan-entry-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { AvailabilityTableComponent } from './availability-table/availability-table.component';
+import { getHolidayName } from '@shared/util/holiday';
 
 @Component({
   selector: 'app-monthly-plan',
@@ -130,7 +131,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.getMonthlyPlan(year, month).subscribe({
       next: plan => {
         this.plan = plan;
-        this.entries = plan?.entries || [];
+        this.entries = (plan?.entries || []).map(e => ({
+          ...e,
+          holidayHint: getHolidayName(new Date(e.date)) || undefined
+        }));
         this.sortEntries();
         this.updateDisplayedColumns();
         this.updateCounterPlan();

--- a/choir-app-frontend/src/app/shared/pipes/holiday-name.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/holiday-name.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { getHolidayName } from '../util/holiday';
+
+@Pipe({
+  name: 'holidayName',
+  standalone: true
+})
+export class HolidayNamePipe implements PipeTransform {
+  transform(value: Date | string | null | undefined): string {
+    if (!value) return '';
+    const date = value instanceof Date ? value : new Date(value);
+    return getHolidayName(date) || '';
+  }
+}

--- a/choir-app-frontend/src/app/shared/util/holiday.ts
+++ b/choir-app-frontend/src/app/shared/util/holiday.ts
@@ -1,0 +1,70 @@
+export function easterSunday(year: number): Date {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31); // 3=March,4=April
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function sameDate(a: Date, b: Date): boolean {
+  return a.getUTCFullYear() === b.getUTCFullYear() &&
+         a.getUTCMonth() === b.getUTCMonth() &&
+         a.getUTCDate() === b.getUTCDate();
+}
+
+function previousSunday(date: Date): Date {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  while (d.getUTCDay() !== 0) {
+    d.setUTCDate(d.getUTCDate() - 1);
+  }
+  return d;
+}
+
+export function getHolidayName(date: Date): string | null {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+
+  if (month === 0 && day === 1) return 'Neujahr';
+  if (month === 11 && day === 24) return 'Heiligabend';
+  if (month === 11 && day === 25) return '1. Weihnachtstag';
+  if (month === 11 && day === 26) return '2. Weihnachtstag';
+
+  const easter = easterSunday(year);
+  const goodFriday = new Date(easter); goodFriday.setUTCDate(easter.getUTCDate() - 2);
+  if (sameDate(date, goodFriday)) return 'Karfreitag';
+  if (sameDate(date, easter)) return 'Ostersonntag';
+  const easterMonday = new Date(easter); easterMonday.setUTCDate(easter.getUTCDate() + 1);
+  if (sameDate(date, easterMonday)) return 'Ostermontag';
+  const pentecost = new Date(easter); pentecost.setUTCDate(easter.getUTCDate() + 49);
+  if (sameDate(date, pentecost)) return 'Pfingstsonntag';
+  const pentecostMonday = new Date(pentecost); pentecostMonday.setUTCDate(pentecost.getUTCDate() + 1);
+  if (sameDate(date, pentecostMonday)) return 'Pfingstmontag';
+
+  const advent4 = previousSunday(new Date(Date.UTC(year, 11, 25)));
+  const advent3 = new Date(advent4); advent3.setUTCDate(advent4.getUTCDate() - 7);
+  const advent2 = new Date(advent3); advent2.setUTCDate(advent3.getUTCDate() - 7);
+  const advent1 = new Date(advent2); advent1.setUTCDate(advent2.getUTCDate() - 7);
+  if (sameDate(date, advent1)) return '1. Advent';
+  if (sameDate(date, advent2)) return '2. Advent';
+  if (sameDate(date, advent3)) return '3. Advent';
+  if (sameDate(date, advent4)) return '4. Advent';
+
+  const penance = new Date(Date.UTC(year, 10, 23));
+  while (penance.getUTCDay() !== 3) {
+    penance.setUTCDate(penance.getUTCDate() - 1);
+  }
+  if (sameDate(date, penance)) return 'Bu\u00df- und Bettag';
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- compute church holidays in frontend util
- show hints next to dates in plan entries and availability table

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686c307b20e8832080183b8d20c09936