### PR TITLE
Fix styleUrls for manage creators component

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
@@ -14,7 +14,7 @@ import { ComposerDialogComponent } from '@features/composers/composer-dialog/com
 @Component({
   selector: 'app-manage-creators',
   templateUrl: './manage-creators.component.html',
-  styleUrl: './manage-creators.component.scss',
+  styleUrls: ['./manage-creators.component.scss'],
   standalone: true,
   imports: [
     CommonModule,


### PR DESCRIPTION
## Summary
- use `styleUrls` array in manage-creators component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d74dd372483208599160c2c5abb4b