### PR TITLE
Fix availability check for schedule

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -67,14 +67,20 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     });
   }
 
+  private dateKey(date: string): string {
+    return new Date(date).toISOString().substring(0, 10);
+  }
+
   isAvailable(userId: number, date: string): boolean {
-    const status = this.availabilityMap[userId]?.[date];
+    const key = this.dateKey(date);
+    const status = this.availabilityMap[userId]?.[key];
     return !status || status === 'AVAILABLE' || status === 'MAYBE';
   }
 
   isMaybe(userId: number | null | undefined, date: string): boolean {
     if (!userId) return false;
-    return this.availabilityMap[userId]?.[date] === 'MAYBE';
+    const key = this.dateKey(date);
+    return this.availabilityMap[userId]?.[key] === 'MAYBE';
   }
 
   availableForDate(list: UserInChoir[], date: string): UserInChoir[] {


### PR DESCRIPTION
## Summary
- ensure availability lookups use the same date format

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68756df0e98c83208704201d4421b921