### PR TITLE
Implement unsaved mail settings guard and test mail override

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -421,7 +421,7 @@ exports.sendTestMail = async (req, res) => {
     try {
         const user = await db.user.findByPk(req.userId);
         if (user) {
-            await emailService.sendTestMail(user.email);
+            await emailService.sendTestMail(user.email, req.body);
         }
         res.status(200).send({ message: 'Test mail sent if user exists.' });
     } catch (err) {

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -41,8 +41,8 @@ exports.sendPasswordResetMail = async (to, token) => {
   });
 };
 
-exports.sendTestMail = async (to) => {
-  const settings = await db.mail_setting.findByPk(1);
+exports.sendTestMail = async (to, override) => {
+  const settings = override || await db.mail_setting.findByPk(1);
   const transporter = await createTransporter(settings);
   await transporter.sendMail({
     from: settings?.fromAddress || process.env.EMAIL_FROM || 'no-reply@nak-chorleiter.de',

--- a/choir-app-frontend/src/app/core/guards/pending-changes.guard.ts
+++ b/choir-app-frontend/src/app/core/guards/pending-changes.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface PendingChanges {
+  hasPendingChanges(): boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PendingChangesGuard implements CanDeactivate<PendingChanges> {
+  canDeactivate(component: PendingChanges): boolean | Observable<boolean> {
+    if (component.hasPendingChanges()) {
+      return confirm('Sie haben ungespeicherte Änderungen. Wirklich verlassen?');
+    }
+    return true;
+  }
+}

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -113,7 +113,7 @@ export class AdminService {
     return this.http.put<MailSettings>(`${this.apiUrl}/admin/mail-settings`, data);
   }
 
-  sendTestMail(): Observable<{ message: string }> {
-    return this.http.post<{ message: string }>(`${this.apiUrl}/admin/mail-settings/test`, {});
+  sendTestMail(data?: MailSettings): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${this.apiUrl}/admin/mail-settings/test`, data || {});
   }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -586,8 +586,8 @@ export class ApiService {
     return this.adminService.updateMailSettings(data);
   }
 
-  sendTestMail(): Observable<{ message: string }> {
-    return this.adminService.sendTestMail();
+  sendTestMail(data?: MailSettings): Observable<{ message: string }> {
+    return this.adminService.sendTestMail(data);
   }
 
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { MainLayoutComponent } from '../../layout/main-layout/main-layout.component';
+import { PendingChangesGuard } from '@core/guards/pending-changes.guard';
 
 export const adminRoutes: Routes = [
   {
@@ -7,7 +8,11 @@ export const adminRoutes: Routes = [
     component: MainLayoutComponent,
     children: [
       { path: '', redirectTo: 'general', pathMatch: 'full' },
-      { path: 'general', loadComponent: () => import('./general/general-settings.component').then(m => m.GeneralSettingsComponent) },
+      {
+        path: 'general',
+        loadComponent: () => import('./general/general-settings.component').then(m => m.GeneralSettingsComponent),
+        canDeactivate: [PendingChangesGuard]
+      },
       { path: 'creators', loadComponent: () => import('./manage-creators/manage-creators.component').then(m => m.ManageCreatorsComponent) },
       { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent) },
       { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent) },

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { MailSettingsComponent } from '../mail-settings/mail-settings.component';
 import { BackupComponent } from '../backup/backup.component';
+import { PendingChanges } from '@core/guards/pending-changes.guard';
 
 @Component({
   selector: 'app-general-settings',
@@ -11,4 +12,10 @@ import { BackupComponent } from '../backup/backup.component';
   templateUrl: './general-settings.component.html',
   styleUrls: ['./general-settings.component.scss']
 })
-export class GeneralSettingsComponent { }
+export class GeneralSettingsComponent implements PendingChanges {
+  @ViewChild(MailSettingsComponent) mailSettings?: MailSettingsComponent;
+
+  hasPendingChanges(): boolean {
+    return this.mailSettings?.hasPendingChanges() ?? false;
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.html
@@ -1,25 +1,27 @@
 <form [formGroup]="form" (ngSubmit)="save()" class="mail-form">
   <mat-form-field appearance="fill">
     <mat-label>Host</mat-label>
-    <input matInput formControlName="host">
+    <input matInput formControlName="host" />
   </mat-form-field>
   <mat-form-field appearance="fill">
     <mat-label>Port</mat-label>
-    <input matInput type="number" formControlName="port">
+    <input matInput type="number" formControlName="port" />
   </mat-form-field>
   <mat-form-field appearance="fill">
     <mat-label>Benutzer</mat-label>
-    <input matInput formControlName="user">
+    <input matInput formControlName="user" />
   </mat-form-field>
   <mat-form-field appearance="fill">
     <mat-label>Passwort</mat-label>
-    <input matInput type="password" formControlName="pass">
+    <input matInput type="password" formControlName="pass" />
   </mat-form-field>
   <mat-checkbox formControlName="secure">TLS/SSL</mat-checkbox>
   <mat-form-field appearance="fill">
     <mat-label>Absenderadresse</mat-label>
-    <input matInput formControlName="fromAddress">
+    <input matInput formControlName="fromAddress" />
   </mat-form-field>
-  <button mat-raised-button color="primary" type="submit">Speichern</button>
-  <button mat-raised-button color="accent" type="button" (click)="sendTest()">Testmail senden</button>
+  <div class="actions">
+    <button mat-raised-button color="primary" type="submit">Speichern</button>
+    <button mat-raised-button color="accent" type="button" (click)="sendTest()">Testmail senden</button>
+  </div>
 </form>

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.scss
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.scss
@@ -1,0 +1,13 @@
+.mail-form {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MailSettings } from '@core/models/mail-settings';
+import { PendingChanges } from '@core/guards/pending-changes.guard';
 
 @Component({
   selector: 'app-mail-settings',
@@ -13,7 +14,7 @@ import { MailSettings } from '@core/models/mail-settings';
   templateUrl: './mail-settings.component.html',
   styleUrls: ['./mail-settings.component.scss']
 })
-export class MailSettingsComponent implements OnInit {
+export class MailSettingsComponent implements OnInit, PendingChanges {
   form!: FormGroup;
 
   constructor(private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar) {
@@ -33,7 +34,10 @@ export class MailSettingsComponent implements OnInit {
 
   load(): void {
     this.api.getMailSettings().subscribe(settings => {
-      if (settings) this.form.patchValue(settings);
+      if (settings) {
+        this.form.patchValue(settings);
+        this.form.markAsPristine();
+      }
     });
   }
 
@@ -41,12 +45,25 @@ export class MailSettingsComponent implements OnInit {
     if (this.form.invalid) return;
     this.api.updateMailSettings(this.form.value as MailSettings).subscribe(() => {
       this.snack.open('Gespeichert', 'OK', { duration: 2000 });
+      this.form.markAsPristine();
     });
   }
 
   sendTest(): void {
-    this.api.sendTestMail().subscribe(() => {
+    this.api.sendTestMail(this.form.value as MailSettings).subscribe(() => {
       this.snack.open('Testmail verschickt', 'OK', { duration: 2000 });
     });
+  }
+
+  hasPendingChanges(): boolean {
+    return this.form.dirty;
+  }
+
+  @HostListener('window:beforeunload', ['$event'])
+  confirmUnload(event: BeforeUnloadEvent): void {
+    if (this.hasPendingChanges()) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add pending changes guard with warning dialog
- send test mails using temporary settings
- warn about leaving page with unsaved mail settings
- improve mail settings form layout using CSS grid

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run check-backend`

------
https://chatgpt.com/codex/tasks/task_e_6874cfd0e720832092d3187590c38c0d