### PR TITLE
Implement event link in calendar

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -8,9 +8,14 @@
   <h3>{{ selectedDate | date:'longDate' }}</h3>
   <mat-list>
     <mat-list-item *ngFor="let ev of eventsForSelectedDate">
-      <div matLine>
-        {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
+      <div matLine *ngIf="ev.type !== 'HOLIDAY'; else holidayLabel">
+        <a [routerLink]="['/events']" [queryParams]="{ eventId: (ev as Event).id }" class="event-link">
+          {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
+        </a>
       </div>
+      <ng-template #holidayLabel>
+        <div matLine>{{ ev.name }}</div>
+      </ng-template>
       <div matLine class="notes" *ngIf="ev.notes">{{ ev.notes }}</div>
     </mat-list-item>
   </mat-list>

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
+import { RouterModule } from '@angular/router';
 import { ApiService } from '@core/services/api.service';
 import { Event } from '@core/models/event';
 
@@ -17,7 +18,7 @@ type CalendarEntry = Event | HolidayEvent;
 @Component({
   selector: 'app-my-calendar',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [CommonModule, MaterialModule, RouterModule],
   templateUrl: './my-calendar.component.html',
   styleUrls: ['./my-calendar.component.scss']
 })


### PR DESCRIPTION
## Summary
- show events in 'Meine Termine' calendar as links
- allow navigation to event details by clicking an event

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d98fb29308320bfb7a62885e84921