### PR TITLE
Fix injection token error on reload

### DIFF
--- a/choir-app-frontend/src/app/core/services/error.service.ts
+++ b/choir-app-frontend/src/app/core/services/error.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpBackend } from '@angular/common/http';
+import { HttpBackend, HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
@@ -22,7 +22,7 @@ export class ErrorService {
   private apiUrl = environment.apiUrl;
   private httpNoInterceptor: HttpClient;
 
-  constructor(private http: HttpClient, httpBackend: HttpBackend) {
+  constructor(httpBackend: HttpBackend) {
     this.httpNoInterceptor = new HttpClient(httpBackend);
   }
 


### PR DESCRIPTION
## Summary
- fix circular dependency in ErrorService constructor by removing HttpClient injection

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756d29720c8320ae75caee17efdbec