### PR TITLE
Refactor piece controller to use BaseCrudController

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -49,6 +49,16 @@ exports.updateMyChoir = async (req, res, next) => {
             return res.status(404).send({ message: "Active choir not found." });
         }
 
+        if (modules !== undefined && req.userRole !== 'admin') {
+            const association = await db.user_choir.findOne({
+                where: { userId: req.userId, choirId: req.activeChoirId }
+            });
+            const isAdmin = association && Array.isArray(association.rolesInChoir) && association.rolesInChoir.includes('choir_admin');
+            if (!isAdmin) {
+                return res.status(403).send({ message: 'Require Choir Admin Role!' });
+            }
+        }
+
         // Führen Sie das Update durch. `update` gibt ein Array mit der Anzahl der betroffenen Zeilen zurück.
         const updateData = {};
         if (name !== undefined) updateData.name = name;

--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -5,8 +5,8 @@ const Category = db.category;
 const Author = db.author;
 const path = require('path');
 const fs = require('fs/promises');
-const CrudService = require("../services/crud.service");
-const pieceService = new CrudService(Piece);
+const BaseCrudController = require('./baseCrud.controller');
+const base = new BaseCrudController(Piece);
 
 /**
  * @description Create a new global piece.
@@ -64,7 +64,7 @@ exports.create = async (req, res) => {
  * when adding pieces to a collection.
  */
 exports.findAll = async (req, res) => {
-    const pieces = await pieceService.findAll({
+    const pieces = await base.service.findAll({
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] }
@@ -81,7 +81,7 @@ exports.findAll = async (req, res) => {
 exports.findOne = async (req, res) => {
     const id = req.params.id;
 
-    const piece = await pieceService.findById(id, {
+    const piece = await base.service.findById(id, {
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] },
@@ -111,7 +111,7 @@ exports.update = async (req, res) => {
             return res.status(202).send({ message: 'Change proposal created.' });
     }
 
-    const num = await pieceService.update(id, req.body);
+    const num = await base.service.update(id, req.body);
 
     if (num == 1) {
         res.send({ message: "Piece was updated successfully." });
@@ -129,7 +129,7 @@ exports.update = async (req, res) => {
 exports.delete = async (req, res) => {
     const id = req.params.id;
 
-    const num = await pieceService.delete(id);
+    const num = await base.service.delete(id);
 
     if (num == 1) {
         res.send({

--- a/choir-app-backend/src/controllers/search.controller.js
+++ b/choir-app-backend/src/controllers/search.controller.js
@@ -5,7 +5,8 @@ exports.search = async (req, res) => {
   const q = req.query.q || req.query.query || '';
   if (!q) return res.status(400).send({ message: 'Missing search query' });
   try {
-    const like = { [Op.iLike]: `%${q}%` };
+    const op = db.sequelize.getDialect() === 'sqlite' ? Op.like : Op.iLike;
+    const like = { [op]: `%${q}%` };
     const pieces = await db.piece.findAll({
       where: { title: like },
       include: [{ model: db.composer, as: 'composer', attributes: ['name'] }],
@@ -16,7 +17,7 @@ exports.search = async (req, res) => {
         choirId: req.activeChoirId,
         [Op.or]: [
           { notes: like },
-          where(cast(col('type'), 'TEXT'), { [Op.iLike]: `%${q}%` })
+          where(cast(col('type'), 'TEXT'), { [op]: `%${q}%` })
         ]
       },
       order: [['date', 'DESC']],


### PR DESCRIPTION
## Summary
- delegate piece CRUD operations to the generic BaseCrudController
- adapt search controller for SQLite tests
- enforce choir admin checks when updating choir modules
- extend piece controller tests for more CRUD paths

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68760aa4ae548320b2c49bd0c2a692d8