### PR TITLE
Add mail template test feature

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -435,6 +435,19 @@ exports.sendTestMail = async (req, res) => {
     }
 };
 
+exports.sendMailTemplateTest = async (req, res) => {
+    try {
+        const { type } = req.params;
+        const user = await db.user.findByPk(req.userId);
+        if (user) {
+            await emailService.sendTemplatePreviewMail(user.email, type, user.name);
+        }
+        res.status(200).send({ message: 'Test mail sent if user exists.' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
 exports.getMailTemplates = async (req, res) => {
     try {
         const templates = await db.mail_template.findAll();

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -42,6 +42,7 @@ router.put('/mail-settings', controller.updateMailSettings);
 router.post('/mail-settings/test', controller.sendTestMail);
 router.get('/mail-templates', controller.getMailTemplates);
 router.put('/mail-templates', controller.updateMailTemplates);
+router.post('/mail-templates/test/:type', controller.sendMailTemplateTest);
 
 module.exports = router;
 

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -118,6 +118,10 @@ export class AdminService {
     return this.http.post<{ message: string }>(`${this.apiUrl}/admin/mail-settings/test`, data || {});
   }
 
+  sendTemplateTest(type: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${this.apiUrl}/admin/mail-templates/test/${type}`, {});
+  }
+
   getMailTemplates(): Observable<MailTemplate[]> {
     return this.http.get<MailTemplate[]>(`${this.apiUrl}/admin/mail-templates`);
   }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -591,6 +591,10 @@ export class ApiService {
     return this.adminService.sendTestMail(data);
   }
 
+  sendTemplateTest(type: string): Observable<{ message: string }> {
+    return this.adminService.sendTemplateTest(type);
+  }
+
   getMailTemplates(): Observable<MailTemplate[]> {
     return this.adminService.getMailTemplates();
   }

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -7,8 +7,14 @@
   <mat-form-field appearance="fill">
     <mat-label>Text (HTML erlaubt)</mat-label>
     <textarea matInput formControlName="inviteBody" rows="5"></textarea>
-    <mat-hint>{{'{{link}}'}} wird durch den Registrierungslink ersetzt.</mat-hint>
+    <mat-hint>
+      Folgende Platzhalter werden ersetzt:
+      {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+    </mat-hint>
   </mat-form-field>
+  <div class="actions">
+    <button mat-raised-button color="accent" type="button" (click)="sendTest('invite')">Testmail</button>
+  </div>
   <h3>Passwort vergessen</h3>
   <mat-form-field appearance="fill">
     <mat-label>Betreff</mat-label>
@@ -17,8 +23,13 @@
   <mat-form-field appearance="fill">
     <mat-label>Text (HTML erlaubt)</mat-label>
     <textarea matInput formControlName="resetBody" rows="5"></textarea>
-    <mat-hint>{{'{{link}}'}} wird durch den Link zum Zurücksetzen ersetzt.</mat-hint>
+    <mat-hint>
+      Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+    </mat-hint>
   </mat-form-field>
+  <div class="actions">
+    <button mat-raised-button color="accent" type="button" (click)="sendTest('reset')">Testmail</button>
+  </div>
   <div class="actions">
     <button mat-raised-button color="primary" type="submit">Speichern</button>
   </div>

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
@@ -56,6 +56,12 @@ export class MailTemplatesComponent implements OnInit, PendingChanges {
     });
   }
 
+  sendTest(type: string): void {
+    this.api.sendTemplateTest(type).subscribe(() => {
+      this.snack.open('Testmail verschickt', 'OK', { duration: 2000 });
+    });
+  }
+
   hasPendingChanges(): boolean {
     return this.form.dirty;
   }


### PR DESCRIPTION
## Summary
- add backend API to send a preview of mail templates
- update admin controller and routes
- expose preview endpoint in frontend services
- allow admins to send test mails for invite and reset templates
- show available placeholders in the admin UI

## Testing
- `npm run check-backend`
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6874f85b2b788320b96d7670ce87a44a