### PR TITLE
Add pre-deploy backend syntax check

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ npm install --save-dev compression-webpack-plugin @angular-builders/custom-webpa
 The generated `.gz` or `.br` files can then be served by a web server that
 supports content negotiation for pre-compressed assets.
 
+Before packaging the files for upload, the deployment scripts run a syntax check
+on `choir-app-backend/server.js` using `node --check`. This catches backend
+syntax errors locally so you don't discover them only after uploading.
+
 ## Deployment
 
 Use `deploy.sh` on Unix systems or `deploy.ps1` on Windows to upload the backend
@@ -83,3 +87,4 @@ private key into an SSH agent (for example with `Start-Service ssh-agent`
 followed by `ssh-add`). When `ssh` or `plink` can authenticate using the agent,
 the deployment runs non‑interactively. The PowerShell script automatically
 detects an available ssh-agent or `plink` to avoid repeated password prompts.
+The scripts will exit early if the backend syntax check fails.

--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js"
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js",
+    "check": "node --check server.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -12,6 +12,9 @@ npm --prefix choir-app-frontend run build
 
 Write-Host "Build finished."
 
+# Verify backend can start by syntax checking server.js
+npm --prefix choir-app-backend run check
+
 # Determine authentication method
 $sshUseAgent = $false
 $sshUsePlink = $false

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,6 +13,9 @@ npm --prefix choir-app-frontend run build
 
 echo "Build finished."
 
+# Verify backend can start by syntax checking server.js
+npm --prefix choir-app-backend run check
+
 # Check for sshpass before proceeding
 USE_SSHPASS=false
 if command -v sshpass >/dev/null; then

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chorleiter-root",
   "private": true,
   "scripts": {
-    "test": "npm test --prefix choir-app-frontend"
+    "test": "npm test --prefix choir-app-frontend",
+    "check-backend": "npm run check --prefix choir-app-backend"
   }
 }


### PR DESCRIPTION
## Summary
- add `check-backend` script and backend `check` command
- run the syntax check in `deploy.sh` and `deploy.ps1`
- document syntax check in README

## Testing
- `npm run check-backend`
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: missing module)*

------
https://chatgpt.com/codex/tasks/task_e_6870059a43808320a6cb293d064c9cd4