### PR TITLE
Introduce generic CRUD controller

### DIFF
--- a/choir-app-backend/src/controllers/baseCrud.controller.js
+++ b/choir-app-backend/src/controllers/baseCrud.controller.js
@@ -1,0 +1,75 @@
+const CrudService = require('../services/crud.service');
+
+class BaseCrudController {
+    constructor(model) {
+        this.service = new CrudService(model);
+
+        // Bind methods so they can be used directly as route handlers
+        this.create = this.create.bind(this);
+        this.findAll = this.findAll.bind(this);
+        this.findById = this.findById.bind(this);
+        this.update = this.update.bind(this);
+        this.delete = this.delete.bind(this);
+    }
+
+    async create(req, res, next) {
+        try {
+            const item = await this.service.create(req.body);
+            res.status(201).send(item);
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+
+    async findAll(req, res, next) {
+        try {
+            const items = await this.service.findAll();
+            res.status(200).send(items);
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+
+    async findById(req, res, next) {
+        try {
+            const id = req.params.id;
+            const item = await this.service.findById(id);
+            if (!item) return res.status(404).send({ message: `Not found.` });
+            res.status(200).send(item);
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+
+    async update(req, res, next) {
+        try {
+            const id = req.params.id;
+            const num = await this.service.update(id, req.body);
+            if (num === 1) {
+                const updated = await this.service.findById(id);
+                return res.status(200).send(updated);
+            }
+            res.status(404).send({ message: `Not found.` });
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+
+    async delete(req, res, next) {
+        try {
+            const id = req.params.id;
+            const num = await this.service.delete(id);
+            if (num === 1) return res.status(204).send();
+            res.status(404).send({ message: `Not found.` });
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+}
+
+module.exports = BaseCrudController;

--- a/choir-app-backend/src/controllers/category.controller.js
+++ b/choir-app-backend/src/controllers/category.controller.js
@@ -1,23 +1,31 @@
 const db = require("../models");
 const Category = db.category;
+const BaseCrudController = require("./baseCrud.controller");
+const base = new BaseCrudController(Category);
 
-exports.create = async (req, res) => {
+exports.create = async (req, res, next) => {
     try {
-        const category = await Category.create({ name: req.body.name });
+        const category = await base.service.create({ name: req.body.name });
         res.status(201).send(category);
     } catch (err) {
         if (err.name === 'SequelizeUniqueConstraintError') {
             return res.status(409).send({ message: "A category with this name already exists." });
         }
+        if (next) return next(err);
         res.status(500).send({ message: err.message });
     }
 };
 
-exports.findAll = async (req, res) => {
+exports.findAll = async (req, res, next) => {
     try {
-        const categories = await Category.findAll({ order: [['name', 'ASC']] });
+        const categories = await base.service.findAll({ order: [['name', 'ASC']] });
         res.status(200).send(categories);
     } catch (err) {
+        if (next) return next(err);
         res.status(500).send({ message: err.message });
-    }
-};
+    }};
+
+// expose generic handlers for completeness
+exports.findById = base.findById;
+exports.update = base.update;
+exports.delete = base.delete;


### PR DESCRIPTION
## Summary
- add `BaseCrudController` implementing standard CRUD handlers
- refactor `category.controller` to use the new base class
- refactor `collection.controller` to reuse the CRUD base

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686d7ab5beb4832082771c83afbca737