### PR TITLE
Add PDF export and emailing of monthly plan

### DIFF
--- a/choir-app-backend/src/routes/monthlyPlan.routes.js
+++ b/choir-app-backend/src/routes/monthlyPlan.routes.js
@@ -9,5 +9,7 @@ router.get("/:year/:month", controller.findByMonth);
 router.post("/", role.requireChoirAdmin, controller.create);
 router.put("/:id/finalize", role.requireChoirAdmin, controller.finalize);
 router.put("/:id/reopen", role.requireChoirAdmin, controller.reopen);
+router.get("/:id/pdf", controller.downloadPdf);
+router.post("/:id/email", role.requireChoirAdmin, controller.emailPdf);
 
 module.exports = router;

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -150,3 +150,21 @@ exports.sendTemplatePreviewMail = async (to, type, name) => {
     throw err;
   }
 };
+
+exports.sendMonthlyPlanMail = async (recipients, pdfBuffer, year, month) => {
+  const settings = await db.mail_setting.findByPk(1);
+  const transporter = await createTransporter(settings);
+  try {
+    await transporter.sendMail({
+      from: getFromAddress(settings),
+      to: recipients,
+      subject: `Dienstplan ${month}/${year}`,
+      text: 'Im Anhang befindet sich der aktuelle Dienstplan.',
+      attachments: [{ filename: `dienstplan-${year}-${month}.pdf`, content: pdfBuffer }]
+    });
+  } catch (err) {
+    logger.error(`Error sending monthly plan mail: ${err.message}`);
+    logger.error(err.stack);
+    throw err;
+  }
+};

--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -1,0 +1,43 @@
+function escape(text) {
+  return text.replace(/[\\()]/g, c => '\\' + c);
+}
+
+function monthlyPlanPdf(plan) {
+  const lines = [];
+  let y = 800;
+  lines.push(`BT /F1 18 Tf 50 ${y} Td (${escape('Dienstplan ' + plan.month + '/' + plan.year)}) Tj ET`);
+  y -= 30;
+  lines.push(`BT /F1 12 Tf 50 ${y} Td (${escape('Datum - Chorleiter - Organist - Notizen')}) Tj ET`);
+  for (const e of plan.entries) {
+    y -= 20;
+    const parts = [
+      new Date(e.date).toISOString().substring(0,10),
+      e.director?.name || '',
+      e.organist?.name || '',
+      e.notes || ''
+    ];
+    lines.push(`BT /F1 12 Tf 50 ${y} Td (${escape(parts.join(' - '))}) Tj ET`);
+  }
+  const content = lines.join('\n');
+  const objects = [];
+  objects.push('<< /Type /Catalog /Pages 2 0 R >>'); //1
+  objects.push('<< /Type /Pages /Kids [3 0 R] /Count 1 >>'); //2
+  objects.push('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 5 0 R /Resources << /Font << /F1 4 0 R >> >> >>'); //3
+  objects.push('<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>'); //4
+  objects.push(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`); //5
+  const offsets = [];
+  let pdf = '%PDF-1.4\n';
+  for (let i = 0; i < objects.length; i++) {
+    offsets[i] = pdf.length;
+    pdf += `${i+1} 0 obj\n${objects[i]}\nendobj\n`;
+  }
+  const xrefStart = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (let i = 0; i < offsets.length; i++) {
+    pdf += `${String(offsets[i]).padStart(10,'0')} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF`;
+  return Buffer.from(pdf, 'binary');
+}
+
+module.exports = { monthlyPlanPdf };

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -363,6 +363,14 @@ export class ApiService {
     return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/reopen`, {});
   }
 
+  downloadMonthlyPlanPdf(id: number): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/monthly-plans/${id}/pdf`, { responseType: 'blob' });
+  }
+
+  emailMonthlyPlan(id: number, recipients: number[]): Observable<any> {
+    return this.http.post(`${this.apiUrl}/monthly-plans/${id}/email`, { recipients });
+  }
+
   // --- Plan Rule Methods ---
   getPlanRules(): Observable<PlanRule[]> {
     return this.planRuleService.getPlanRules();

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -17,6 +17,8 @@
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEntryDialog()">Eintrag hinzufügen</button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
     <button *ngIf="isChoirAdmin && plan.finalized" mat-raised-button color="primary" (click)="reopenPlan()">Plan erneut öffnen</button>
+    <button mat-raised-button color="accent" (click)="downloadPdf()">PDF herunterladen</button>
+    <button mat-raised-button color="accent" (click)="openEmailDialog()">Per E-Mail senden</button>
   </div>
   <table mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">

--- a/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
@@ -1,0 +1,13 @@
+<h1 mat-dialog-title>Dienstplan versenden</h1>
+<div mat-dialog-content>
+  <p>Empfänger auswählen:</p>
+  <mat-selection-list>
+    <mat-list-option *ngFor="let m of data.members" [value]="m.id" (selectionChange)="toggle(m.id, $event.source.selected)">
+      {{ m.name }} ({{ m.email }})
+    </mat-list-option>
+  </mat-selection-list>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" (click)="send()" [disabled]="selected.size===0">Senden</button>
+</div>

--- a/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.scss
@@ -1,0 +1,4 @@
+mat-selection-list {
+  max-height: 300px;
+  overflow: auto;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.ts
@@ -1,0 +1,37 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { UserInChoir } from '@core/models/user';
+
+export interface SendPlanDialogData {
+  members: UserInChoir[];
+}
+
+@Component({
+  selector: 'app-send-plan-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './send-plan-dialog.component.html',
+  styleUrls: ['./send-plan-dialog.component.scss']
+})
+export class SendPlanDialogComponent {
+  selected = new Set<number>();
+
+  constructor(
+    public dialogRef: MatDialogRef<SendPlanDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: SendPlanDialogData
+  ) {}
+
+  toggle(id: number, checked: boolean): void {
+    if (checked) this.selected.add(id); else this.selected.delete(id);
+  }
+
+  send(): void {
+    this.dialogRef.close(Array.from(this.selected));
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple PDF generation service
- allow monthly plan PDF download and emailing in backend
- expose new endpoints in backend routes
- add API service functions to handle PDF and email
- create dialog to select recipients for emailing
- add buttons in monthly plan view to download or send via mail

## Testing
- `npm test --silent --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test --silent --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875219ed7c883208fb85dff991ec472