### PR TITLE
Install backend deps during deploy

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -122,6 +122,9 @@ Invoke-Scp $FrontendArchive "${Remote}:/tmp/frontend.tar.gz"
 Invoke-Ssh "tar -xzf /tmp/backend.tar.gz -C '$BackendDest'; rm /tmp/backend.tar.gz"
 Invoke-Ssh "tar -xzf /tmp/frontend.tar.gz -C '$FrontendDest'; rm /tmp/frontend.tar.gz"
 
+# Ensure backend dependencies are installed
+Invoke-Ssh "cd '$BackendDest' && npm install"
+
 # Restart backend
 Invoke-Ssh "pm2 restart chorleiter-api"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -90,6 +90,9 @@ scp_cmd "$FRONTEND_ARCHIVE" ${REMOTE}:/tmp/frontend.tar.gz
 ssh_cmd "$REMOTE" "tar -xzf /tmp/backend.tar.gz -C \"$BACKEND_DEST\"; rm /tmp/backend.tar.gz"
 ssh_cmd "$REMOTE" "tar -xzf /tmp/frontend.tar.gz -C \"$FRONTEND_DEST\"; rm /tmp/frontend.tar.gz"
 
+# Ensure backend dependencies are installed
+ssh_cmd "$REMOTE" "cd \"$BACKEND_DEST\" && npm install"
+
 # Restart backend
 ssh_cmd "$REMOTE" "pm2 restart chorleiter-api"
 


### PR DESCRIPTION
## Summary
- run `npm install` on server after uploading backend files in `deploy.sh`
- run `npm install` on server after uploading backend files in `deploy.ps1`

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm test --prefix choir-app-backend` *(fails: missing module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686e9d936dcc8320a69d32f2ab51ef9e