### PR TITLE
Include all choir events in my calendar

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -13,10 +13,14 @@
           <ng-container *ngSwitchCase="'PLAN'">
             <div matLine>
               Dienst:
-              <span *ngIf="$any(ev).director?.id === currentUserId">Chorleitung</span>
-              <span *ngIf="$any(ev).organist?.id === currentUserId">{{ $any(ev).director?.id === currentUserId && $any(ev).organist?.id === currentUserId ? ', ' : '' }}Orgel</span>
+              <span *ngIf="$any(ev).director">
+                <span [class.me]="$any(ev).director?.id === currentUserId">Chorleitung {{ $any(ev).director.name }}</span>
+              </span>
+              <span *ngIf="$any(ev).organist">
+                {{ $any(ev).director ? ', ' : '' }}<span [class.me]="$any(ev).organist?.id === currentUserId">Orgel {{ $any(ev).organist.name }}</span>
+              </span>
             </div>
-              <div matLine class="notes" *ngIf="$any(ev).notes">{{ $any(ev).notes }}</div>
+            <div matLine class="notes" *ngIf="$any(ev).notes">{{ $any(ev).notes }}</div>
           </ng-container>
           <ng-container *ngSwitchDefault>
             <div matLine *ngIf="$any(ev).type !== 'HOLIDAY'; else holidayLabel">

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
@@ -39,6 +39,10 @@ mat-calendar.compact {
   max-width: 360px;
 }
 
+.me {
+  font-weight: bold;
+}
+
 .event-list {
   margin-top: 16px;
 }

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -70,14 +70,11 @@ export class MyCalendarComponent implements OnInit {
 
   private loadPlanEntriesForMonth(year: number, month: number): void {
     const key = `${year}-${month}`;
-    if (this.loadedPlanMonths.has(key) || this.currentUserId === null) return;
+    if (this.loadedPlanMonths.has(key)) return;
     this.loadedPlanMonths.add(key);
     this.api.getMonthlyPlan(year, month).subscribe(plan => {
       if (!plan) return;
       for (const entry of plan.entries || []) {
-        if (entry.director?.id !== this.currentUserId && entry.organist?.id !== this.currentUserId) {
-          continue;
-        }
         const dKey = new Date(entry.date).toISOString().substring(0, 10);
         if (!this.planEntryMap[dKey]) this.planEntryMap[dKey] = [];
         this.planEntryMap[dKey].push(entry);


### PR DESCRIPTION
## Summary
- show plan entries for other choir members in "My Calendar"
- display director and organist names
- highlight current user's assignments

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe89e92dc8320911b9d87baedf4c1