### PR TITLE
Modularize ApiService usage

### DIFF
--- a/choir-app-frontend/src/app/core/services/search.service.ts
+++ b/choir-app-frontend/src/app/core/services/search.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { Piece } from '../models/piece';
+import { Event } from '../models/event';
+import { Collection } from '../models/collection';
+
+@Injectable({ providedIn: 'root' })
+export class SearchService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  searchAll(term: string): Observable<{ pieces: Piece[]; events: Event[]; collections: Collection[] }> {
+    const params = new HttpParams().set('q', term);
+    return this.http.get<{ pieces: Piece[]; events: Event[]; collections: Collection[] }>(`${this.apiUrl}/search`, { params });
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
-import { ApiService } from 'src/app/core/services/api.service';
+import { ComposerService } from 'src/app/core/services/composer.service';
+import { AuthorService } from 'src/app/core/services/author.service';
 import { Composer } from 'src/app/core/models/composer';
 import { Author } from 'src/app/core/models/author';
 import { MatTableDataSource } from '@angular/material/table';
@@ -35,7 +36,8 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
-  constructor(private adminApiService: ApiService,
+  constructor(private composerService: ComposerService,
+              private authorService: AuthorService,
               private dialog: MatDialog,
               private paginatorService: PaginatorService) {
     this.pageSize = this.paginatorService.getPageSize('manage-creators', this.pageSizeOptions[0]);
@@ -56,8 +58,8 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
 
   loadData(): void {
     const obs = this.mode === 'composer'
-      ? this.adminApiService.getComposers()
-      : this.adminApiService.getAuthors();
+      ? this.composerService.getComposers()
+      : this.authorService.getAuthors();
 
     obs.subscribe((data) => {
       this.people = data;
@@ -92,8 +94,8 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
     ref.afterClosed().subscribe(result => {
       if (result) {
         const req = this.mode === 'composer'
-          ? this.adminApiService.createComposer(result)
-          : this.adminApiService.createAuthor(result);
+          ? this.composerService.createComposer(result)
+          : this.authorService.createAuthor(result);
         req.subscribe(() => this.loadData());
       }
     });
@@ -107,8 +109,8 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
     ref.afterClosed().subscribe(result => {
       if (result) {
         const req = this.mode === 'composer'
-          ? this.adminApiService.updateComposer(person.id, result)
-          : this.adminApiService.updateAuthor(person.id, result);
+          ? this.composerService.updateComposer(person.id, result)
+          : this.authorService.updateAuthor(person.id, result);
         req.subscribe(() => this.loadData());
       }
     });
@@ -119,16 +121,16 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
     const question = this.mode === 'composer' ? 'Komponist löschen?' : 'Dichter löschen?';
     if (confirm(question)) {
       const req = this.mode === 'composer'
-        ? this.adminApiService.deleteComposer(person.id)
-        : this.adminApiService.deleteAuthor(person.id);
+        ? this.composerService.deleteComposer(person.id)
+        : this.authorService.deleteAuthor(person.id);
       req.subscribe(() => this.loadData());
     }
   }
 
   enrichPerson(person: Composer | Author): void {
     const req = this.mode === 'composer'
-      ? this.adminApiService.enrichComposer(person.id)
-      : this.adminApiService.enrichAuthor(person.id);
+      ? this.composerService.enrichComposer(person.id)
+      : this.authorService.enrichAuthor(person.id);
     req.subscribe(updated => {
       const idx = this.people.findIndex(p => p.id === person.id);
       if (idx !== -1) {

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.spec.ts
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.spec.ts
@@ -1,25 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
-import { ApiService } from '@core/services/api.service';
+import { SearchService } from '@core/services/search.service';
 import { SearchResultsComponent } from './search-results.component';
 
 describe('SearchResultsComponent', () => {
   let component: SearchResultsComponent;
   let fixture: ComponentFixture<SearchResultsComponent>;
-  let apiSpy: jasmine.SpyObj<ApiService>;
+  let searchSpy: jasmine.SpyObj<SearchService>;
 
   beforeEach(async () => {
-    apiSpy = jasmine.createSpyObj('ApiService', ['searchAll']);
+    searchSpy = jasmine.createSpyObj('SearchService', ['searchAll']);
     await TestBed.configureTestingModule({
       imports: [SearchResultsComponent],
       providers: [
         { provide: ActivatedRoute, useValue: { queryParamMap: of({ get: () => 'x' }) } },
-        { provide: ApiService, useValue: apiSpy }
+        { provide: SearchService, useValue: searchSpy }
       ]
     }).compileComponents();
 
-    apiSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [] }));
+    searchSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [] }));
     fixture = TestBed.createComponent(SearchResultsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.ts
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
-import { ApiService } from '@core/services/api.service';
+import { SearchService } from '@core/services/search.service';
 import { Piece } from '@core/models/piece';
 import { Event } from '@core/models/event';
 import { Collection } from '@core/models/collection';
@@ -18,13 +18,13 @@ export class SearchResultsComponent implements OnInit {
   query = '';
   results: { pieces: Piece[]; events: Event[]; collections: Collection[] } = { pieces: [], events: [], collections: [] };
 
-  constructor(private route: ActivatedRoute, private api: ApiService) {}
+  constructor(private route: ActivatedRoute, private search: SearchService) {}
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe(params => {
       this.query = params.get('q') || '';
       if (this.query) {
-        this.api.searchAll(this.query).subscribe(res => this.results = res);
+        this.search.searchAll(this.query).subscribe(res => this.results = res);
       } else {
         this.results = { pieces: [], events: [], collections: [] };
       }

--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
-import { ApiService } from '@core/services/api.service';
+import { SearchService } from '@core/services/search.service';
 import { SearchBoxComponent } from './search-box.component';
 
 
@@ -10,21 +10,21 @@ describe('SearchBoxComponent', () => {
   let component: SearchBoxComponent;
   let fixture: ComponentFixture<SearchBoxComponent>;
 
-  let apiSpy: jasmine.SpyObj<ApiService>;
+  let searchSpy: jasmine.SpyObj<SearchService>;
   let routerSpy: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
-    apiSpy = jasmine.createSpyObj('ApiService', ['searchAll']);
+    searchSpy = jasmine.createSpyObj('SearchService', ['searchAll']);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     await TestBed.configureTestingModule({
       imports: [SearchBoxComponent, HttpClientTestingModule],
       providers: [
-        { provide: ApiService, useValue: apiSpy },
+        { provide: SearchService, useValue: searchSpy },
         { provide: Router, useValue: routerSpy }
       ]
     }).compileComponents();
 
-    apiSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [] }));
+    searchSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [] }));
     fixture = TestBed.createComponent(SearchBoxComponent);
     component = fixture.componentInstance;
 
@@ -39,7 +39,7 @@ describe('SearchBoxComponent', () => {
 
     component.searchCtrl.setValue('abc');
     tick(300); // advance time for debounceTime
-    expect(apiSpy.searchAll).toHaveBeenCalledWith('abc');
+    expect(searchSpy.searchAll).toHaveBeenCalledWith('abc');
 
   }));
 

--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.ts
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.ts
@@ -5,7 +5,7 @@ import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { of } from 'rxjs';
-import { ApiService } from '@core/services/api.service';
+import { SearchService } from '@core/services/search.service';
 import { Router, RouterModule } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 
@@ -24,13 +24,13 @@ export class SearchBoxComponent implements OnInit {
   searchCtrl = new FormControl('');
   results: { pieces: any[]; events: any[]; collections: any[] } = { pieces: [], events: [], collections: [] };
 
-  constructor(private api: ApiService, private router: Router) {}
+  constructor(private search: SearchService, private router: Router) {}
 
   ngOnInit(): void {
     this.searchCtrl.valueChanges.pipe(
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(val => val ? this.api.searchAll(val) : of({ pieces: [], events: [], collections: [] }))
+      switchMap(val => val ? this.search.searchAll(val) : of({ pieces: [], events: [], collections: [] }))
     ).subscribe(res => this.results = res);
 
   }


### PR DESCRIPTION
## Summary
- add new `SearchService`
- update components to use `SearchService`
- inject `ComposerService` and `AuthorService` in admin creator management

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7afeb2288320b394ebd2776626ff