### PR TITLE
Integrate express-validator

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.1",
+    "express-validator": "^6.15.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.0",
     "multer": "^2.0.1",

--- a/choir-app-backend/src/routes/auth.routes.js
+++ b/choir-app-backend/src/routes/auth.routes.js
@@ -1,8 +1,10 @@
 const { verifyToken } = require("../middleware/auth.middleware");
 const controller = require("../controllers/auth.controller");
+const { signupValidation } = require("../validators/auth.validation");
+const validate = require("../validators/validate");
 const router = require("express").Router();
 
-router.post("/signup", controller.signup);
+router.post("/signup", signupValidation, validate, controller.signup);
 router.post("/signin", controller.signin);
 
 router.post("/switch-choir/:choirId", verifyToken, controller.switchChoir);

--- a/choir-app-backend/src/routes/event.routes.js
+++ b/choir-app-backend/src/routes/event.routes.js
@@ -1,5 +1,7 @@
 const authJwt = require("../middleware/auth.middleware");
 const controller = require("../controllers/event.controller");
+const { createEventValidation } = require("../validators/event.validation");
+const validate = require("../validators/validate");
 const router = require("express").Router();
 
 router.use(authJwt.verifyToken);
@@ -7,11 +9,10 @@ router.use(authJwt.verifyToken);
 router.get("/last", controller.findLast);
 router.get("/", controller.findAll);
 router.get("/:id", controller.findOne);
-router.post("/", controller.create);
+router.post("/", createEventValidation, validate, controller.create);
 router.put("/:id", controller.update);
 router.delete("/range", authJwt.isChoirAdminOrAdmin, controller.deleteRange);
 router.delete("/:id", authJwt.isChoirAdminOrAdmin, controller.delete);
 router.post("/recalculate-piece-statuses", authJwt.isAdmin, controller.recalculatePieceStatuses);
 // Later you will add POST for creation: router.post("/", controller.create);
-
 module.exports = router;

--- a/choir-app-backend/src/validators/auth.validation.js
+++ b/choir-app-backend/src/validators/auth.validation.js
@@ -1,0 +1,8 @@
+const { body } = require('express-validator');
+
+exports.signupValidation = [
+  body('name').notEmpty().withMessage('Name is required.'),
+  body('email').isEmail().withMessage('Valid email is required.'),
+  body('password').isLength({ min: 4 }).withMessage('Password must be at least 4 characters.'),
+  body('choirName').notEmpty().withMessage('Choir name is required.')
+];

--- a/choir-app-backend/src/validators/event.validation.js
+++ b/choir-app-backend/src/validators/event.validation.js
@@ -1,0 +1,13 @@
+const { body } = require('express-validator');
+
+exports.createEventValidation = [
+  body('date').isISO8601().withMessage('Valid date is required.'),
+  body('type').isIn(['REHEARSAL', 'SERVICE']).withMessage('Type must be REHEARSAL or SERVICE.'),
+  body('pieceIds').optional().isArray().withMessage('pieceIds must be an array'),
+  body('pieceIds.*').optional().isInt().withMessage('pieceIds must contain integers'),
+  body('organistId').optional({ nullable: true }).isInt().withMessage('organistId must be an integer'),
+  body('directorId').optional({ nullable: true }).isInt().withMessage('directorId must be an integer'),
+  body('finalized').optional().isBoolean(),
+  body('version').optional().isInt(),
+  body('monthlyPlanId').optional({ nullable: true }).isInt()
+];

--- a/choir-app-backend/src/validators/validate.js
+++ b/choir-app-backend/src/validators/validate.js
@@ -1,0 +1,9 @@
+const { validationResult } = require('express-validator');
+
+module.exports = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+};


### PR DESCRIPTION
## Summary
- add express-validator dependency
- define signup and event creation validation schemas
- validate requests in auth and event routes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7b1c3d2083208dc00293c330fd6f