### PR TITLE
Fix logger after log deletion

### DIFF
--- a/choir-app-backend/src/config/logger.js
+++ b/choir-app-backend/src/config/logger.js
@@ -79,3 +79,18 @@ function getLogger() {
 }
 
 module.exports = getLogger();
+
+/**
+ * Schließt alle aktuellen Logger-Transporte und erstellt sie neu.
+ * Dies wird verwendet, wenn Logdateien gelöscht werden, damit
+ * keine Puffereinträge erneut geschrieben werden.
+ */
+function resetLogger() {
+  if (logger) {
+    logger.close();
+  }
+  logger = buildLogger();
+  return logger;
+}
+
+module.exports.reset = resetLogger;

--- a/choir-app-backend/src/services/log.service.js
+++ b/choir-app-backend/src/services/log.service.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const logger = require('../config/logger');
 
 const LOG_DIR = path.join(__dirname, '..', '..', 'logs');
 
@@ -62,12 +63,14 @@ async function deleteLogFile(filename) {
     const filePath = path.join(LOG_DIR, safe);
     try {
         await fs.promises.unlink(filePath);
+        logger.reset();
         return true;
     } catch (err) {
         if (err.code === 'ENOENT') return false;
         if (err.code === 'EPERM') {
             // On Windows the file might still be locked by the logger
             await fs.promises.truncate(filePath, 0);
+            logger.reset();
             return true;
         }
         throw err;


### PR DESCRIPTION
## Summary
- add logger reset capability
- reset logger when a log file is removed

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874de0ffe508320869aad6b6be1cc4d