### PR TITLE
Remove calendar debug section

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -40,15 +40,4 @@
   <div *ngIf="eventsForSelectedDate.length === 0">
     <p>Keine Termine an diesem Tag.</p>
   </div>
-  <div *ngIf="isAdmin" class="debug-info">
-    <h3>Debug Info</h3>
-    <p>Events geladen: {{ events.length }}</p>
-    <ul>
-      <li *ngFor="let ev of events">{{ ev.date }} - {{ ev.type }}</li>
-    </ul>
-    <p>PlanEntries geladen: {{ allPlanEntries.length }}</p>
-    <ul>
-      <li *ngFor="let pe of allPlanEntries">{{ pe.date }} - {{ pe.notes }}</li>
-    </ul>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- remove the debug section from the calendar template

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ff3fc7cfc8320b27a354af4a98c2a