### PR TITLE
Add custom piece search container

### DIFF
--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -29,29 +29,38 @@
 
     <!-- Piece Lookup -->
     <h3 class="mat-subheading-2">Stücke</h3>
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Nach Titel oder Referenz suchen (z.B. CB45)</mat-label>
-      <input
-        type="text"
-        matInput
-        [formControl]="pieceCtrl"
-        [matAutocomplete]="auto"
-        #pieceInput
-      >
-      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayPiece" (optionSelected)="selected($event)">
-        <mat-option *ngFor="let piece of filteredPieces$ | async" [value]="piece">
-          <div class="option-layout">
-            <!-- Zeigt den Titel und den Komponisten an -->
-            <div class="option-main">
-              <span class="option-title">{{ piece.title }}</span>
-              <small class="composer-hint"> - {{ piece.composerName }}</small>
-            </div>
-            <!-- Zeigt die Referenz an, wenn eine vorhanden ist -->
-            <span *ngIf="piece.reference" class="option-reference">{{ piece.reference }}</span>
-          </div>
-        </mat-option>
-      </mat-autocomplete>
-    </mat-form-field>
+    <div class="autocomplete-container">
+      <div class="search-box">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Nach Titel oder Referenz suchen (z.B. CB45)</mat-label>
+          <input
+            type="text"
+            matInput
+            autocomplete="off"
+            placeholder="im Literaturverzeichnis …"
+            [formControl]="pieceCtrl"
+            [matAutocomplete]="auto"
+            #pieceInput
+          >
+          <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayPiece" (optionSelected)="selected($event)">
+            <mat-option *ngFor="let piece of filteredPieces$ | async" [value]="piece">
+              <div class="option-layout">
+                <!-- Zeigt den Titel und den Komponisten an -->
+                <div class="option-main">
+                  <span class="option-title">{{ piece.title }}</span>
+                  <small class="composer-hint"> - {{ piece.composerName }}</small>
+                </div>
+                <!-- Zeigt die Referenz an, wenn eine vorhanden ist -->
+                <span *ngIf="piece.reference" class="option-reference">{{ piece.reference }}</span>
+              </div>
+            </mat-option>
+          </mat-autocomplete>
+        </mat-form-field>
+      </div>
+      <div class="add-custom">
+        oder <a (click)="openAddPieceDialog()">Eigene Literatur hinzufügen</a>
+      </div>
+    </div>
 
     <!-- Display Selected Pieces in a Table -->
     <table mat-table [dataSource]="selectedPiecesDataSource" class="selected-pieces-table">

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.scss
@@ -40,3 +40,18 @@ h3.mat-subheading-2 {
     color: #888;
     margin-top: 1rem;
 }
+
+// Neuer Container für die Stück-Suche
+.autocomplete-container {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+
+    .add-custom {
+        font-size: 0.875rem;
+        a {
+            cursor: pointer;
+        }
+    }
+}

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
@@ -16,6 +16,7 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { LookupPiece } from '@core/models/lookup-piece';
+import { PieceDialogComponent } from '../../literature/piece-dialog/piece-dialog.component';
 
 
 @Component({
@@ -52,6 +53,7 @@ export class EventDialogComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     private apiService: ApiService,
+    private dialog: MatDialog,
     public dialogRef: MatDialogRef<EventDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: { event?: Event } | null
   ) {
@@ -145,6 +147,32 @@ export class EventDialogComponent implements OnInit {
     }
     // Triggern Sie die Neubewertung der Autocomplete-Liste
     this.pieceCtrl.updateValueAndValidity();
+  }
+
+  openAddPieceDialog(): void {
+    const dialogRef = this.dialog.open(PieceDialogComponent, {
+      width: '90vw',
+      maxWidth: '800px',
+      data: { pieceId: null }
+    });
+
+    dialogRef.afterClosed().subscribe((newPiece: Piece | boolean | undefined) => {
+      if (newPiece && typeof newPiece !== 'boolean') {
+        const lookup: LookupPiece = {
+          id: newPiece.id,
+          title: newPiece.title,
+          composerName: newPiece.composer?.name || '',
+          reference:
+            newPiece.collections && newPiece.collections.length > 0
+              ? `${newPiece.collections[0].prefix || ''}${newPiece.collections[0].collection_piece.numberInCollection}`
+              : null
+        };
+        this.allRepertoirePieces.push(lookup);
+        this.selectedPieces = [...this.selectedPieces, lookup];
+        this.selectedPiecesDataSource.data = this.selectedPieces;
+        this.pieceCtrl.setValue('');
+      }
+    });
   }
 
   private populateFromEvent(event: Event): void {


### PR DESCRIPTION
## Summary
- add UI link for adding custom pieces directly from event dialog
- style search area with new autocomplete container
- update TypeScript to open the piece dialog when the link is clicked

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c82e39f08320a3e5153d8413587f