### PR TITLE
Log email errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ When the application is started for the first time these settings are written to
 the database and can later be changed through the admin endpoint
 `/admin/mail-settings`.
 After saving new settings you can send yourself a test email from that page to verify the configuration.
+Any errors during mail delivery are written to `logs/error.log` for troubleshooting.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- log email errors in `email.service`
- mention new log location in README

## Testing
- `npm test` *(fails: ng not found)*
- `npm run check-backend`
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874dada7acc8320be6009632b1e4a81