### PR TITLE
Fix mail template display when toggling HTML mode

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -14,7 +14,7 @@
         >HTML bearbeiten</mat-slide-toggle
       >
     </div>
-    <div *ngIf="!inviteHtmlMode" #inviteEditor class="quill-editor"></div>
+    <div [hidden]="inviteHtmlMode" #inviteEditor class="quill-editor"></div>
     <textarea
       *ngIf="inviteHtmlMode"
       class="html-editor"
@@ -43,7 +43,7 @@
         >HTML bearbeiten</mat-slide-toggle
       >
     </div>
-    <div *ngIf="!resetHtmlMode" #resetEditor class="quill-editor"></div>
+    <div [hidden]="resetHtmlMode" #resetEditor class="quill-editor"></div>
     <textarea
       *ngIf="resetHtmlMode"
       class="html-editor"


### PR DESCRIPTION
## Summary
- preserve the Quill editor DOM when switching between text and HTML modes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687520081b80832091ebd28dc8543e55