### PR TITLE
Fix send-plan dialog build error

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
@@ -1,7 +1,7 @@
 <h1 mat-dialog-title>Dienstplan versenden</h1>
 <div mat-dialog-content>
   <p>Empfänger auswählen:</p>
-  <mat-selection-list (selectionChange)="toggle($event.option.value, $event.option.selected)">
+  <mat-selection-list (selectionChange)="toggle($event.options[0].value, $event.options[0].selected)">
     <mat-list-option *ngFor="let m of data.members" [value]="m.id">
       {{ m.name }} ({{ m.email }})
     </mat-list-option>


### PR DESCRIPTION
## Summary
- fix send plan dialog to use `options[0]` from `MatSelectionListChange`

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_687559e2e81c8320b55053f1bc4fe6bf