### PR TITLE
Support choirname and invitor placeholders

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -293,7 +293,8 @@ exports.addUserToChoir = async (req, res) => {
             const expiry = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
             user = await db.user.create({ email });
             await choir.addUser(user, { through: { roleInChoir, registrationStatus: 'PENDING', inviteToken: token, inviteExpiry: expiry, isOrganist: !!isOrganist } });
-            await emailService.sendInvitationMail(email, token, choir.name, expiry);
+            const invitor = await db.user.findByPk(req.userId);
+            await emailService.sendInvitationMail(email, token, choir.name, expiry, invitor?.name);
             res.status(200).send({ message: `An invitation has been sent to ${email}. Valid until ${expiry.toLocaleDateString()}.` });
         }
     } catch (err) {

--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -150,7 +150,8 @@ exports.inviteUserToChoir = async (req, res, next) => {
             const expiry = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
             user = await db.user.create({ email });
             await choir.addUser(user, { through: { roleInChoir, registrationStatus: 'PENDING', inviteToken: token, inviteExpiry: expiry, isOrganist: !!isOrganist } });
-            await emailService.sendInvitationMail(email, token, choir.name, expiry);
+            const invitor = await db.user.findByPk(req.userId);
+            await emailService.sendInvitationMail(email, token, choir.name, expiry, invitor?.name);
             res.status(200).send({ message: `An invitation has been sent to ${email}. Valid until ${expiry.toLocaleDateString()}.` });
         }
     } catch (err) {


### PR DESCRIPTION
## Summary
- expand invitation mails with `choirname` and `invitor` placeholders
- pass inviter name from admin and choir management controllers

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874ebdf6e88832084f3990a5ffa46da