### PR TITLE
Add calendar debug info for admins

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -36,4 +36,15 @@
   <div *ngIf="eventsForSelectedDate.length === 0">
     <p>Keine Termine an diesem Tag.</p>
   </div>
+  <div *ngIf="isAdmin" class="debug-info">
+    <h3>Debug Info</h3>
+    <p>Events geladen: {{ events.length }}</p>
+    <ul>
+      <li *ngFor="let ev of events">{{ ev.date }} - {{ ev.type }}</li>
+    </ul>
+    <p>PlanEntries geladen: {{ allPlanEntries.length }}</p>
+    <ul>
+      <li *ngFor="let pe of allPlanEntries">{{ pe.date }} - {{ pe.notes }}</li>
+    </ul>
+  </div>
 </div>

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -34,12 +34,15 @@ export class MyCalendarComponent implements OnInit {
   selectedDate: Date = new Date();
   currentUserId: number | null = null;
   private loadedPlanMonths = new Set<string>();
+  allPlanEntries: PlanEntry[] = [];
+  isAdmin = false;
 
   @ViewChild('eventList') eventList?: ElementRef<HTMLElement>;
 
   constructor(private api: ApiService, private auth: AuthService) {}
 
   ngOnInit(): void {
+    this.auth.isAdmin$.subscribe(v => (this.isAdmin = v));
     this.loadEvents();
     const year = this.selectedDate.getFullYear();
     [year - 1, year, year + 1].forEach(y => {
@@ -78,6 +81,7 @@ export class MyCalendarComponent implements OnInit {
         const dKey = new Date(entry.date).toISOString().substring(0, 10);
         if (!this.planEntryMap[dKey]) this.planEntryMap[dKey] = [];
         this.planEntryMap[dKey].push(entry);
+        this.allPlanEntries.push(entry);
       }
     });
   }


### PR DESCRIPTION
## Summary
- show loaded events/plan entries for admins
- track loaded plan entries for debugging

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f45bd84308320918c8305a7f5a24b