### PR TITLE
Fix calendar compile errors

### DIFF
--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -4,6 +4,12 @@ export interface Event {
   id: number;
   date: string;
   type: 'REHEARSAL' | 'SERVICE';
+  /**
+   * Optional name for display purposes. Regular events usually do not have
+   * a name but holiday entries in the calendar do. The property is optional so
+   * that existing API responses without a name remain valid.
+   */
+  name?: string;
   notes?: string;
   createdAt: string;
   updatedAt: string;

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -8,6 +8,8 @@ interface HolidayEvent {
   type: 'HOLIDAY';
   name: string;
   date: string;
+  /** Optional notes for display consistency with normal events */
+  notes?: string;
 }
 
 type CalendarEntry = Event | HolidayEvent;


### PR DESCRIPTION
## Summary
- add optional `name` field to `Event` model
- allow notes in `HolidayEvent`

## Testing
- `npm run build --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca6d8a3e083209b760165a339b389