### PR TITLE
Refactor composer/author controllers

### DIFF
--- a/choir-app-backend/src/routes/author.routes.js
+++ b/choir-app-backend/src/routes/author.routes.js
@@ -7,7 +7,7 @@ router.use(authJwt.verifyToken);
 router.post("/", controller.create);
 router.get("/", controller.findAll);
 router.put("/:id", controller.update);
-router.delete("/:id", controller.remove);
+router.delete("/:id", controller.delete);
 router.post("/:id/enrich", controller.enrich);
 
 module.exports = router;

--- a/choir-app-backend/src/routes/composer.routes.js
+++ b/choir-app-backend/src/routes/composer.routes.js
@@ -7,7 +7,7 @@ router.use(authJwt.verifyToken);
 router.post("/", controller.create);
 router.get("/", controller.findAll);
 router.put("/:id", controller.update);
-router.delete("/:id", controller.remove);
+router.delete("/:id", controller.delete);
 router.post("/:id/enrich", controller.enrich);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- use `BaseCrudController` for composer and author models
- delegate CRUD logic to the base controller
- keep piece count checks for deletion
- update routes to call new `delete` handlers

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874e1ac79548320a9616f2cfc93bae4