### PR TITLE
Add upcoming events to dashboard

### DIFF
--- a/choir-app-backend/src/routes/event.routes.js
+++ b/choir-app-backend/src/routes/event.routes.js
@@ -8,6 +8,7 @@ const router = require("express").Router();
 router.use(authJwt.verifyToken);
 
 router.get("/last", controller.findLast);
+router.get("/next", controller.findNext);
 router.get("/", controller.findAll);
 router.get("/:id", controller.findOne);
 router.post("/", createEventValidation, validate, controller.create);

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -312,6 +312,10 @@ export class ApiService {
     return this.eventService.getEvents(type);
   }
 
+  getNextEvents(limit?: number, mine?: boolean): Observable<Event[]> {
+    return this.eventService.getNextEvents(limit, !!mine);
+  }
+
   getEventById(id: number): Observable<Event> {
     return this.eventService.getEventById(id);
   }

--- a/choir-app-frontend/src/app/core/services/event.service.ts
+++ b/choir-app-frontend/src/app/core/services/event.service.ts
@@ -26,6 +26,12 @@ export class EventService {
     return this.http.get<Event[]>(`${this.apiUrl}/events`, { params });
   }
 
+  getNextEvents(limit: number = 3, mine: boolean = false): Observable<Event[]> {
+    let params = new HttpParams().set('limit', limit);
+    if (mine) params = params.set('mine', 'true');
+    return this.http.get<Event[]>(`${this.apiUrl}/events/next`, { params });
+  }
+
   getEventById(id: number): Observable<Event> {
     return this.http.get<Event>(`${this.apiUrl}/events/${id}`);
   }

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -25,6 +25,21 @@
   </app-event-card>
 </div>
 
+<div class="upcoming-section">
+  <h2>Nächste Termine</h2>
+  <mat-slide-toggle [(ngModel)]="showOnlyMine" (change)="onToggleMine()">
+    Nur meine Termine
+  </mat-slide-toggle>
+  <mat-list>
+    <mat-list-item *ngFor="let ev of nextEvents$ | async">
+      <a [routerLink]="['/events', ev.id]">
+        {{ ev.date | date:'shortDate' }} -
+        {{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}
+      </a>
+    </mat-list-item>
+  </mat-list>
+</div>
+
 <div *ngIf="pieceChanges$ | async as changes">
   <h2>Änderungsvorschläge</h2>
   <mat-list *ngIf="changes.length > 0; else noChanges">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -7,6 +7,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { MaterialModule } from '@modules/material.module';
+import { FormsModule } from '@angular/forms';
 import { ApiService } from '@core/services/api.service';
 import { CreateEventResponse, Event } from '@core/models/event';
 import { EventDialogComponent } from '../../events/event-dialog/event-dialog.component';
@@ -27,6 +28,7 @@ import { UserPreferences } from '@core/models/user-preferences';
     CommonModule,
     RouterModule,
     MaterialModule,
+    FormsModule,
     EventCardComponent
   ],
   templateUrl: './dashboard.component.html',
@@ -40,6 +42,8 @@ export class DashboardComponent implements OnInit {
   lastRehearsal$!: Observable<Event | null>;
   activeChoir$: Observable<Choir | null>;
   pieceChanges$!: Observable<PieceChange[]>;
+  nextEvents$!: Observable<Event[]>;
+  showOnlyMine = false;
 
   constructor(
     private apiService: ApiService,
@@ -60,6 +64,10 @@ export class DashboardComponent implements OnInit {
 
     this.lastRehearsal$ = this.refresh$.pipe(
       switchMap(() => this.apiService.getLastEvent('REHEARSAL'))
+    );
+
+    this.nextEvents$ = this.refresh$.pipe(
+      switchMap(() => this.apiService.getNextEvents(3, this.showOnlyMine))
     );
 
     this.pieceChanges$ = this.authService.isAdmin$.pipe(
@@ -158,6 +166,10 @@ export class DashboardComponent implements OnInit {
         });
       }
     });
+  }
+
+  onToggleMine(): void {
+    this.refresh$.next();
   }
 
 }


### PR DESCRIPTION
## Summary
- create endpoint to fetch upcoming events
- expose new API method on the frontend
- show the next three appointments on the dashboard with a toggle to filter by user

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686ff03cc2d883209dece1d07e7b2432