### PR TITLE
Fix Monday as first day of week

### DIFF
--- a/choir-app-frontend/src/app/core/adapters/monday-first-date-adapter.ts
+++ b/choir-app-frontend/src/app/core/adapters/monday-first-date-adapter.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { NativeDateAdapter } from '@angular/material/core';
+
+@Injectable()
+export class MondayFirstDateAdapter extends NativeDateAdapter {
+  override getFirstDayOfWeek(): number {
+    return 1; // Monday
+  }
+}

--- a/choir-app-frontend/src/main.ts
+++ b/choir-app-frontend/src/main.ts
@@ -15,7 +15,8 @@ import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de'; // Importieren Sie das deutsche Sprachpaket
 import localeDeExtra from '@angular/common/locales/extra/de'; // Optionale extra Daten
 import { LOCALE_ID } from '@angular/core';
-import { MAT_DATE_LOCALE } from '@angular/material/core';
+import { MAT_DATE_LOCALE, DateAdapter } from '@angular/material/core';
+import { MondayFirstDateAdapter } from './app/core/adapters/monday-first-date-adapter';
 
 registerLocaleData(localeDe, 'de-DE', localeDeExtra);
 
@@ -31,6 +32,7 @@ bootstrapApplication(AppComponent, {
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
     { provide: LOCALE_ID, useValue: 'de-DE' },
     { provide: MAT_DATE_LOCALE, useValue: 'de-DE' },
+    { provide: DateAdapter, useClass: MondayFirstDateAdapter },
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: { verticalPosition: 'top' } }
   ]
 }).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- ensure calendars use Monday as first day of week
- create custom adapter `MondayFirstDateAdapter`
- provide adapter in app bootstrap

## Testing
- `npm test --silent --prefix choir-app-frontend`
- `npm test --silent --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_686ff35be5fc8320930dcf004d270a17