### PR TITLE
Fix monthly plan PDF route

### DIFF
--- a/choir-app-backend/src/routes/monthlyPlan.routes.js
+++ b/choir-app-backend/src/routes/monthlyPlan.routes.js
@@ -5,11 +5,13 @@ const router = require("express").Router();
 
 router.use(auth.verifyToken);
 
+// Specific ID-based routes must be defined before the year/month route to
+// avoid conflicts like GET /1/pdf being handled as year=1, month='pdf'.
+router.get("/:id/pdf", controller.downloadPdf);
+router.post("/:id/email", role.requireChoirAdmin, controller.emailPdf);
 router.get("/:year/:month", controller.findByMonth);
 router.post("/", role.requireChoirAdmin, controller.create);
 router.put("/:id/finalize", role.requireChoirAdmin, controller.finalize);
 router.put("/:id/reopen", role.requireChoirAdmin, controller.reopen);
-router.get("/:id/pdf", controller.downloadPdf);
-router.post("/:id/email", role.requireChoirAdmin, controller.emailPdf);
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/error.service.ts
+++ b/choir-app-frontend/src/app/core/services/error.service.ts
@@ -7,6 +7,7 @@ export interface AppError {
   message: string;
   status?: number;
   details?: string;
+  url?: string;
 }
 
 @Injectable({
@@ -42,7 +43,7 @@ export class ErrorService {
       message: error.message,
       status: error.status,
       details: error.details,
-      url: window.location.href
+      url: error.url ?? window.location.href
     });
   }
 }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -25,6 +25,7 @@ import { FilterPresetDialogComponent, FilterPresetDialogData } from '../filter-p
 import { ErrorService } from '@core/services/error.service';
 import { UserPreferencesService } from '@core/services/user-preferences.service';
 import { UserPreferences } from '@core/models/user-preferences';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-literature-list',
@@ -102,7 +103,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     private snackBar: MatSnackBar, // Inject MatSnackBar for feedback
     private paginatorService: PaginatorService,
     private errorService: ErrorService,
-    private prefs: UserPreferencesService
+    private prefs: UserPreferencesService,
+    private router: Router
   ) {
     this.pageSize = this.paginatorService.getPageSize('literature-list', this.pageSizeOptions[0]);
   }
@@ -204,7 +206,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
               this.errorService.setError({
                 message: msg,
                 status: err.status,
-                details: err.error?.details
+                details: err.error?.details,
+                url: this.router.url
               });
               return of({ data: [], total: 0 });
             })
@@ -431,10 +434,14 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         console.log(`Status for piece ${pieceId} updated to ${newStatus}`);
         this.snackBar.open('Status updated.', 'OK', { duration: 2000 });
       },
-      error: (err) => {
-        console.error('Failed to update status', err);
-        const msg = err.error?.message || 'Could not update status.';
-        this.errorService.setError({ message: msg, status: err.status });
+        error: (err) => {
+          console.error('Failed to update status', err);
+          const msg = err.error?.message || 'Could not update status.';
+          this.errorService.setError({
+            message: msg,
+            status: err.status,
+            url: this.router.url
+          });
         this.snackBar.open('Fehler: Status konnte nicht aktualisiert werden.', 'Schließen', { duration: 5000 });
         // Revert changes by triggering a refresh
         this.refresh$.next();


### PR DESCRIPTION
## Summary
- reorder monthly plan routes so ID-based routes match before the month/year route

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_6875637b3f488320b924ece44648708a