### PR TITLE
Add WYSIWYG editing for mail templates

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -4,14 +4,14 @@
     <mat-label>Betreff</mat-label>
     <input matInput formControlName="inviteSubject" />
   </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Text (HTML erlaubt)</mat-label>
-    <textarea matInput formControlName="inviteBody" rows="5"></textarea>
-    <mat-hint>
+  <div class="editor-group">
+    <label class="editor-label">Text (HTML erlaubt)</label>
+    <div #inviteEditor class="quill-editor"></div>
+    <p class="hint">
       Folgende Platzhalter werden ersetzt:
       {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
-    </mat-hint>
-  </mat-form-field>
+    </p>
+  </div>
   <div class="actions">
     <button mat-raised-button color="accent" type="button" (click)="sendTest('invite')">Testmail</button>
   </div>
@@ -20,13 +20,13 @@
     <mat-label>Betreff</mat-label>
     <input matInput formControlName="resetSubject" />
   </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Text (HTML erlaubt)</mat-label>
-    <textarea matInput formControlName="resetBody" rows="5"></textarea>
-    <mat-hint>
+  <div class="editor-group">
+    <label class="editor-label">Text (HTML erlaubt)</label>
+    <div #resetEditor class="quill-editor"></div>
+    <p class="hint">
       Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
-    </mat-hint>
-  </mat-form-field>
+    </p>
+  </div>
   <div class="actions">
     <button mat-raised-button color="accent" type="button" (click)="sendTest('reset')">Testmail</button>
   </div>

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.scss
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.scss
@@ -8,3 +8,20 @@
   display: flex;
   gap: 1rem;
 }
+
+.editor-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.quill-editor {
+  height: 200px;
+  background-color: #fff;
+}
+
+.hint {
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.6);
+  margin-top: 0.25rem;
+}

--- a/choir-app-frontend/src/index.html
+++ b/choir-app-frontend/src/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 </head>
 <body>
   <div id="no-js-message" style="font-family: Roboto, 'Helvetica Neue', sans-serif; padding: 2rem; color:#000;">
@@ -19,6 +20,7 @@
     </p>
   </div>
   <app-root style="display: none;"></app-root>
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
   <script>
     const msg = document.getElementById('no-js-message');
     if (msg) {


### PR DESCRIPTION
## Summary
- embed Quill editor in admin mail template page
- style new editor widgets
- load Quill from CDN in index.html

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6875021f28148320806480537394735d