### PR TITLE
Implement frontend error reporting

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -67,6 +67,7 @@ const monthlyPlanRoutes = require("./routes/monthlyPlan.routes");
 const planRuleRoutes = require("./routes/planRule.routes");
 const planEntryRoutes = require("./routes/planEntry.routes");
 const availabilityRoutes = require("./routes/availability.routes");
+const clientErrorRoutes = require("./routes/client-error.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -92,6 +93,7 @@ app.use("/api/monthly-plans", monthlyPlanRoutes);
 app.use("/api/plan-rules", planRuleRoutes);
 app.use("/api/plan-entries", planEntryRoutes);
 app.use("/api/availabilities", availabilityRoutes);
+app.use("/api/client-errors", clientErrorRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/client-error.controller.js
+++ b/choir-app-backend/src/controllers/client-error.controller.js
@@ -1,0 +1,12 @@
+const logger = require('../config/logger');
+
+exports.reportError = (req, res) => {
+  const { message, stack, url } = req.body || {};
+  const origin = url || req.headers.referer || 'unknown';
+  const logMessage = `Client Error at ${origin}: ${message}`;
+  logger.error(logMessage);
+  if (stack) {
+    logger.error(stack);
+  }
+  res.status(200).send({ message: 'Error logged' });
+};

--- a/choir-app-backend/src/routes/client-error.routes.js
+++ b/choir-app-backend/src/routes/client-error.routes.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const controller = require('../controllers/client-error.controller');
+
+router.post('/', controller.reportError);
+
+module.exports = router;

--- a/choir-app-frontend/src/app/core/handlers/global-error.handler.ts
+++ b/choir-app-frontend/src/app/core/handlers/global-error.handler.ts
@@ -1,0 +1,13 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+import { ErrorService } from '../services/error.service';
+
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+  constructor(private errorService: ErrorService) {}
+
+  handleError(error: any): void {
+    const message = error?.message || error.toString();
+    this.errorService.setError({ message });
+    console.error(error);
+  }
+}

--- a/choir-app-frontend/src/app/core/services/error.service.ts
+++ b/choir-app-frontend/src/app/core/services/error.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 export interface AppError {
   message: string;
@@ -13,14 +15,30 @@ export interface AppError {
 export class ErrorService {
   private errorSubject = new BehaviorSubject<AppError | null>(null);
   public error$ = this.errorSubject.asObservable();
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
 
   // Setzt einen neuen Fehler
   setError(error: AppError | null): void {
     this.errorSubject.next(error);
+    if (error) {
+      this.reportError(error).subscribe({
+        error: () => {}
+      });
+    }
   }
 
   // Löscht den aktuellen Fehler
   clearError(): void {
     this.errorSubject.next(null);
+  }
+
+  private reportError(error: AppError) {
+    return this.http.post(`${this.apiUrl}/client-errors`, {
+      message: error.message,
+      status: error.status,
+      details: error.details,
+    });
   }
 }

--- a/choir-app-frontend/src/main.ts
+++ b/choir-app-frontend/src/main.ts
@@ -14,9 +14,10 @@ import { ErrorInterceptor } from '@core/interceptors/error-interceptor';
 import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de'; // Importieren Sie das deutsche Sprachpaket
 import localeDeExtra from '@angular/common/locales/extra/de'; // Optionale extra Daten
-import { LOCALE_ID } from '@angular/core';
+import { LOCALE_ID, ErrorHandler } from '@angular/core';
 import { MAT_DATE_LOCALE, DateAdapter } from '@angular/material/core';
-import { MondayFirstDateAdapter } from './app/core/adapters/monday-first-date-adapter';
+import { MondayFirstDateAdapter } from '@core/adapters/monday-first-date-adapter';
+import { GlobalErrorHandler } from '@core/handlers/global-error.handler';
 
 registerLocaleData(localeDe, 'de-DE', localeDeExtra);
 
@@ -30,6 +31,7 @@ bootstrapApplication(AppComponent, {
     { provide: HTTP_INTERCEPTORS, useClass: TimeoutInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
+    { provide: ErrorHandler, useClass: GlobalErrorHandler },
     { provide: LOCALE_ID, useValue: 'de-DE' },
     { provide: MAT_DATE_LOCALE, useValue: 'de-DE' },
     { provide: DateAdapter, useClass: MondayFirstDateAdapter },


### PR DESCRIPTION
## Summary
- add client error endpoint to backend
- hook up new route in Express app
- send errors from frontend to backend
- handle global errors in Angular

## Testing
- `npm test` *(fails: ng not found)*
- `npm run check-backend`

------
https://chatgpt.com/codex/tasks/task_e_68755c96652c8320a1c17056223d1b6c