### PR TITLE
Add German holiday support to calendar

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -1,5 +1,6 @@
 <h2>Meine Termine</h2>
-<mat-calendar [selected]="selectedDate"
+<mat-calendar class="compact"
+              [selected]="selectedDate"
               (selectedChange)="onSelectedChange($event)"
               [dateClass]="dateClass"></mat-calendar>
 
@@ -7,7 +8,9 @@
   <h3>{{ selectedDate | date:'longDate' }}</h3>
   <mat-list>
     <mat-list-item *ngFor="let ev of eventsForSelectedDate">
-      <div matLine>{{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}</div>
+      <div matLine>
+        {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
+      </div>
       <div matLine class="notes" *ngIf="ev.notes">{{ ev.notes }}</div>
     </mat-list-item>
   </mat-list>

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
@@ -4,6 +4,22 @@
   border-radius: 50%;
 }
 
+.holiday:not(.has-event) .mat-calendar-body-cell-content {
+  background-color: #ffecb3;
+  border-radius: 50%;
+}
+
+.weekend:not(.has-event) .mat-calendar-body-cell-content {
+  background-color: #e0e0e0;
+  border-radius: 50%;
+}
+
+mat-calendar.compact .mat-calendar-body-cell-content {
+  height: 32px;
+  width: 32px;
+  line-height: 32px;
+}
+
 .event-list {
   margin-top: 16px;
 }

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -4,6 +4,14 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { Event } from '@core/models/event';
 
+interface HolidayEvent {
+  type: 'HOLIDAY';
+  name: string;
+  date: string;
+}
+
+type CalendarEntry = Event | HolidayEvent;
+
 @Component({
   selector: 'app-my-calendar',
   standalone: true,
@@ -14,12 +22,17 @@ import { Event } from '@core/models/event';
 export class MyCalendarComponent implements OnInit {
   events: Event[] = [];
   eventMap: { [date: string]: Event[] } = {};
+  holidayMap: { [date: string]: string } = {};
   selectedDate: Date = new Date();
 
   constructor(private api: ApiService) {}
 
   ngOnInit(): void {
     this.loadEvents();
+    const year = this.selectedDate.getFullYear();
+    [year - 1, year, year + 1].forEach(y => {
+      Object.assign(this.holidayMap, this.calculateGermanHolidays(y));
+    });
   }
 
   private loadEvents(): void {
@@ -34,9 +47,42 @@ export class MyCalendarComponent implements OnInit {
     });
   }
 
+  private calculateGermanHolidays(year: number): { [date: string]: string } {
+    const toKey = (d: Date) => d.toISOString().substring(0, 10);
+
+    // Meeus/Jones/Butcher algorithm for Easter Sunday
+    const f = Math.floor;
+    const G = year % 19;
+    const C = f(year / 100);
+    const H = (C - f(C / 4) - f((8 * C + 13) / 25) + 19 * G + 15) % 30;
+    const I = H - f(H / 28) * (1 - f(29 / (H + 1)) * f((21 - G) / 11));
+    const J = (year + f(year / 4) + I + 2 - C + f(C / 4)) % 7;
+    const L = I - J;
+    const month = 3 + f((L + 40) / 44);
+    const day = L + 28 - 31 * f(month / 4);
+    const easterSunday = new Date(year, month - 1, day);
+
+    const msDay = 24 * 60 * 60 * 1000;
+    const holidays: { [date: string]: string } = {};
+    holidays[toKey(new Date(year, 0, 1))] = 'Neujahr';
+    holidays[toKey(new Date(easterSunday.getTime() - 2 * msDay))] = 'Karfreitag';
+    holidays[toKey(new Date(easterSunday.getTime() + 1 * msDay))] = 'Ostermontag';
+    holidays[toKey(new Date(year, 4, 1))] = 'Tag der Arbeit';
+    holidays[toKey(new Date(easterSunday.getTime() + 39 * msDay))] = 'Christi Himmelfahrt';
+    holidays[toKey(new Date(easterSunday.getTime() + 50 * msDay))] = 'Pfingstmontag';
+    holidays[toKey(new Date(year, 9, 3))] = 'Tag der Deutschen Einheit';
+    holidays[toKey(new Date(year, 11, 25))] = '1. Weihnachtstag';
+    holidays[toKey(new Date(year, 11, 26))] = '2. Weihnachtstag';
+    return holidays;
+  }
+
   dateClass = (d: Date): string => {
     const key = d.toISOString().substring(0, 10);
-    return this.eventMap[key] ? 'has-event' : '';
+    const classes: string[] = [];
+    if (this.eventMap[key]) classes.push('has-event');
+    if (this.holidayMap[key]) classes.push('holiday');
+    if (d.getDay() === 0 || d.getDay() === 6) classes.push('weekend');
+    return classes.join(' ');
   };
 
   onSelectedChange(date: Date | null): void {
@@ -45,8 +91,13 @@ export class MyCalendarComponent implements OnInit {
     }
   }
 
-  get eventsForSelectedDate(): Event[] {
+  get eventsForSelectedDate(): CalendarEntry[] {
     const key = this.selectedDate.toISOString().substring(0, 10);
-    return this.eventMap[key] || [];
+    const entries: CalendarEntry[] = [...(this.eventMap[key] || [])];
+    const holiday = this.holidayMap[key];
+    if (holiday) {
+      entries.push({ type: 'HOLIDAY', name: holiday, date: key });
+    }
+    return entries;
   }
 }


### PR DESCRIPTION
## Summary
- show German holidays automatically in the "Meine Termine" calendar
- style weekends in gray
- compact the calendar layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca4b2cdf48320b6c326796a078420