### PR TITLE
Fix singer registration

### DIFF
--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -21,7 +21,8 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: true
       },
       role: {
-        type: DataTypes.ENUM('director', 'choir_admin', 'admin', 'demo'),
+        // Include 'singer' so regular choir members can register
+        type: DataTypes.ENUM('director', 'choir_admin', 'admin', 'demo', 'singer'),
         defaultValue: 'director'
       },
       lastDonation: {


### PR DESCRIPTION
## Summary
- allow singers to register by extending `user.role` enum

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686d978612c4832090e7a0fb5bd81281