### PR TITLE
Add HTML toggle and color options for mail templates

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -5,8 +5,21 @@
     <input matInput formControlName="inviteSubject" />
   </mat-form-field>
   <div class="editor-group">
-    <label class="editor-label">Text (HTML erlaubt)</label>
-    <div #inviteEditor class="quill-editor"></div>
+    <div class="editor-header">
+      <label class="editor-label">Text (HTML erlaubt)</label>
+      <mat-slide-toggle
+        class="html-toggle"
+        [checked]="inviteHtmlMode"
+        (change)="toggleInviteHtml()"
+        >HTML bearbeiten</mat-slide-toggle
+      >
+    </div>
+    <div *ngIf="!inviteHtmlMode" #inviteEditor class="quill-editor"></div>
+    <textarea
+      *ngIf="inviteHtmlMode"
+      class="html-editor"
+      formControlName="inviteBody"
+    ></textarea>
     <p class="hint">
       Folgende Platzhalter werden ersetzt:
       {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
@@ -21,8 +34,21 @@
     <input matInput formControlName="resetSubject" />
   </mat-form-field>
   <div class="editor-group">
-    <label class="editor-label">Text (HTML erlaubt)</label>
-    <div #resetEditor class="quill-editor"></div>
+    <div class="editor-header">
+      <label class="editor-label">Text (HTML erlaubt)</label>
+      <mat-slide-toggle
+        class="html-toggle"
+        [checked]="resetHtmlMode"
+        (change)="toggleResetHtml()"
+        >HTML bearbeiten</mat-slide-toggle
+      >
+    </div>
+    <div *ngIf="!resetHtmlMode" #resetEditor class="quill-editor"></div>
+    <textarea
+      *ngIf="resetHtmlMode"
+      class="html-editor"
+      formControlName="resetBody"
+    ></textarea>
     <p class="hint">
       Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
     </p>

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.scss
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.scss
@@ -15,9 +15,22 @@
   margin-bottom: 1rem;
 }
 
+.editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
 .quill-editor {
   height: 200px;
   background-color: #fff;
+}
+
+.html-editor {
+  height: 200px;
+  width: 100%;
+  font-family: monospace;
 }
 
 .hint {

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
@@ -22,6 +22,8 @@ export class MailTemplatesComponent implements OnInit, AfterViewInit, PendingCha
   @ViewChild('resetEditor') resetEditor!: ElementRef<HTMLDivElement>;
   private inviteQuill: any;
   private resetQuill: any;
+  inviteHtmlMode = false;
+  resetHtmlMode = false;
 
   constructor(private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar) {
     this.form = this.fb.group({
@@ -69,15 +71,25 @@ export class MailTemplatesComponent implements OnInit, AfterViewInit, PendingCha
   }
 
   private initEditors(): void {
+    const options = {
+      theme: 'snow',
+      modules: {
+        toolbar: [
+          ['bold', 'italic', 'underline'],
+          [{ color: [] }, { background: [] }],
+          ['link', 'clean']
+        ]
+      }
+    };
     if ((window as any).Quill && this.inviteEditor && !this.inviteQuill) {
-      this.inviteQuill = new (window as any).Quill(this.inviteEditor.nativeElement, { theme: 'snow' });
+      this.inviteQuill = new (window as any).Quill(this.inviteEditor.nativeElement, options);
       this.inviteQuill.on('text-change', () => {
         this.form.patchValue({ inviteBody: this.inviteQuill.root.innerHTML });
         this.form.get('inviteBody')?.markAsDirty();
       });
     }
     if ((window as any).Quill && this.resetEditor && !this.resetQuill) {
-      this.resetQuill = new (window as any).Quill(this.resetEditor.nativeElement, { theme: 'snow' });
+      this.resetQuill = new (window as any).Quill(this.resetEditor.nativeElement, options);
       this.resetQuill.on('text-change', () => {
         this.form.patchValue({ resetBody: this.resetQuill.root.innerHTML });
         this.form.get('resetBody')?.markAsDirty();
@@ -90,6 +102,26 @@ export class MailTemplatesComponent implements OnInit, AfterViewInit, PendingCha
       this.inviteQuill.root.innerHTML = this.form.value.inviteBody || '';
     }
     if (this.resetQuill) {
+      this.resetQuill.root.innerHTML = this.form.value.resetBody || '';
+    }
+  }
+
+  toggleInviteHtml(): void {
+    this.inviteHtmlMode = !this.inviteHtmlMode;
+    if (this.inviteHtmlMode && this.inviteQuill) {
+      this.form.patchValue({ inviteBody: this.inviteQuill.root.innerHTML });
+    }
+    if (!this.inviteHtmlMode && this.inviteQuill) {
+      this.inviteQuill.root.innerHTML = this.form.value.inviteBody || '';
+    }
+  }
+
+  toggleResetHtml(): void {
+    this.resetHtmlMode = !this.resetHtmlMode;
+    if (this.resetHtmlMode && this.resetQuill) {
+      this.form.patchValue({ resetBody: this.resetQuill.root.innerHTML });
+    }
+    if (!this.resetHtmlMode && this.resetQuill) {
       this.resetQuill.root.innerHTML = this.form.value.resetBody || '';
     }
   }


### PR DESCRIPTION
## Summary
- enhance mail template editor with HTML toggle mode
- allow color formatting via Quill toolbar
- adjust styles for HTML text area

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750add6a288320b766d2b49f1de71a