### PR TITLE
Display session expired message

### DIFF
--- a/choir-app-frontend/src/app/core/interceptors/auth-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/auth-interceptor.ts
@@ -46,7 +46,7 @@ export class AuthInterceptor implements HttpInterceptor {
                     console.warn(
                         'Unauthorized or Forbidden error detected. Logging out user.'
                     );
-                    this.authService.logout();
+                    this.authService.logout('sessionExpired');
                 }
                 // Leiten Sie den Fehler an den aufrufenden Service weiter, damit er auch behandelt werden kann.
                 return throwError(() => error);

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -77,7 +77,7 @@ export class AuthService {
     );
   }
 
-  logout(): void {
+  logout(reason?: string): void {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
     localStorage.removeItem('theme');
@@ -86,7 +86,8 @@ export class AuthService {
     this.currentUserSubject.next(null);
     this.activeChoir$.next(null);
     this.availableChoirs$.next([]);
-    this.router.navigate(['/login']);
+    const queryParams = reason === 'sessionExpired' ? { sessionExpired: true } : undefined;
+    this.router.navigate(['/login'], { queryParams });
   }
 
   switchChoir(choirId: number): Observable<SwitchChoirResponse> {

--- a/choir-app-frontend/src/app/features/login/login.component.html
+++ b/choir-app-frontend/src/app/features/login/login.component.html
@@ -1,6 +1,7 @@
 <div class="login-container">
-  <mat-card>
-    <mat-card-title class="card-title">Anmelden</mat-card-title>
+<mat-card>
+  <p *ngIf="sessionExpired" class="session-expired">Letzte Sitzung abgelaufen.</p>
+  <mat-card-title class="card-title">Anmelden</mat-card-title>
     <mat-card-content>
       <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
         <p>

--- a/choir-app-frontend/src/app/features/login/login.component.scss
+++ b/choir-app-frontend/src/app/features/login/login.component.scss
@@ -28,3 +28,9 @@ mat-form-field {
   display: inline-block;
   margin: 0 12px;
 }
+
+.session-expired {
+  color: red;
+  text-align: center;
+  margin-bottom: 1rem;
+}

--- a/choir-app-frontend/src/app/features/login/login.component.ts
+++ b/choir-app-frontend/src/app/features/login/login.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Router, RouterModule } from '@angular/router';
+import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { AuthService } from 'src/app/core/services/auth.service';
@@ -19,20 +19,28 @@ import { MaterialModule } from '@modules/material.module';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
   loginForm: FormGroup;
   isLoading = false;
+  sessionExpired = false;
 
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
     private router: Router, // Injizieren Sie den Angular Router
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private route: ActivatedRoute
   ) {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
       rememberMe: [false]
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.queryParamMap.subscribe(params => {
+      this.sessionExpired = params.has('sessionExpired');
     });
   }
 


### PR DESCRIPTION
## Summary
- handle token expiration in `auth.interceptor`
- allow `logout()` to pass reason and set query params
- show session expired message in login component

## Testing
- `npm test` *(fails: ng not found)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6874c529667c8320a909d3c5b183dbe5