### PR TITLE
Fix forgot password link

### DIFF
--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.ts
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset-request.component.ts
@@ -2,12 +2,13 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
+import { RouterModule } from '@angular/router';
 import { ApiService } from '@core/services/api.service';
 
 @Component({
   selector: 'app-password-reset-request',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule, RouterModule],
   templateUrl: './password-reset-request.component.html',
   styleUrls: ['./password-reset-request.component.scss']
 })


### PR DESCRIPTION
## Summary
- import Angular RouterModule for the password reset request component

## Testing
- `npm test` *(fails: ng not found)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687578607640832090d587e630c79919