### PR TITLE
Fix Angular warning for unused component

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -20,7 +20,7 @@ import { getHolidayName } from '@shared/util/holiday';
 @Component({
   selector: 'app-monthly-plan',
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule, AvailabilityTableComponent, SendPlanDialogComponent],
+  imports: [CommonModule, FormsModule, MaterialModule, AvailabilityTableComponent],
   templateUrl: './monthly-plan.component.html',
   styleUrls: ['./monthly-plan.component.scss']
 })


### PR DESCRIPTION
## Summary
- remove SendPlanDialogComponent from the `imports` array in MonthlyPlanComponent

## Testing
- `npm test` *(fails: ng not found)*
- `npm install --prefix choir-app-frontend` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68755c2c721883209f771f5548deca33