### PR TITLE
Fix SendPlan selection event

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
@@ -1,8 +1,8 @@
 <h1 mat-dialog-title>Dienstplan versenden</h1>
 <div mat-dialog-content>
   <p>Empfänger auswählen:</p>
-  <mat-selection-list>
-    <mat-list-option *ngFor="let m of data.members" [value]="m.id" (selectionChange)="toggle(m.id, $event.source.selected)">
+  <mat-selection-list (selectionChange)="toggle($event.option.value, $event.option.selected)">
+    <mat-list-option *ngFor="let m of data.members" [value]="m.id">
       {{ m.name }} ({{ m.email }})
     </mat-list-option>
   </mat-selection-list>


### PR DESCRIPTION
## Summary
- fix compilation error in send plan dialog by binding selectionChange on the list

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*
- `npm run check-backend`

------
https://chatgpt.com/codex/tasks/task_e_687525c468f48320a27c13033504936b