### PR TITLE
Highlight calendar days with entries in bold

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
@@ -2,6 +2,7 @@
   background-color: #3f51b5;
   color: #fff;
   border-radius: 50%;
+  font-weight: bold;
 }
 
 .holiday:not(.has-event) .mat-calendar-body-cell-content {


### PR DESCRIPTION
## Summary
- mark calendar cells that contain PlanEntries or Events as bold

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f42a1de9c8320b035e95fc78741f8