### PR TITLE
Fix deployment build check

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -8,7 +8,12 @@ $BackendDest = "/usr/local/lsws/ChorStatistik/backend"
 $FrontendDest = "/usr/local/lsws/ChorStatistik/html"
 
 # Build Angular frontend
+Write-Host "Building Angular frontend..."
 npm --prefix choir-app-frontend run build
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Build failed. Aborting deployment."
+    exit 1
+}
 
 Write-Host "Build finished."
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,11 @@ BACKEND_DEST="/usr/local/lsws/ChorStatistik/backend"
 FRONTEND_DEST="/usr/local/lsws/ChorStatistik/html"
 
 # Build Angular frontend
-npm --prefix choir-app-frontend run build
+echo "Building Angular frontend..."
+if ! npm --prefix choir-app-frontend run build; then
+    echo "Build failed. Aborting deployment." >&2
+    exit 1
+fi
 
 echo "Build finished."
 


### PR DESCRIPTION
## Summary
- bail out of deploy when frontend build fails

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687525eba86c8320acb0fec007a5f5ed