### PR TITLE
Add validation for pieces and collections

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js",
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js",
     "check": "node --check server.js"
   },
   "dependencies": {

--- a/choir-app-backend/src/routes/collection.routes.js
+++ b/choir-app-backend/src/routes/collection.routes.js
@@ -1,6 +1,8 @@
 const authJwt = require("../middleware/auth.middleware");
 const role = require("../middleware/role.middleware");
 const controller = require("../controllers/collection.controller");
+const { createCollectionValidation, updateCollectionValidation } = require("../validators/collection.validation");
+const validate = require("../validators/validate");
 const router = require("express").Router();
 const { diskUpload } = require('../utils/upload');
 const upload = diskUpload('collection-covers');
@@ -9,10 +11,10 @@ const upload = diskUpload('collection-covers');
 router.get("/:id/cover", controller.getCover);
 
 router.use(authJwt.verifyToken);
-router.post("/", role.requireNonDemo, controller.create);
+router.post("/", role.requireNonDemo, createCollectionValidation, validate, controller.create);
 router.get("/", controller.findAll);
 router.get("/:id", controller.findOne);
-router.put("/:id", role.requireNonDemo, controller.update);
+router.put("/:id", role.requireNonDemo, updateCollectionValidation, validate, controller.update);
 router.post("/:id/cover", role.requireNonDemo, upload.single('cover'), controller.uploadCover);
 router.post("/:id/addToChoir", role.requireNonDemo, controller.addToChoir); // Crucial endpoint
 module.exports = router;

--- a/choir-app-backend/src/routes/piece.routes.js
+++ b/choir-app-backend/src/routes/piece.routes.js
@@ -1,6 +1,8 @@
 const authJwt = require("../middleware/auth.middleware");
 const role = require("../middleware/role.middleware");
 const controller = require("../controllers/piece.controller");
+const { createPieceValidation, updatePieceValidation } = require("../validators/piece.validation");
+const validate = require("../validators/validate");
 const router = require("express").Router();
 const { diskUpload } = require('../utils/upload');
 const upload = diskUpload('piece-images');
@@ -13,8 +15,8 @@ router.use(authJwt.verifyToken);
 
 router.get("/", controller.findAll);
 router.get("/:id", controller.findOne);
-router.post("/", role.requireNonDemo, controller.create);
-router.put("/:id", role.requireNonDemo, controller.update);
+router.post("/", role.requireNonDemo, createPieceValidation, validate, controller.create);
+router.put("/:id", role.requireNonDemo, updatePieceValidation, validate, controller.update);
 router.delete("/:id", role.requireNonDemo, controller.delete);
 router.post("/:id/image", role.requireNonDemo, upload.single('image'), controller.uploadImage);
 

--- a/choir-app-backend/src/validators/collection.validation.js
+++ b/choir-app-backend/src/validators/collection.validation.js
@@ -1,0 +1,17 @@
+const { body } = require('express-validator');
+
+exports.createCollectionValidation = [
+  body('title').notEmpty().withMessage('Title is required.'),
+  body('pieces').optional().isArray().withMessage('pieces must be an array'),
+  body('pieces.*.pieceId').optional().isInt().withMessage('pieceId must be an integer'),
+  body('pieces.*.numberInCollection').optional().isInt().withMessage('numberInCollection must be an integer'),
+  body('singleEdition').optional().isBoolean()
+];
+
+exports.updateCollectionValidation = [
+  body('title').optional().notEmpty(),
+  body('pieces').optional().isArray(),
+  body('pieces.*.pieceId').optional().isInt(),
+  body('pieces.*.numberInCollection').optional().isInt(),
+  body('singleEdition').optional().isBoolean()
+];

--- a/choir-app-backend/src/validators/piece.validation.js
+++ b/choir-app-backend/src/validators/piece.validation.js
@@ -1,0 +1,25 @@
+const { body } = require('express-validator');
+
+exports.createPieceValidation = [
+  body('title').notEmpty().withMessage('Title is required.'),
+  body('composerId').isInt().withMessage('Valid composerId is required.'),
+  body('arrangerIds').optional().isArray().withMessage('arrangerIds must be an array'),
+  body('arrangerIds.*').optional().isInt().withMessage('arrangerIds must contain integers'),
+  body('links').optional().isArray().withMessage('links must be an array'),
+  body('links.*.description').optional().isString(),
+  body('links.*.url').optional().isURL().withMessage('links.*.url must be a valid URL'),
+  body('authorId').optional({ nullable: true }).isInt(),
+  body('categoryId').optional({ nullable: true }).isInt()
+];
+
+exports.updatePieceValidation = [
+  body('title').optional().notEmpty(),
+  body('composerId').optional().isInt(),
+  body('arrangerIds').optional().isArray(),
+  body('arrangerIds.*').optional().isInt(),
+  body('links').optional().isArray(),
+  body('links.*.description').optional().isString(),
+  body('links.*.url').optional().isURL(),
+  body('authorId').optional({ nullable: true }).isInt(),
+  body('categoryId').optional({ nullable: true }).isInt()
+];

--- a/choir-app-backend/tests/collection.validation.test.js
+++ b/choir-app-backend/tests/collection.validation.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { validationResult } = require('express-validator');
+const { createCollectionValidation, updateCollectionValidation } = require('../src/validators/collection.validation');
+
+(async () => {
+  try {
+    const req1 = { body: {} };
+    for (const v of createCollectionValidation) { await v.run(req1); }
+    let res = validationResult(req1);
+    assert.ok(!res.isEmpty(), 'create should fail without title');
+
+    const req2 = { body: { title: 'A', pieces: 'x' } };
+    for (const v of updateCollectionValidation) { await v.run(req2); }
+    res = validationResult(req2);
+    assert.ok(!res.isEmpty(), 'update should fail when pieces is not array');
+
+    console.log('collection.validation tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/choir-app-backend/tests/piece.validation.test.js
+++ b/choir-app-backend/tests/piece.validation.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { validationResult } = require('express-validator');
+const { createPieceValidation, updatePieceValidation } = require('../src/validators/piece.validation');
+
+(async () => {
+  try {
+    const req1 = { body: { composerId: 1 } };
+    for (const v of createPieceValidation) { await v.run(req1); }
+    let res = validationResult(req1);
+    assert.ok(!res.isEmpty(), 'create should fail without title');
+
+    const req2 = { body: { title: 'X', arrangerIds: 'foo' } };
+    for (const v of updatePieceValidation) { await v.run(req2); }
+    res = validationResult(req2);
+    assert.ok(!res.isEmpty(), 'update should fail with invalid arrangerIds');
+
+    console.log('piece.validation tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add validators for piece and collection routes
- hook up validators in corresponding routers
- cover the new validators with tests
- run backend tests

## Testing
- `npm test` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874e1afbeac8320affe62a7a432865b