### PR TITLE
Enable STARTTLS in mail settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ SMTP_PORT=25
 SMTP_USER=no-reply
 SMTP_PASS=
 EMAIL_FROM=no-reply@nak-chorleiter.de
+SMTP_STARTTLS=false
 ```
+Set `SMTP_STARTTLS` to `true` to enforce a STARTTLS handshake when connecting to the mail server.
 
 When the application is started for the first time these settings are written to
 the database and can later be changed through the admin endpoint

--- a/choir-app-backend/.env
+++ b/choir-app-backend/.env
@@ -13,3 +13,4 @@ SMTP_PORT=25
 SMTP_USER=no-reply
 SMTP_PASS=
 EMAIL_FROM=no-reply@nak-chorleiter.de
+SMTP_STARTTLS=false

--- a/choir-app-backend/src/models/mail_setting.model.js
+++ b/choir-app-backend/src/models/mail_setting.model.js
@@ -6,6 +6,7 @@ module.exports = (sequelize, DataTypes) => {
     user: { type: DataTypes.STRING, allowNull: true },
     pass: { type: DataTypes.STRING, allowNull: true },
     secure: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    starttls: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
     fromAddress: { type: DataTypes.STRING, allowNull: true }
   });
   return MailSetting;

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -38,6 +38,7 @@ async function seedDatabase(options = {}) {
                     user: process.env.SMTP_USER || '',
                     pass: process.env.SMTP_PASS || '',
                     secure: false,
+                    starttls: false,
                     fromAddress: process.env.EMAIL_FROM || 'no-reply@nak-chorleiter.de'
                 }
             });

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -8,6 +8,7 @@ async function createTransporter(existingSettings) {
     host: settings?.host || process.env.SMTP_HOST,
     port: settings?.port || process.env.SMTP_PORT || 587,
     secure: settings?.secure || false,
+    requireTLS: settings?.starttls || process.env.SMTP_STARTTLS === 'true' || false,
     auth: {
       user: settings?.user || process.env.SMTP_USER,
       pass: settings?.pass || process.env.SMTP_PASS

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -29,7 +29,7 @@ const db = require('../src/models');
     checkFields(db.user_choir, ['roleInChoir', 'registrationStatus', 'isOrganist']);
     checkFields(db.piece_change, ['data']);
     checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
-    checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'fromAddress']);
+    checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
 
     // Basic association checks

--- a/choir-app-frontend/src/app/core/models/mail-settings.ts
+++ b/choir-app-frontend/src/app/core/models/mail-settings.ts
@@ -4,5 +4,6 @@ export interface MailSettings {
   user?: string;
   pass?: string;
   secure: boolean;
+  starttls: boolean;
   fromAddress?: string;
 }

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.html
@@ -16,6 +16,7 @@
     <input matInput type="password" formControlName="pass">
   </mat-form-field>
   <mat-checkbox formControlName="secure">TLS/SSL</mat-checkbox>
+  <mat-checkbox formControlName="starttls">STARTTLS</mat-checkbox>
   <mat-form-field appearance="fill">
     <mat-label>Absenderadresse</mat-label>
     <input matInput formControlName="fromAddress">

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
@@ -23,6 +23,7 @@ export class MailSettingsComponent implements OnInit {
       user: [''],
       pass: [''],
       secure: [false],
+      starttls: [false],
       fromAddress: ['']
     });
   }


### PR DESCRIPTION
## Summary
- add `starttls` field to mail settings model
- configure nodemailer to use `requireTLS`
- expose the new setting via seed data and `.env`
- update admin UI to edit the option
- document `SMTP_STARTTLS` in README
- adjust model tests

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d75e979c8320aa87a256fcad0780