### PR TITLE
Fix 403 for director role on monthly plan

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -118,12 +118,14 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
       this.isChoirAdmin = r.isChoirAdmin;
       this.updateDisplayedColumns();
       this.loadAvailabilities(this.selectedYear, this.selectedMonth);
-    });
-    this.api.getChoirMembers().subscribe(m => {
-      this.members = m;
-      this.directors = m.filter(u => u.membership?.roleInChoir === 'director' || u.membership?.roleInChoir === 'choir_admin');
-      this.organists = m.filter(u => u.membership?.isOrganist);
-      this.updateCounterPlan();
+      if (this.isChoirAdmin) {
+        this.api.getChoirMembers().subscribe(m => {
+          this.members = m;
+          this.directors = m.filter(u => u.membership?.roleInChoir === 'director' || u.membership?.roleInChoir === 'choir_admin');
+          this.organists = m.filter(u => u.membership?.isOrganist);
+          this.updateCounterPlan();
+        });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- avoid calling the restricted choir members API for non-admins

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686d747555a08320889dc8e80141e2ba