### PR TITLE
Fix build-info generation for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Angular CLI dependencies
         run: npm install --prefix choir-app-frontend
 
+      - name: Generate build info
+        run: npm run generate-build-info --prefix choir-app-frontend
+
       - name: Run Angular tests
         run: npm run test --prefix choir-app-frontend -- --watch=false --progress=false --browsers=ChromeHeadlessCI
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ npm test
 
 This command uses the Angular CLI to execute Karma tests from the `choir-app-frontend` project.
 
+The build information file `choir-app-frontend/src/environments/build-info.ts` is generated automatically when running the build, start or test scripts. This keeps the ever-changing commit hash and timestamp out of version control while still allowing the application and tests to access the data.
+
 Run backend model tests with:
 
 ```bash

--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -8,6 +8,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "pretest": "npm run generate-build-info",
     "generate-build-info": "node ./scripts/generate-build-info.js",
     "prebuild": "npm run generate-build-info",
     "prestart": "npm run generate-build-info",


### PR DESCRIPTION
## Summary
- generate build-info.ts before running tests
- run build-info generation step in GitHub workflow
- document automatic build-info generation

## Testing
- `node choir-app-frontend/scripts/generate-build-info.js`
- `npm install --prefix choir-app-frontend` *(fails: network not available)*

------
https://chatgpt.com/codex/tasks/task_e_686d7c812f648320bb1dde9c15f6e0c0