### PR TITLE
Remove Organist checkbox

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.html
@@ -15,7 +15,6 @@
         <mat-option value="singer">Sänger</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-checkbox formControlName="isOrganist">Organist</mat-checkbox>
   </form>
 </div>
 <div mat-dialog-actions align="end">

--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.ts
@@ -20,8 +20,7 @@ export class InviteUserDialogComponent {
   ) {
     this.inviteForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
-      roles: [['director'], Validators.required],
-      isOrganist: [false]
+      roles: [['director'], Validators.required]
     });
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -134,12 +134,6 @@
               <ng-template #roleText>{{ user.membership?.rolesInChoir?.join(', ') || '-' }}</ng-template>
             </td>
           </ng-container>
-          <ng-container matColumnDef="organist">
-            <th mat-header-cell *matHeaderCellDef>Organist</th>
-            <td mat-cell *matCellDef="let user">
-              <mat-checkbox [checked]="user.membership?.isOrganist" (change)="toggleOrganist(user, $event.checked)" [disabled]="!isChoirAdmin"></mat-checkbox>
-            </td>
-          </ng-container>
           <ng-container matColumnDef="status">
             <th mat-header-cell *matHeaderCellDef> Status </th>
             <td mat-cell *matCellDef="let user"> {{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}} </td>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -52,7 +52,7 @@ export class ManageChoirComponent implements OnInit {
 
 
   // Für die Mitglieder-Tabelle
-  displayedColumns: string[] = ['name', 'email', 'address', 'role', 'organist', 'status', 'actions'];
+  displayedColumns: string[] = ['name', 'email', 'address', 'role', 'status', 'actions'];
   dataSource = new MatTableDataSource<UserInChoir>();
 
   constructor(
@@ -158,7 +158,7 @@ export class ManageChoirComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result && result.email && result.roles) {
-        this.apiService.inviteUserToChoir(result.email, result.roles, result.isOrganist).subscribe({
+        this.apiService.inviteUserToChoir(result.email, result.roles).subscribe({
           next: (response: { message: string }) => {
             this.snackBar.open(response.message, 'OK', { duration: 4000 });
             this.reloadData(); // Aktualisieren Sie die Datenquelle der Tabelle
@@ -195,13 +195,6 @@ export class ManageChoirComponent implements OnInit {
     });
   }
 
-  toggleOrganist(user: UserInChoir, checked: boolean): void {
-    if (!this.isChoirAdmin) return;
-    this.apiService.updateChoirMember(user.id, { isOrganist: checked }).subscribe({
-      next: () => user.membership!.isOrganist = checked,
-      error: () => this.snackBar.open('Fehler beim Aktualisieren.', 'Schließen')
-    });
-  }
 
   onRolesChange(user: UserInChoir, roles: ('director' | 'choir_admin' | 'organist' | 'singer')[]): void {
     if (!this.isChoirAdmin) return;


### PR DESCRIPTION
## Summary
- remove Organist checkbox from Manage Choir page
- update invite dialog form to exclude Organist checkbox
- adjust API call when inviting members

## Testing
- `npm run check-backend`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875030ec91c8320bb63dfba090d0982