### PR TITLE
Add back to login link on reset page

### DIFF
--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.html
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.html
@@ -15,6 +15,7 @@
         </mat-card-actions>
       </form>
       <p *ngIf="message">{{ message }}</p>
+      <p class="reset-link"><a routerLink="/login">Zurück zum Login</a></p>
     </mat-card-content>
   </mat-card>
 </div>

--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.scss
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.scss
@@ -1,1 +1,2 @@
 .reset-container { display: flex; justify-content: center; margin-top: 2rem; }
+.reset-link { margin-top: 1rem; }


### PR DESCRIPTION
## Summary
- provide a link from the password reset request page back to the login page

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700617edec8320a71423df55d1caa6