### PR TITLE
Add choir member list component

### DIFF
--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -28,6 +28,7 @@ import { DonateComponent } from '@features/donations/donate.component';
 import { DonationSuccessComponent } from '@features/donations/donation-success.component';
 import { DonationCancelComponent } from '@features/donations/donation-cancel.component';
 import { SearchResultsComponent } from './features/search-results/search-results.component';
+import { ChoirMembersComponent } from '@features/choir-members/choir-members.component';
 
 export const routes: Routes = [
     // Die MainLayoutComponent ist jetzt die Wurzel und hat keine Guards
@@ -127,6 +128,11 @@ export const routes: Routes = [
                 path: 'profile',
                 component: ProfileComponent,
                 canActivate: [AuthGuard],
+            },
+            {
+                path: 'members',
+                component: ChoirMembersComponent,
+                canActivate: [AuthGuard]
             },
             {
                 path: 'manage-choir',

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -1,0 +1,40 @@
+<h1>Chormitglieder</h1>
+<div class="table-container mat-elevation-z4">
+  <table mat-table [dataSource]="dataSource">
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Name</th>
+      <td mat-cell *matCellDef="let m">{{ m.name }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="voice">
+      <th mat-header-cell *matHeaderCellDef>Stimme</th>
+      <td mat-cell *matCellDef="let m">{{ m.membership?.roleInChoir || '-' }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="email">
+      <th mat-header-cell *matHeaderCellDef>E-Mail</th>
+      <td mat-cell *matCellDef="let m">{{ m.email }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="street">
+      <th mat-header-cell *matHeaderCellDef>Straße</th>
+      <td mat-cell *matCellDef="let m">{{ mask(m.street, m.shareWithChoir) }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="postalCode">
+      <th mat-header-cell *matHeaderCellDef>PLZ</th>
+      <td mat-cell *matCellDef="let m">{{ mask(m.postalCode, m.shareWithChoir) }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="city">
+      <th mat-header-cell *matHeaderCellDef>Ort</th>
+      <td mat-cell *matCellDef="let m">{{ mask(m.city, m.shareWithChoir) }}</td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</td>
+    </tr>
+  </table>
+</div>

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.scss
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.scss
@@ -1,0 +1,3 @@
+.table-container {
+  overflow-x: auto;
+}

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.ts
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableDataSource } from '@angular/material/table';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { UserInChoir } from '@core/models/user';
+
+@Component({
+  selector: 'app-choir-members',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './choir-members.component.html',
+  styleUrls: ['./choir-members.component.scss']
+})
+export class ChoirMembersComponent implements OnInit {
+  displayedColumns: string[] = ['name', 'voice', 'email', 'street', 'postalCode', 'city'];
+  dataSource = new MatTableDataSource<UserInChoir>();
+
+  constructor(private apiService: ApiService) {}
+
+  ngOnInit(): void {
+    this.apiService.getChoirMembers().subscribe(members => {
+      this.dataSource.data = members;
+    });
+  }
+
+  mask(value: string | undefined, share: boolean | undefined): string {
+    return share ? (value || '') : '*****';
+  }
+}


### PR DESCRIPTION
## Summary
- add a new component to show choir members and their contact info
- mask address fields when member hasn't shared data
- register component under `/members` route

## Testing
- `npm test --silent --prefix choir-app-frontend` *(fails: ng not found)*
- `npm test --silent --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686d3f792a248320bbf3252b90829d72