### PR TITLE
Refactor server init

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Before starting the backend, install its dependencies:
 npm install --prefix choir-app-backend
 ```
 
+You can initialize the database separately using
+
+```bash
+npm run init --prefix choir-app-backend
+```
+
+Run only the seeding step with
+
+```bash
+npm run seed --prefix choir-app-backend
+```
+
 ### Mail Configuration
 
 Configure the SMTP server used for password resets and invitations by adding the

--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -7,7 +7,9 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js",
-    "check": "node --check server.js"
+    "check": "node --check server.js",
+    "init": "node scripts/init.js",
+    "seed": "node scripts/seed.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -16,15 +18,16 @@
     "csv-parse": "^5.6.0",
     "dotenv": "^16.0.3",
     "express": "^4.21.2",
+    "express-async-handler": "^1.2.0",
     "express-rate-limit": "^7.5.1",
     "express-validator": "^6.15.0",
-    "express-async-handler": "^1.2.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.0",
     "multer": "^2.0.1",
     "nodemailer": "^7.0.3",
     "pg": "^8.9.0",
     "sequelize": "^6.29.0",
+    "sqlite3": "^5.1.7",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/choir-app-backend/scripts/init.js
+++ b/choir-app-backend/scripts/init.js
@@ -1,0 +1,8 @@
+const { init } = require('../src/init');
+
+init().then(() => {
+    console.log('Initialization completed.');
+}).catch(err => {
+    console.error('Initialization failed:', err);
+    process.exit(1);
+});

--- a/choir-app-backend/scripts/seed.js
+++ b/choir-app-backend/scripts/seed.js
@@ -1,0 +1,10 @@
+const { seedDatabase } = require('../src/seed');
+
+const includeDemo = process.env.INCLUDE_DEMO === 'true';
+
+seedDatabase({ includeDemoData: includeDemo }).then(() => {
+    console.log('Seeding completed.');
+}).catch(err => {
+    console.error('Seeding failed:', err);
+    process.exit(1);
+});

--- a/choir-app-backend/server.js
+++ b/choir-app-backend/server.js
@@ -5,44 +5,27 @@ try {
     process.exit(1);
 }
 const app = require("./src/app");
-const db = require("./src/models");
-const crypto = require("crypto");
-const { seedDatabase } = require("./src/seed");
+const { init } = require("./src/init");
 
 
 const PORT = process.env.PORT || 8088;
 const ADDRESS = process.env.ADDRESS || "localhost"
 
-console.log("Database synchronized.");
+async function start() {
+    try {
+        await init({ includeDemoData: true });
+        const server = app.listen(PORT, ADDRESS, () => {
+            console.log(`Server is running on port ${PORT}, listening ${ADDRESS}.`);
+        });
+        // Close requests that take longer than 20 seconds
+        server.setTimeout(20 * 1000);
+        server.on('timeout', (socket) => {
+            console.warn('Request timed out.');
+            socket.destroy();
+        });
+    } catch (err) {
+        console.error("Database startup failed:", err);
+    }
+}
 
-// In development, you might want to force-sync the DB
-// db.sequelize.sync({ force: true }).then(() => {
-//   console.log("Drop and re-sync db.");
-// });
-db.sequelize.sync({ alter: true })
-    .then(() => {
-
-        try {
-            console.log("Database synchronized.");
-
-            // Ensure all choirs have a join hash
-            db.choir.findAll({ where: { joinHash: null } }).then(choirs => {
-                choirs.forEach(async c => { c.joinHash = crypto.randomBytes(12).toString('hex'); await c.save(); });
-            });
-
-            // Seed database depending on environment
-            seedDatabase({ includeDemoData: true });
-
-            const server = app.listen(PORT, ADDRESS, () => {
-                console.log(`Server is running on port ${PORT}, listening ${ADDRESS}.`);
-            });
-            // Close requests that take longer than 20 seconds
-            server.setTimeout(20 * 1000);
-            server.on('timeout', (socket) => {
-                console.warn('Request timed out.');
-                socket.destroy();
-            });
-        } catch (err) {
-            console.error("Database startup failed:", err);
-        }
-});
+start();

--- a/choir-app-backend/src/controllers/search.controller.js
+++ b/choir-app-backend/src/controllers/search.controller.js
@@ -5,7 +5,8 @@ exports.search = async (req, res) => {
   const q = req.query.q || req.query.query || '';
   if (!q) return res.status(400).send({ message: 'Missing search query' });
   try {
-    const like = { [Op.iLike]: `%${q}%` };
+    const likeOp = db.sequelize.getDialect() === 'sqlite' ? Op.like : Op.iLike;
+    const like = { [likeOp]: `%${q}%` };
     const pieces = await db.piece.findAll({
       where: { title: like },
       include: [{ model: db.composer, as: 'composer', attributes: ['name'] }],
@@ -16,7 +17,7 @@ exports.search = async (req, res) => {
         choirId: req.activeChoirId,
         [Op.or]: [
           { notes: like },
-          where(cast(col('type'), 'TEXT'), { [Op.iLike]: `%${q}%` })
+          where(cast(col('type'), 'TEXT'), { [likeOp]: `%${q}%` })
         ]
       },
       order: [['date', 'DESC']],

--- a/choir-app-backend/src/init/dbSync.js
+++ b/choir-app-backend/src/init/dbSync.js
@@ -1,0 +1,8 @@
+const db = require('../models');
+
+async function syncDatabase(options = { alter: true }) {
+    await db.sequelize.sync(options);
+    console.log('Database synchronized.');
+}
+
+module.exports = { syncDatabase };

--- a/choir-app-backend/src/init/index.js
+++ b/choir-app-backend/src/init/index.js
@@ -1,0 +1,16 @@
+const { syncDatabase } = require('./dbSync');
+const { ensureJoinHashes } = require('./joinHashes');
+const { seedDatabase } = require('../seed');
+
+async function init(options = {}) {
+    const { includeDemoData = true, syncOptions = { alter: true } } = options;
+    await syncDatabase(syncOptions);
+    await ensureJoinHashes();
+    await seedDatabase({ includeDemoData });
+}
+
+module.exports = {
+    init,
+    syncDatabase,
+    ensureJoinHashes,
+};

--- a/choir-app-backend/src/init/joinHashes.js
+++ b/choir-app-backend/src/init/joinHashes.js
@@ -1,0 +1,15 @@
+const crypto = require('crypto');
+const db = require('../models');
+
+async function ensureJoinHashes() {
+    const choirs = await db.choir.findAll({ where: { joinHash: null } });
+    for (const choir of choirs) {
+        choir.joinHash = crypto.randomBytes(12).toString('hex');
+        await choir.save();
+    }
+    if (choirs.length > 0) {
+        console.log(`Generated join hashes for ${choirs.length} choirs.`);
+    }
+}
+
+module.exports = { ensureJoinHashes };


### PR DESCRIPTION
## Summary
- modularize backend startup logic
- add DB sync and join-hash helper functions
- expose npm scripts for init and seed
- document seeding and init commands
- make search controller sqlite-compatible

## Testing
- `npm run check-backend`
- `npm test --prefix choir-app-backend` *(fails: AssertionError in choir-management.controller.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68760aa633c0832081929a16415ee250