### PR TITLE
Add test mail functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ EMAIL_FROM=no-reply@nak-chorleiter.de
 When the application is started for the first time these settings are written to
 the database and can later be changed through the admin endpoint
 `/admin/mail-settings`.
+After saving new settings you can send yourself a test email from that page to verify the configuration.
 
 ## Tests
 

--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -416,3 +416,15 @@ exports.updateMailSettings = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+exports.sendTestMail = async (req, res) => {
+    try {
+        const user = await db.user.findByPk(req.userId);
+        if (user) {
+            await emailService.sendTestMail(user.email);
+        }
+        res.status(200).send({ message: 'Test mail sent if user exists.' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -39,6 +39,7 @@ router.get('/logs/:filename', controller.getLog);
 router.delete('/logs/:filename', controller.deleteLog);
 router.get('/mail-settings', controller.getMailSettings);
 router.put('/mail-settings', controller.updateMailSettings);
+router.post('/mail-settings/test', controller.sendTestMail);
 
 module.exports = router;
 

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -40,3 +40,14 @@ exports.sendPasswordResetMail = async (to, token) => {
     html: `<p>Click <a href="${link}">here</a> to set a new password.</p>`
   });
 };
+
+exports.sendTestMail = async (to) => {
+  const settings = await db.mail_setting.findByPk(1);
+  const transporter = await createTransporter(settings);
+  await transporter.sendMail({
+    from: settings?.fromAddress || process.env.EMAIL_FROM || 'no-reply@example.com',
+    to,
+    subject: 'Testmail',
+    html: '<p>Dies ist eine Testmail.</p>'
+  });
+};

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -112,4 +112,8 @@ export class AdminService {
   updateMailSettings(data: MailSettings): Observable<MailSettings> {
     return this.http.put<MailSettings>(`${this.apiUrl}/admin/mail-settings`, data);
   }
+
+  sendTestMail(): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${this.apiUrl}/admin/mail-settings/test`, {});
+  }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -586,6 +586,10 @@ export class ApiService {
     return this.adminService.updateMailSettings(data);
   }
 
+  sendTestMail(): Observable<{ message: string }> {
+    return this.adminService.sendTestMail();
+  }
+
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {
     return this.adminService.checkChoirAdminStatus();
   }

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.html
@@ -21,4 +21,5 @@
     <input matInput formControlName="fromAddress">
   </mat-form-field>
   <button mat-raised-button color="primary" type="submit">Speichern</button>
+  <button mat-raised-button color="accent" type="button" (click)="sendTest()">Testmail senden</button>
 </form>

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
@@ -43,4 +43,10 @@ export class MailSettingsComponent implements OnInit {
       this.snack.open('Gespeichert', 'OK', { duration: 2000 });
     });
   }
+
+  sendTest(): void {
+    this.api.sendTestMail().subscribe(() => {
+      this.snack.open('Testmail verschickt', 'OK', { duration: 2000 });
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- allow sending test mails from admin mail settings
- support endpoint in the backend and API services
- document test mail capability

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702364ced0832092f12903cef7fd38