### PR TITLE
Fix null assignments for optional IDs

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -173,8 +173,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
       notes: ev.notes || '',
-      directorId: userId,
-      organistId: ev.organist?.id ?? null
+      directorId: userId ?? undefined,
+      organistId: ev.organist?.id ?? undefined
     }).subscribe(updated => {
       ev.director = updated.director;
       this.updateCounterPlan();
@@ -185,8 +185,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
       notes: ev.notes || '',
-      directorId: ev.director?.id ?? null,
-      organistId: userId
+      directorId: ev.director?.id ?? undefined,
+      organistId: userId ?? undefined
     }).subscribe(updated => {
       ev.organist = updated.organist;
       this.updateCounterPlan();
@@ -197,8 +197,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,
       notes,
-      directorId: ev.director?.id ?? null,
-      organistId: ev.organist?.id ?? null
+      directorId: ev.director?.id ?? undefined,
+      organistId: ev.organist?.id ?? undefined
     }).subscribe(updated => {
       ev.notes = updated.notes;
     });


### PR DESCRIPTION
## Summary
- fix `null` assignments when updating plan entries

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875707c43b88320b2299b83f0b4c1fc