### PR TITLE
Remove default min-height from Angular Material inputs

### DIFF
--- a/choir-app-frontend/src/themes/_nak-theme.scss
+++ b/choir-app-frontend/src/themes/_nak-theme.scss
@@ -149,3 +149,11 @@ mat-option:hover {
 .mdc-text-field--outlined .mat-mdc-form-field-infix, .mdc-text-field--no-label .mat-mdc-form-field-infix {
   padding-left: 0.3rem;
 }
+
+// Remove the default minimum height from Material form fields so inputs align
+// with the surrounding text line.
+.mat-mdc-form-field-infix {
+  min-height: unset !important;
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- adjust global Material theme to remove the minimum height on `mat-mdc-form-field-infix`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687522ab5b708320a406ee235109454f