### PR TITLE
Show user assignments in calendar

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -9,17 +9,29 @@
     <h3>{{ selectedDate | date:'longDate' }}</h3>
     <mat-list>
       <mat-list-item *ngFor="let ev of eventsForSelectedDate">
-      <div matLine *ngIf="ev.type !== 'HOLIDAY'; else holidayLabel">
-        <a [routerLink]="['/events']" [queryParams]="{ eventId: ev.id }" class="event-link">
-          {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
-        </a>
-      </div>
-      <ng-template #holidayLabel>
-        <div matLine>{{ ev.name }}</div>
-      </ng-template>
-      <div matLine class="notes" *ngIf="ev.notes">{{ ev.notes }}</div>
-    </mat-list-item>
-  </mat-list>
+        <ng-container [ngSwitch]="ev.entryType">
+          <ng-container *ngSwitchCase="'PLAN'">
+            <div matLine>
+              Dienst:
+              <span *ngIf="ev.director?.id === currentUserId">Chorleitung</span>
+              <span *ngIf="ev.organist?.id === currentUserId">{{ ev.director?.id === currentUserId && ev.organist?.id === currentUserId ? ', ' : '' }}Orgel</span>
+            </div>
+            <div matLine class="notes" *ngIf="ev.notes">{{ ev.notes }}</div>
+          </ng-container>
+          <ng-container *ngSwitchDefault>
+            <div matLine *ngIf="ev.type !== 'HOLIDAY'; else holidayLabel">
+              <a [routerLink]="['/events']" [queryParams]="{ eventId: ev.id }" class="event-link">
+                {{ ev.type === 'SERVICE' ? 'Gottesdienst' : (ev.type === 'REHEARSAL' ? 'Probe' : ev.name) }}
+              </a>
+            </div>
+            <ng-template #holidayLabel>
+              <div matLine>{{ ev.name }}</div>
+            </ng-template>
+            <div matLine class="notes" *ngIf="ev.notes">{{ ev.notes }}</div>
+          </ng-container>
+        </ng-container>
+      </mat-list-item>
+    </mat-list>
   </div>
   <div *ngIf="eventsForSelectedDate.length === 0">
     <p>Keine Termine an diesem Tag.</p>


### PR DESCRIPTION
## Summary
- extend calendar model to include plan entries
- fetch plan assignments for each month
- highlight plan entries in date picker
- display assigned duties in "Meine Termine"

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e927ca0308320b09cb45827f11f97