### PR TITLE
Fix clearing assignments in monthly plan

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -173,8 +173,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
       notes: ev.notes || '',
-      directorId: userId ?? undefined,
-      organistId: ev.organist?.id || undefined
+      directorId: userId,
+      organistId: ev.organist?.id ?? null
     }).subscribe(updated => {
       ev.director = updated.director;
       this.updateCounterPlan();
@@ -185,8 +185,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
       notes: ev.notes || '',
-      directorId: ev.director?.id,
-      organistId: userId ?? undefined
+      directorId: ev.director?.id ?? null,
+      organistId: userId
     }).subscribe(updated => {
       ev.organist = updated.organist;
       this.updateCounterPlan();
@@ -197,8 +197,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
       notes,
-      directorId: ev.director?.id,
-      organistId: ev.organist?.id || undefined
+      directorId: ev.director?.id ?? null,
+      organistId: ev.organist?.id ?? null
     }).subscribe(updated => {
       ev.notes = updated.notes;
     });


### PR DESCRIPTION
## Summary
- send explicit `null` when removing director/organist assignments

## Testing
- `npm test --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756ef3b6c883209002c1f9e2f440bc