### PR TITLE
Add mail configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Before starting the backend, install its dependencies:
 npm install --prefix choir-app-backend
 ```
 
+### Mail Configuration
+
+Configure the SMTP server used for password resets and invitations by adding the
+following variables to `choir-app-backend/.env` (or set them as environment
+variables):
+
+```ini
+SMTP_HOST=localhost
+SMTP_PORT=25
+SMTP_USER=no-reply
+SMTP_PASS=
+EMAIL_FROM=no-reply@nak-chorleiter.de
+```
+
+When the application is started for the first time these settings are written to
+the database and can later be changed through the admin endpoint
+`/admin/mail-settings`.
+
 ## Tests
 
 Run frontend unit tests with:

--- a/choir-app-backend/.env
+++ b/choir-app-backend/.env
@@ -6,3 +6,10 @@ DB_PASSWORD=1234
 DB_NAME=choir_db
 DB_DIALECT=postgres
 JWT_SECRET=this-is-a-very-secret-key-change-it
+
+# SMTP configuration for outgoing mails
+SMTP_HOST=localhost
+SMTP_PORT=25
+SMTP_USER=no-reply
+SMTP_PASS=
+EMAIL_FROM=no-reply@nak-chorleiter.de


### PR DESCRIPTION
## Summary
- document SMTP configuration in README
- include sample mail variables in `.env`

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --prefix choir-app-frontend` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffb7a0e508320a3cd5d6efadf696a