### PR TITLE
Remove duplicate demo check

### DIFF
--- a/choir-app-backend/src/controllers/collection.controller.js
+++ b/choir-app-backend/src/controllers/collection.controller.js
@@ -30,9 +30,6 @@ exports.update = async (req, res, next) => {
     const id = req.params.id;
     const { title, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
     try {
-        if (req.userRole === 'demo') {
-            return res.status(403).send({ message: 'Demo user cannot modify collections.' });
-        }
         const collection = await db.collection.findByPk(id);
 
         if (!collection) return res.status(404).send({ message: `Collection with id=${id} not found.` });


### PR DESCRIPTION
## Summary
- rely on `role.requireNonDemo` middleware
- remove redundant demo-user check in collection controller

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874e1fd51148320a425b8b6d035bbbd