### PR TITLE
Improve client error logging

### DIFF
--- a/choir-app-backend/src/controllers/client-error.controller.js
+++ b/choir-app-backend/src/controllers/client-error.controller.js
@@ -1,9 +1,16 @@
 const logger = require('../config/logger');
 
 exports.reportError = (req, res) => {
-  const { message, stack, url } = req.body || {};
+  const { message, stack, url, file, line } = req.body || {};
   const origin = url || req.headers.referer || 'unknown';
-  const logMessage = `Client Error at ${origin}: ${message}`;
+  const userInfo = req.userId ? `user ${req.userId}` : 'anonymous';
+  let locationInfo = '';
+  if (file && line) {
+    locationInfo = ` in ${file}:${line}`;
+  } else if (file) {
+    locationInfo = ` in ${file}`;
+  }
+  const logMessage = `Client Error at ${origin} (${userInfo})${locationInfo}: ${message}`;
   logger.error(logMessage);
   if (stack) {
     logger.error(stack);

--- a/choir-app-backend/src/middleware/auth.middleware.js
+++ b/choir-app-backend/src/middleware/auth.middleware.js
@@ -1,7 +1,21 @@
 const jwt = require("jsonwebtoken");
 const db = require("../models");
 
-verifyToken = (req, res, next) => {
+const optionalAuth = (req, res, next) => {
+  let token = req.headers["authorization"];
+  if (!token) return next();
+  token = token.split(' ')[1];
+  jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
+    if (!err) {
+      req.userId = decoded.id;
+      req.activeChoirId = decoded.activeChoirId;
+      req.userRole = decoded.role;
+    }
+    next();
+  });
+};
+
+const verifyToken = (req, res, next) => {
   let token = req.headers["authorization"];
 
   if (!token) {
@@ -23,7 +37,7 @@ verifyToken = (req, res, next) => {
   });
 };
 
-isChoirAdminOrAdmin = async (req, res, next) => {
+const isChoirAdminOrAdmin = async (req, res, next) => {
     // Der globale Admin darf alles
     if (req.userRole === 'admin') {
         return next();
@@ -49,7 +63,7 @@ isChoirAdminOrAdmin = async (req, res, next) => {
     }
 };
 
-isAdmin = (req, res, next) => {
+const isAdmin = (req, res, next) => {
     if (req.userRole === 'admin') {
         next();
         return;
@@ -60,6 +74,7 @@ isAdmin = (req, res, next) => {
 const authJwt = {
   verifyToken,
   isAdmin,
-  isChoirAdminOrAdmin
+  isChoirAdminOrAdmin,
+  optionalAuth
 };
 module.exports = authJwt;

--- a/choir-app-backend/src/routes/client-error.routes.js
+++ b/choir-app-backend/src/routes/client-error.routes.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const controller = require('../controllers/client-error.controller');
+const { optionalAuth } = require('../middleware/auth.middleware');
 
-router.post('/', controller.reportError);
+router.post('/', optionalAuth, controller.reportError);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/guards/choir-admin-guard.ts
+++ b/choir-app-frontend/src/app/core/guards/choir-admin-guard.ts
@@ -38,7 +38,12 @@ export class ChoirAdminGuard implements CanActivate {
           catchError((err) => {
             // Bei einem Fehler bei der API-Anfrage den Zugriff verweigern und umleiten.
             console.error('ChoirAdminGuard API check failed', err);
-            this.errorService.setError({ message: 'Zugriff verweigert.', status: err.status });
+            this.errorService.setError({
+              message: 'Zugriff verweigert.',
+              status: err.status,
+              stack: err.stack,
+              url: this.router.url
+            });
             return of(this.router.createUrlTree(['/dashboard']));
           })
         );

--- a/choir-app-frontend/src/app/core/handlers/global-error.handler.ts
+++ b/choir-app-frontend/src/app/core/handlers/global-error.handler.ts
@@ -7,7 +7,24 @@ export class GlobalErrorHandler implements ErrorHandler {
 
   handleError(error: any): void {
     const message = error?.message || error.toString();
-    this.errorService.setError({ message });
+    const stack = error instanceof Error ? error.stack : undefined;
+    let file: string | undefined;
+    let line: number | undefined;
+    if (stack) {
+      const first = stack.split('\n')[1];
+      const match = first && first.match(/\((.*):(\d+):(\d+)\)/);
+      if (match) {
+        file = match[1];
+        line = parseInt(match[2], 10);
+      }
+    }
+    this.errorService.setError({
+      message,
+      stack,
+      url: window.location.href,
+      file,
+      line
+    });
     console.error(error);
   }
 }

--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -18,7 +18,11 @@ export class ErrorInterceptor implements HttpInterceptor {
         this.errorService.setError({
           message,
           status: error.status,
-          details: error.error?.details
+          details: error.error?.details,
+          stack: error.stack,
+          url: req.url,
+          file: undefined,
+          line: undefined
         });
         console.error('HTTP Error:', error);
 

--- a/choir-app-frontend/src/app/core/services/error.service.ts
+++ b/choir-app-frontend/src/app/core/services/error.service.ts
@@ -7,6 +7,10 @@ export interface AppError {
   message: string;
   status?: number;
   details?: string;
+  stack?: string;
+  url?: string;
+  file?: string;
+  line?: number;
 }
 
 @Injectable({
@@ -39,6 +43,10 @@ export class ErrorService {
       message: error.message,
       status: error.status,
       details: error.details,
+      stack: error.stack,
+      url: error.url,
+      file: error.file,
+      line: error.line,
     });
   }
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -60,7 +60,12 @@ export class ManageChoirResolver implements Resolve<any> {
       catchError((error) => {
         const errorMessage = error.error?.message || 'Could not load data for choir management.';
         console.error('ManageChoirResolver error', error);
-        this.errorService.setError({ message: errorMessage, status: error.status });
+        this.errorService.setError({
+          message: errorMessage,
+          status: error.status,
+          stack: error.stack,
+          url: this.router.url
+        });
         this.router.navigate(['/dashboard']);
         return of(null);
       })

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -204,7 +204,9 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
               this.errorService.setError({
                 message: msg,
                 status: err.status,
-                details: err.error?.details
+                details: err.error?.details,
+                stack: err.stack,
+                url: this.router.url
               });
               return of({ data: [], total: 0 });
             })
@@ -434,7 +436,12 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
       error: (err) => {
         console.error('Failed to update status', err);
         const msg = err.error?.message || 'Could not update status.';
-        this.errorService.setError({ message: msg, status: err.status });
+        this.errorService.setError({
+          message: msg,
+          status: err.status,
+          stack: err.stack,
+          url: this.router.url
+        });
         this.snackBar.open('Fehler: Status konnte nicht aktualisiert werden.', 'Schließen', { duration: 5000 });
         // Revert changes by triggering a refresh
         this.refresh$.next();


### PR DESCRIPTION
## Summary
- log optional auth details on client error reporting
- send detailed stack/location info from frontend errors
- capture file and line number in global error handler

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687561963c608320a3c2ea4345e43b5f