### PR TITLE
Add availability warning icon

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -34,8 +34,12 @@
             <mat-option [value]="null">--</mat-option>
             <mat-option *ngFor="let m of availableForDate(directors, ev.date)" [value]="m.id">{{ m.name }}</mat-option>
           </mat-select>
+          <mat-icon *ngIf="ev.director?.id && isMaybe(ev.director.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-container>
-        <ng-template #directorText>{{ ev.director?.name }}</ng-template>
+        <ng-template #directorText>
+          {{ ev.director?.name }}
+          <mat-icon *ngIf="ev.director?.id && isMaybe(ev.director.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
+        </ng-template>
       </td>
     </ng-container>
     <ng-container matColumnDef="organist">
@@ -46,8 +50,12 @@
             <mat-option [value]="null">--</mat-option>
             <mat-option *ngFor="let m of availableForDate(organists, ev.date)" [value]="m.id">{{ m.name }}</mat-option>
           </mat-select>
+          <mat-icon *ngIf="ev.organist?.id && isMaybe(ev.organist.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-container>
-        <ng-template #organistText>{{ ev.organist?.name }}</ng-template>
+        <ng-template #organistText>
+          {{ ev.organist?.name }}
+          <mat-icon *ngIf="ev.organist?.id && isMaybe(ev.organist.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
+        </ng-template>
       </td>
     </ng-container>
     <ng-container matColumnDef="notes">

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -33,3 +33,8 @@ mat-tab-group {
   font-style: italic;
   color: #555;
 }
+
+.warning-icon {
+  vertical-align: middle;
+  margin-left: 4px;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -71,6 +71,11 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     return !status || status === 'AVAILABLE' || status === 'MAYBE';
   }
 
+  isMaybe(userId: number | null | undefined, date: string): boolean {
+    if (!userId) return false;
+    return this.availabilityMap[userId]?.[date] === 'MAYBE';
+  }
+
   availableForDate(list: UserInChoir[], date: string): UserInChoir[] {
     return list.filter(u => this.isAvailable(u.id, date));
   }


### PR DESCRIPTION
## Summary
- show a warning icon when a director or organist is only "maybe" available
- add helper method to check MAYBE availability
- style the warning icon in the monthly plan view

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687509823f68832082c593444ffbd4e1