### PR TITLE
Add Christmas availability rules

### DIFF
--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -12,9 +12,22 @@ exports.findByMonth = async (req, res) => {
         const dateSet = new Set();
         for (const rule of rules) {
             for (const d of datesForRule(year, month, rule)) {
-
                 if (isPublicHoliday(d) && d.getUTCDay() !== 0) continue;
                 dateSet.add(isoDateString(d));
+            }
+        }
+
+        if (Number(month) === 12) {
+            const dec25 = new Date(Date.UTC(year, 11, 25));
+            const dec26 = new Date(Date.UTC(year, 11, 26));
+            const hasRuleForDec25 = rules.some(r => r.dayOfWeek === dec25.getUTCDay());
+
+            if (!hasRuleForDec25) {
+                dateSet.add(isoDateString(dec25));
+            }
+
+            if (dec26.getUTCDay() === 0) {
+                dateSet.delete(isoDateString(dec26));
             }
         }
         const dates = Array.from(dateSet).sort();

--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -7,11 +7,22 @@ async function createEntriesFromRules(plan) {
     for (const rule of rules) {
         const dates = datesForRule(plan.year, plan.month, rule);
         for (const date of dates) {
+            if (date.getUTCMonth() === 11 && date.getUTCDate() === 26 && date.getUTCDay() === 0) {
+                continue;
+            }
             await db.plan_entry.create({
                 monthlyPlanId: plan.id,
                 date,
                 notes: rule.notes || null
             });
+        }
+    }
+
+    if (plan.month === 12) {
+        const dec25 = new Date(Date.UTC(plan.year, 11, 25));
+        const hasRuleForDec25 = rules.some(r => r.dayOfWeek === dec25.getUTCDay());
+        if (!hasRuleForDec25) {
+            await db.plan_entry.create({ monthlyPlanId: plan.id, date: dec25, notes: null });
         }
     }
 }

--- a/choir-app-backend/tests/availability.controller.test.js
+++ b/choir-app-backend/tests/availability.controller.test.js
@@ -25,10 +25,22 @@ const controller = require('../src/controllers/availability.controller');
     const mayDates = res.data.map(a => a.date);
     assert.ok(!mayDates.includes('2025-05-29'));
 
-    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 12 } }, res);
-    const decDates = res.data.map(a => a.date);
-    assert.ok(!decDates.includes('2025-12-25'));
-    assert.ok(!decDates.includes('2025-12-26'));
+  await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 12 } }, res);
+  const decDates = res.data.map(a => a.date);
+  assert.ok(!decDates.includes('2025-12-25'));
+  assert.ok(!decDates.includes('2025-12-26'));
+
+  // Christmas scheduling rules
+  const choir2 = await db.choir.create({ name: 'Xmas Choir' });
+  const user2 = await db.user.create({ email: 'x@example.com' });
+  await db.plan_rule.create({ choirId: choir2.id, dayOfWeek: 0 }); // Sundays
+
+  const baseReq2 = { activeChoirId: choir2.id, userId: user2.id };
+
+  await controller.findByMonth({ ...baseReq2, params: { year: 2021, month: 12 } }, res);
+  const xmasDates = res.data.map(a => a.date);
+  assert.ok(xmasDates.includes('2021-12-25'));
+  assert.ok(!xmasDates.includes('2021-12-26'));
 
     console.log('availability.controller tests passed');
     await db.sequelize.close();

--- a/choir-app-backend/tests/monthlyPlan.controller.test.js
+++ b/choir-app-backend/tests/monthlyPlan.controller.test.js
@@ -35,6 +35,16 @@ const controller = require('../src/controllers/monthlyPlan.controller');
     assert.strictEqual(res.data.finalized, false);
     assert.strictEqual(res.data.version, versionAfter); // version should not change on reopen
 
+    // Christmas rules
+    const choir2 = await db.choir.create({ name: 'Xmas Choir', modules: { dienstplan: true } });
+    await db.plan_rule.create({ choirId: choir2.id, dayOfWeek: 0 });
+    const baseReq2 = { activeChoirId: choir2.id };
+    await controller.create({ ...baseReq2, body: { year: 2021, month: 12 } }, res);
+    const entries2021 = await db.plan_entry.findAll({ where: { monthlyPlanId: res.data.id } });
+    const dates = entries2021.map(e => e.date.toISOString().split('T')[0]);
+    assert.ok(dates.includes('2021-12-25'));
+    assert.ok(!dates.includes('2021-12-26'));
+
     console.log('monthlyPlan controller tests passed');
     await db.sequelize.close();
   } catch (err) {


### PR DESCRIPTION
## Summary
- show December 25th as additional availability when it's not on a regular service day
- omit service on December 26th if it falls on a Sunday
- adjust plan generation for these rules
- expand unit tests for the new behavior

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --prefix choir-app-frontend` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d83996b8c8320abb1f8dd7180c26a