### PR TITLE
Add Entschlafenengottesdienst holiday

### DIFF
--- a/choir-app-backend/src/services/holiday.service.js
+++ b/choir-app-backend/src/services/holiday.service.js
@@ -11,6 +11,14 @@ function easterSunday(year) {
   return new Date(Date.UTC(year, month - 1, day));
 }
 
+function firstSundayOfMonth(year, month) {
+  const d = new Date(Date.UTC(year, month, 1));
+  while (d.getUTCDay() !== 0) {
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return d;
+}
+
 function publicHolidays(year) {
   const easter = easterSunday(year);
   const goodFriday = new Date(easter);
@@ -20,8 +28,11 @@ function publicHolidays(year) {
 
   const christmas1 = new Date(Date.UTC(year, 11, 25));
   const christmas2 = new Date(Date.UTC(year, 11, 26));
+  const entMarch = firstSundayOfMonth(year, 2);
+  const entJuly = firstSundayOfMonth(year, 6);
+  const entNov = firstSundayOfMonth(year, 10);
 
-  return [goodFriday, ascensionDay, christmas1, christmas2];
+  return [goodFriday, ascensionDay, christmas1, christmas2, entMarch, entJuly, entNov];
 }
 
 function isPublicHoliday(date) {

--- a/choir-app-backend/tests/holiday.service.test.js
+++ b/choir-app-backend/tests/holiday.service.test.js
@@ -6,9 +6,15 @@ const { isPublicHoliday } = require('../src/services/holiday.service');
     const gf = new Date('2025-04-18T00:00:00Z');
     const asc = new Date('2025-05-29T00:00:00Z');
     const xmas = new Date('2025-12-25T00:00:00Z');
+    const entMarch = new Date('2025-03-02T00:00:00Z');
+    const entJuly = new Date('2025-07-06T00:00:00Z');
+    const entNov = new Date('2025-11-02T00:00:00Z');
     assert.ok(isPublicHoliday(gf));
     assert.ok(isPublicHoliday(asc));
     assert.ok(isPublicHoliday(xmas));
+    assert.ok(isPublicHoliday(entMarch));
+    assert.ok(isPublicHoliday(entJuly));
+    assert.ok(isPublicHoliday(entNov));
     console.log('holiday.service tests passed');
   } catch (err) {
     console.error(err);

--- a/choir-app-frontend/src/app/shared/util/holiday.ts
+++ b/choir-app-frontend/src/app/shared/util/holiday.ts
@@ -30,10 +30,24 @@ function previousSunday(date: Date): Date {
   return d;
 }
 
+function firstSundayOfMonth(year: number, month: number): Date {
+  const d = new Date(Date.UTC(year, month, 1));
+  while (d.getUTCDay() !== 0) {
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return d;
+}
+
 export function getHolidayName(date: Date): string | null {
   const year = date.getUTCFullYear();
   const month = date.getUTCMonth();
   const day = date.getUTCDate();
+
+  if ([2, 6, 10].includes(month)) {
+    if (sameDate(date, firstSundayOfMonth(year, month))) {
+      return 'Entschlafenengottesdienst';
+    }
+  }
 
   if (month === 0 && day === 1) return 'Neujahr';
   if (month === 11 && day === 24) return 'Heiligabend';


### PR DESCRIPTION
## Summary
- support Entschlafenengottesdienst on first Sunday of March, July and November
- verify new dates in holiday service test

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686d8352ca788320b47d7486a6d259ec