### PR TITLE
Fix duplicate URL property in error reporting

### DIFF
--- a/choir-app-frontend/src/app/core/services/error.service.ts
+++ b/choir-app-frontend/src/app/core/services/error.service.ts
@@ -47,10 +47,9 @@ export class ErrorService {
       status: error.status,
       details: error.details,
       stack: error.stack,
-      url: error.url,
+      url: error.url || window.location.href,
       file: error.file,
-      line: error.line,
-      url: window.location.href
+      line: error.line
     });
   }
 }


### PR DESCRIPTION
## Summary
- ensure the ErrorService only sends one URL field

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756b03ed548320b253dbb655e1fb79