### PR TITLE
Fix calendar layout

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -1,13 +1,14 @@
-<h2>Meine Termine</h2>
-<mat-calendar class="compact"
-              [selected]="selectedDate"
-              (selectedChange)="onSelectedChange($event)"
-              [dateClass]="dateClass"></mat-calendar>
+<div class="calendar-wrapper">
+  <h2>Meine Termine</h2>
+  <mat-calendar class="compact"
+                [selected]="selectedDate"
+                (selectedChange)="onSelectedChange($event)"
+                [dateClass]="dateClass"></mat-calendar>
 
-<div class="event-list" *ngIf="eventsForSelectedDate.length > 0">
-  <h3>{{ selectedDate | date:'longDate' }}</h3>
-  <mat-list>
-    <mat-list-item *ngFor="let ev of eventsForSelectedDate">
+  <div #eventList class="event-list" *ngIf="eventsForSelectedDate.length > 0">
+    <h3>{{ selectedDate | date:'longDate' }}</h3>
+    <mat-list>
+      <mat-list-item *ngFor="let ev of eventsForSelectedDate">
       <div matLine *ngIf="ev.type !== 'HOLIDAY'; else holidayLabel">
         <a [routerLink]="['/events']" [queryParams]="{ eventId: ev.id }" class="event-link">
           {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
@@ -19,7 +20,8 @@
       <div matLine class="notes" *ngIf="ev.notes">{{ ev.notes }}</div>
     </mat-list-item>
   </mat-list>
-</div>
-<div *ngIf="eventsForSelectedDate.length === 0">
-  <p>Keine Termine an diesem Tag.</p>
+  </div>
+  <div *ngIf="eventsForSelectedDate.length === 0">
+    <p>Keine Termine an diesem Tag.</p>
+  </div>
 </div>

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
@@ -20,6 +20,24 @@ mat-calendar.compact .mat-calendar-body-cell-content {
   line-height: 32px;
 }
 
+.calendar-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: auto;
+}
+
+mat-calendar.compact {
+  width: 100%;
+  max-width: 360px;
+}
+
+.event-list {
+  margin-top: 16px;
+  width: 100%;
+  max-width: 360px;
+}
+
 .event-list {
   margin-top: 16px;
 }

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { RouterModule } from '@angular/router';
@@ -27,6 +27,8 @@ export class MyCalendarComponent implements OnInit {
   eventMap: { [date: string]: Event[] } = {};
   holidayMap: { [date: string]: string } = {};
   selectedDate: Date = new Date();
+
+  @ViewChild('eventList') eventList?: ElementRef<HTMLElement>;
 
   constructor(private api: ApiService) {}
 
@@ -91,6 +93,9 @@ export class MyCalendarComponent implements OnInit {
   onSelectedChange(date: Date | null): void {
     if (date) {
       this.selectedDate = date;
+      setTimeout(() => {
+        this.eventList?.nativeElement.scrollIntoView({ behavior: 'smooth' });
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- tweak calendar layout and width for mobile
- scroll to selected entry automatically

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dfa0d30908320a496fe6ec88aba8d