### PR TITLE
Improve monthly plan PDF layout

### DIFF
--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -41,7 +41,7 @@ exports.findByMonth = async (req, res) => {
                     { model: db.user, as: 'director', attributes: ['id', 'name'] },
                     { model: db.user, as: 'organist', attributes: ['id', 'name'], required: false }
                 ]
-            }],
+            }, { model: db.choir, as: 'choir', attributes: ['id', 'name'] }],
             order: [[{ model: db.plan_entry, as: 'entries' }, 'date', 'ASC']]
         });
         if (!plan) return res.status(204).send();
@@ -111,7 +111,7 @@ exports.downloadPdf = async (req, res) => {
                     { model: db.user, as: 'director', attributes: ['id', 'name'] },
                     { model: db.user, as: 'organist', attributes: ['id', 'name'], required: false }
                 ]
-            }],
+            }, { model: db.choir, as: 'choir', attributes: ['id', 'name'] }],
             order: [[{ model: db.plan_entry, as: 'entries' }, 'date', 'ASC']]
         });
         if (!plan) return res.status(404).send({ message: 'Plan not found.' });
@@ -140,7 +140,7 @@ exports.emailPdf = async (req, res) => {
                     { model: db.user, as: 'director', attributes: ['id', 'name'] },
                     { model: db.user, as: 'organist', attributes: ['id', 'name'], required: false }
                 ]
-            }],
+            }, { model: db.choir, as: 'choir', attributes: ['id', 'name'] }],
             order: [[{ model: db.plan_entry, as: 'entries' }, 'date', 'ASC']]
         });
         if (!plan) return res.status(404).send({ message: 'Plan not found.' });


### PR DESCRIPTION
## Summary
- include choir name in monthly plan PDF
- center all table cells and shade the header
- fetch choir info when generating PDFs

## Testing
- `npm test --silent --prefix choir-app-backend` *(fails: Cannot find module 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_68760486f71083208a51c58fe6c92b6a