### PR TITLE
Add frontend base URL configuration

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -18,6 +18,7 @@ import { InviteUserDialogComponent } from '../invite-user-dialog/invite-user-dia
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { ActivatedRoute } from '@angular/router';
 import { PieceDetailDialogComponent } from '@features/literature/piece-detail-dialog/piece-detail-dialog.component';
+import { environment } from 'src/environments/environment';
 
 
 @Component({
@@ -102,7 +103,7 @@ export class ManageChoirComponent implements OnInit {
           });
         }
         if (pageData.choirDetails.joinHash) {
-          this.joinLink = `${window.location.origin}/join/${pageData.choirDetails.joinHash}`;
+          this.joinLink = `${environment.baseUrl}/join/${pageData.choirDetails.joinHash}`;
         }
         if (!this.isChoirAdmin) {
           this.choirForm.disable();

--- a/choir-app-frontend/src/app/features/donations/donate.component.ts
+++ b/choir-app-frontend/src/app/features/donations/donate.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-donate',
@@ -11,7 +12,7 @@ import { MaterialModule } from '@modules/material.module';
 })
 export class DonateComponent {
   openPaypal() {
-    const base = window.location.origin;
+    const base = environment.baseUrl;
     const returnUrl = encodeURIComponent(`${base}/donation-success`);
     const cancelUrl = encodeURIComponent(`${base}/donation-cancel`);
     window.location.href = `https://www.paypal.com/donate?business=michael.free%40gmx.de&currency_code=EUR&return=${returnUrl}&cancel_return=${cancelUrl}`;

--- a/choir-app-frontend/src/environments/environment.prod.ts
+++ b/choir-app-frontend/src/environments/environment.prod.ts
@@ -8,5 +8,6 @@
 
 export const environment = {
   production: true,
-  apiUrl: 'https://nak-chorleiter.de/api' // Your backend API URL
+  apiUrl: 'https://nak-chorleiter.de/api', // Your backend API URL
+  baseUrl: 'https://nak-chorleiter.de'
 };

--- a/choir-app-frontend/src/environments/environment.ts
+++ b/choir-app-frontend/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080/api' // Your backend API URL
+  apiUrl: 'http://localhost:8080/api', // Your backend API URL
+  baseUrl: 'http://localhost:4200'
 };


### PR DESCRIPTION
## Summary
- configure `baseUrl` in Angular environments
- use `baseUrl` when creating PayPal and join links

## Testing
- `npm test` *(fails: ng not found)*
- `npm test --prefix choir-app-backend` *(fails: cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_687572f960308320b5005721c6212c4b