### PR TITLE
Fix mail settings layout

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.scss
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.scss
@@ -1,16 +1,20 @@
+
 .mail-form {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
-  align-items: start;
+
+  mat-form-field {
+    width: 100%;
+  }
 }
 
+
 .hint {
-  grid-column: 1 / -1;
+  margin-top: 0.5rem;
 }
 
 .actions {
-  grid-column: 1 / -1;
   display: flex;
   justify-content: flex-end;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- switch mail settings form layout to vertical with flexbox

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*
- `npm run check --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_6875203c2a188320b74aaf0e808eb478