### PR TITLE
Hide search on narrow screens

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -6,7 +6,7 @@
   <span class="title"><a href="/" class="page-title-link">NAK Chorleiter</a></span>
 
   <span class="spacer"></span>
-  <app-search-box *ngIf="isLoggedIn$ | async"></app-search-box>
+  <app-search-box *ngIf="(isLoggedIn$ | async) && !(isHandset$ | async)"></app-search-box>
   <ng-container *ngIf="(isLoggedIn$ | async) && !(donatedRecently$ | async)">
     <button mat-button color="accent" routerLink="/donate">Spenden</button>
   </ng-container>
@@ -19,7 +19,7 @@
     <button mat-icon-button [matMenuTriggerFor]="userMenu" matTooltip="Benutzerprofil">
       <mat-icon style="color:white"><img src="./../../assets/icons/user-filled.svg"></mat-icon>
     </button>
-    <span class="user-name">{{ userName$ | async }}</span>
+    <span class="user-name" [ngClass]="{'hide-on-handset': (isHandset$ | async)}">{{ userName$ | async }}</span>
     <mat-menu #userMenu="matMenu">
       <a mat-menu-item routerLink="/profile">
         <mat-icon><img src="./../../assets/icons/user-filled.svg"></mat-icon>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
@@ -92,3 +92,7 @@
     width: 70vw;
   }
 }
+
+.hide-on-handset {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- hide the search box on phones using `isHandset$`
- add hide-on-handset class for username

## Testing
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f42fae0f8832086b451d939b42160