### PR TITLE
Fix Angular template parse errors

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterModule } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 import { EventTypeLabelPipe } from '@shared/pipes/event-type-label.pipe';
-import { PieceStatusLabelPipe } from '@shared/pipes/piece-status-label.pipe';
 import { ApiService } from '@core/services/api.service';
 import { Piece, PieceNote } from '@core/models/piece';
 import { AuthService } from '@core/services/auth.service';
@@ -18,8 +17,7 @@ import { FormsModule } from '@angular/forms';
     FormsModule,
     MaterialModule,
     RouterModule,
-    EventTypeLabelPipe,
-    PieceStatusLabelPipe
+    EventTypeLabelPipe
   ],
   templateUrl: './piece-detail.component.html',
   styleUrls: ['./piece-detail.component.scss']

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -9,7 +9,7 @@
   <mat-list>
     <mat-list-item *ngFor="let ev of eventsForSelectedDate">
       <div matLine *ngIf="ev.type !== 'HOLIDAY'; else holidayLabel">
-        <a [routerLink]="['/events']" [queryParams]="{ eventId: (ev as Event).id }" class="event-link">
+        <a [routerLink]="['/events']" [queryParams]="{ eventId: ev.id }" class="event-link">
           {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
         </a>
       </div>


### PR DESCRIPTION
## Summary
- remove unused `PieceStatusLabelPipe` from `PieceDetailComponent`
- simplify query param expression in `MyCalendarComponent` template

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df65ec0288320b26f749488ec777f