### PR TITLE
Add placeholders for email templates

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -190,7 +190,7 @@ exports.sendPasswordReset = async (req, res) => {
             const token = crypto.randomBytes(32).toString('hex');
             const expiry = new Date(Date.now() + 60 * 60 * 1000);
             await user.update({ resetToken: token, resetTokenExpiry: expiry });
-            await emailService.sendPasswordResetMail(user.email, token);
+            await emailService.sendPasswordResetMail(user.email, token, user.name);
         }
         res.status(200).send({ message: 'Reset email sent if user exists.' });
     } catch (err) {
@@ -293,7 +293,7 @@ exports.addUserToChoir = async (req, res) => {
             const expiry = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
             user = await db.user.create({ email });
             await choir.addUser(user, { through: { roleInChoir, registrationStatus: 'PENDING', inviteToken: token, inviteExpiry: expiry, isOrganist: !!isOrganist } });
-            await emailService.sendInvitationMail(email, token, choir.name, expiry);
+            await emailService.sendInvitationMail(email, token, choir.name, expiry, user.name);
             res.status(200).send({ message: `An invitation has been sent to ${email}. Valid until ${expiry.toLocaleDateString()}.` });
         }
     } catch (err) {
@@ -421,7 +421,7 @@ exports.sendTestMail = async (req, res) => {
     try {
         const user = await db.user.findByPk(req.userId);
         if (user) {
-            await emailService.sendTestMail(user.email, req.body);
+            await emailService.sendTestMail(user.email, req.body, user.name);
         }
         res.status(200).send({ message: 'Test mail sent if user exists.' });
     } catch (err) {

--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -150,7 +150,7 @@ exports.inviteUserToChoir = async (req, res, next) => {
             const expiry = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
             user = await db.user.create({ email });
             await choir.addUser(user, { through: { roleInChoir, registrationStatus: 'PENDING', inviteToken: token, inviteExpiry: expiry, isOrganist: !!isOrganist } });
-            await emailService.sendInvitationMail(email, token, choir.name, expiry);
+            await emailService.sendInvitationMail(email, token, choir.name, expiry, user.name);
             res.status(200).send({ message: `An invitation has been sent to ${email}. Valid until ${expiry.toLocaleDateString()}.` });
         }
     } catch (err) {

--- a/choir-app-backend/src/controllers/password-reset.controller.js
+++ b/choir-app-backend/src/controllers/password-reset.controller.js
@@ -18,7 +18,7 @@ exports.requestPasswordReset = async (req, res) => {
       const token = crypto.randomBytes(32).toString('hex');
       const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
       await user.update({ resetToken: token, resetTokenExpiry: expiry });
-      await emailService.sendPasswordResetMail(email, token);
+      await emailService.sendPasswordResetMail(email, token, user.name);
     }
     res.status(200).send({ message: 'If registered, you will receive an email with a reset link.' });
   } catch (err) {

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -17,16 +17,33 @@ async function createTransporter(existingSettings) {
   });
 }
 
-exports.sendInvitationMail = async (to, token, choirName, expiry) => {
+function replacePlaceholders(text, replacements) {
+  let result = text;
+  for (const [key, value] of Object.entries(replacements)) {
+    result = result.split(`{{${key}}}`).join(value);
+  }
+  return result;
+}
+
+exports.sendInvitationMail = async (to, token, choirName, expiry, name) => {
   const linkBase = process.env.FRONTEND_URL || 'http://localhost:4200';
   const link = `${linkBase}/register/${token}`;
   const settings = await db.mail_setting.findByPk(1);
   const template = await db.mail_template.findOne({ where: { type: 'invite' } });
   const transporter = await createTransporter(settings);
   try {
-    const subject = template?.subject.replace('{{choir}}', choirName) || `Invitation to join ${choirName}`;
-    let body = template?.body || `<p>You have been invited to join <b>{{choir}}</b>.<br>Click <a href="{{link}}">here</a> to complete your registration. This link is valid until {{expiry}}.</p>`;
-    body = body.replace('{{choir}}', choirName).replace('{{link}}', link).replace('{{expiry}}', expiry.toLocaleString());
+    const userName = name || to.split('@')[0];
+    const placeholders = {
+      choir: choirName,
+      link,
+      expiry: expiry.toLocaleString(),
+      surname: userName,
+      date: new Date().toLocaleString()
+    };
+    const subjectTemplate = template?.subject || 'Invitation to join {{choir}}';
+    const subject = replacePlaceholders(subjectTemplate, placeholders);
+    let bodyTemplate = template?.body || `<p>You have been invited to join <b>{{choir}}</b>.<br>Click <a href="{{link}}">here</a> to complete your registration. This link is valid until {{expiry}}.</p>`;
+    const body = replacePlaceholders(bodyTemplate, placeholders);
     await transporter.sendMail({
       from: settings?.fromAddress || process.env.EMAIL_FROM || 'no-reply@nak-chorleiter.de',
       to,
@@ -40,16 +57,23 @@ exports.sendInvitationMail = async (to, token, choirName, expiry) => {
   }
 };
 
-exports.sendPasswordResetMail = async (to, token) => {
+exports.sendPasswordResetMail = async (to, token, name) => {
   const linkBase = process.env.FRONTEND_URL || 'http://localhost:4200';
   const link = `${linkBase}/reset-password/${token}`;
   const settings = await db.mail_setting.findByPk(1);
   const template = await db.mail_template.findOne({ where: { type: 'reset' } });
   const transporter = await createTransporter(settings);
   try {
-    const subject = template?.subject || 'Password Reset';
-    let body = template?.body || '<p>Click <a href="{{link}}">here</a> to set a new password.</p>';
-    body = body.replace('{{link}}', link);
+    const userName = name || to.split('@')[0];
+    const placeholders = {
+      link,
+      surname: userName,
+      date: new Date().toLocaleString()
+    };
+    const subjectTemplate = template?.subject || 'Password Reset';
+    const subject = replacePlaceholders(subjectTemplate, placeholders);
+    let bodyTemplate = template?.body || '<p>Click <a href="{{link}}">here</a> to set a new password.</p>';
+    const body = replacePlaceholders(bodyTemplate, placeholders);
     await transporter.sendMail({
       from: settings?.fromAddress || process.env.EMAIL_FROM || 'no-reply@nak-chorleiter.de',
       to,
@@ -63,15 +87,21 @@ exports.sendPasswordResetMail = async (to, token) => {
   }
 };
 
-exports.sendTestMail = async (to, override) => {
+exports.sendTestMail = async (to, override, name) => {
   const settings = override || await db.mail_setting.findByPk(1);
   const transporter = await createTransporter(settings);
   try {
+    const userName = name || to.split('@')[0];
+    const placeholders = {
+      surname: userName,
+      date: new Date().toLocaleString()
+    };
+    const body = replacePlaceholders('<p>Dies ist eine Testmail.</p>', placeholders);
     await transporter.sendMail({
       from: settings?.fromAddress || process.env.EMAIL_FROM || 'no-reply@nak-chorleiter.de',
       to,
       subject: 'Testmail',
-      html: '<p>Dies ist eine Testmail.</p>'
+      html: body
     });
   } catch (err) {
     logger.error(`Error sending test mail to ${to}: ${err.message}`);


### PR DESCRIPTION
## Summary
- support `{{surname}}` and `{{date}}` in email templates
- pass user names when sending invitation, password reset and test mails

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874ea9f3e3c8320bad2aa7cd9761bec