### PR TITLE
Split API service and delegate to specialized services

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -1,8 +1,5 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { environment } from 'src/environments/environment';
 
 // Import all the models your service will interact with
 import { Piece } from '../models/piece';
@@ -40,14 +37,15 @@ import { FilterPresetService } from './filter-preset.service';
 import { UserAvailability } from '../models/user-availability';
 import { MemberAvailability } from '../models/member-availability';
 import { AvailabilityService } from './availability.service';
+import { SearchService } from './search.service';
+import { MonthlyPlanService } from './monthly-plan.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ApiService {
-  private apiUrl = environment.apiUrl;
 
-  constructor(private http: HttpClient,
+  constructor(
               private pieceService: PieceService,
               private composerService: ComposerService,
               private authorService: AuthorService,
@@ -62,7 +60,9 @@ export class ApiService {
               private systemService: SystemService,
               private filterPresetService: FilterPresetService,
               private planRuleService: PlanRuleService,
-              private availabilityService: AvailabilityService) {
+              private availabilityService: AvailabilityService,
+              private searchService: SearchService,
+              private monthlyPlanService: MonthlyPlanService) {
 
   }
 
@@ -165,15 +165,11 @@ export class ApiService {
   }
 
   uploadPieceImage(id: number, file: File): Observable<any> {
-    const formData = new FormData();
-    formData.append('image', file);
-    return this.http.post(`${this.apiUrl}/pieces/${id}/image`, formData);
+    return this.pieceService.uploadPieceImage(id, file);
   }
 
   getPieceImage(id: number): Observable<string> {
-    return this.http
-      .get<{ data: string }>(`${this.apiUrl}/pieces/${id}/image`)
-      .pipe(map(res => res.data));
+    return this.pieceService.getPieceImage(id);
   }
 
   proposePieceChange(id: number, pieceData: any): Observable<any> {
@@ -286,8 +282,7 @@ export class ApiService {
   }
 
   searchAll(term: string): Observable<{ pieces: Piece[]; events: Event[]; collections: Collection[] }> {
-    const params = new HttpParams().set('q', term);
-    return this.http.get<{ pieces: Piece[]; events: Event[]; collections: Collection[] }>(`${this.apiUrl}/search`, { params });
+    return this.searchService.searchAll(term);
   }
 
 
@@ -348,27 +343,27 @@ export class ApiService {
 
   // --- Monthly Plan Methods ---
   getMonthlyPlan(year: number, month: number): Observable<MonthlyPlan | null> {
-    return this.http.get<MonthlyPlan | null>(`${this.apiUrl}/monthly-plans/${year}/${month}`);
+    return this.monthlyPlanService.getMonthlyPlan(year, month);
   }
 
   createMonthlyPlan(year: number, month: number): Observable<MonthlyPlan> {
-    return this.http.post<MonthlyPlan>(`${this.apiUrl}/monthly-plans`, { year, month });
+    return this.monthlyPlanService.createMonthlyPlan(year, month);
   }
 
   finalizeMonthlyPlan(id: number): Observable<MonthlyPlan> {
-    return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/finalize`, {});
+    return this.monthlyPlanService.finalizeMonthlyPlan(id);
   }
 
   reopenMonthlyPlan(id: number): Observable<MonthlyPlan> {
-    return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/reopen`, {});
+    return this.monthlyPlanService.reopenMonthlyPlan(id);
   }
 
   downloadMonthlyPlanPdf(id: number): Observable<Blob> {
-    return this.http.get(`${this.apiUrl}/monthly-plans/${id}/pdf`, { responseType: 'blob' });
+    return this.monthlyPlanService.downloadMonthlyPlanPdf(id);
   }
 
   emailMonthlyPlan(id: number, recipients: number[]): Observable<any> {
-    return this.http.post(`${this.apiUrl}/monthly-plans/${id}/email`, { recipients });
+    return this.monthlyPlanService.emailMonthlyPlan(id, recipients);
   }
 
   // --- Plan Rule Methods ---

--- a/choir-app-frontend/src/app/core/services/monthly-plan.service.ts
+++ b/choir-app-frontend/src/app/core/services/monthly-plan.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { MonthlyPlan } from '../models/monthly-plan';
+
+@Injectable({ providedIn: 'root' })
+export class MonthlyPlanService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getMonthlyPlan(year: number, month: number): Observable<MonthlyPlan | null> {
+    return this.http.get<MonthlyPlan | null>(`${this.apiUrl}/monthly-plans/${year}/${month}`);
+  }
+
+  createMonthlyPlan(year: number, month: number): Observable<MonthlyPlan> {
+    return this.http.post<MonthlyPlan>(`${this.apiUrl}/monthly-plans`, { year, month });
+  }
+
+  finalizeMonthlyPlan(id: number): Observable<MonthlyPlan> {
+    return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/finalize`, {});
+  }
+
+  reopenMonthlyPlan(id: number): Observable<MonthlyPlan> {
+    return this.http.put<MonthlyPlan>(`${this.apiUrl}/monthly-plans/${id}/reopen`, {});
+  }
+
+  downloadMonthlyPlanPdf(id: number): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/monthly-plans/${id}/pdf`, { responseType: 'blob' });
+  }
+
+  emailMonthlyPlan(id: number, recipients: number[]): Observable<any> {
+    return this.http.post(`${this.apiUrl}/monthly-plans/${id}/email`, { recipients });
+  }
+}

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { Piece } from '../models/piece';
 import { LookupPiece } from '../models/lookup-piece';
@@ -118,5 +119,17 @@ export class PieceService {
 
   getRepertoireForLookup(): Observable<LookupPiece[]> {
     return this.http.get<LookupPiece[]>(`${this.apiUrl}/repertoire/lookup`);
+  }
+
+  uploadPieceImage(id: number, file: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('image', file);
+    return this.http.post(`${this.apiUrl}/pieces/${id}/image`, formData);
+  }
+
+  getPieceImage(id: number): Observable<string> {
+    return this.http
+      .get<{ data: string }>(`${this.apiUrl}/pieces/${id}/image`)
+      .pipe(map(res => res.data));
   }
 }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -571,7 +571,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         this.hoverImage = cached;
         return;
       }
-      this.apiService.getPieceImage(piece.id).subscribe(img => {
+      this.pieceService.getPieceImage(piece.id).subscribe(img => {
         this.imageCache.set(piece.id, img);
         this.hoverImage = img;
       });

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -275,7 +275,7 @@ export class PieceDialogComponent implements OnInit {
         });
 
         if (piece.imageIdentifier) {
-            this.apiService.getPieceImage(piece.id).subscribe(data => this.imagePreview = data);
+            this.pieceService.getPieceImage(piece.id).subscribe(data => this.imagePreview = data);
         }
 
         // Populate the links FormArray
@@ -308,7 +308,7 @@ export class PieceDialogComponent implements OnInit {
                 .pipe(
                     switchMap(() =>
                         this.imageFile && this.isAdmin
-                            ? this.apiService.uploadPieceImage(this.data.pieceId!, this.imageFile)
+                            ? this.pieceService.uploadPieceImage(this.data.pieceId!, this.imageFile)
                             : of(null)
                     )
                 )
@@ -329,7 +329,7 @@ export class PieceDialogComponent implements OnInit {
                     ),
                     switchMap((createdPiece) =>
                         this.imageFile
-                            ? this.apiService.uploadPieceImage(createdPiece.id, this.imageFile).pipe(map(() => createdPiece))
+                            ? this.pieceService.uploadPieceImage(createdPiece.id, this.imageFile).pipe(map(() => createdPiece))
                             : of(createdPiece)
                     )
                 )

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -5,6 +5,7 @@ import { MaterialModule } from '@modules/material.module';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ApiService } from '@core/services/api.service';
+import { MonthlyPlanService } from '@core/services/monthly-plan.service';
 import { MonthlyPlan } from '@core/models/monthly-plan';
 import { PlanEntry } from '@core/models/plan-entry';
 import { UserInChoir } from '@core/models/user';
@@ -116,6 +117,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   constructor(private api: ApiService,
+              private monthlyPlan: MonthlyPlanService,
               private auth: AuthService,
               private dialog: MatDialog,
               private snackBar: MatSnackBar) {}
@@ -142,7 +144,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   loadPlan(year: number, month: number): void {
-    this.api.getMonthlyPlan(year, month).subscribe({
+    this.monthlyPlan.getMonthlyPlan(year, month).subscribe({
       next: plan => {
         this.plan = plan;
         this.entries = (plan?.entries || []).map(e => ({
@@ -206,7 +208,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
 
   finalizePlan(): void {
     if (this.plan) {
-      this.api.finalizeMonthlyPlan(this.plan.id).subscribe(p => { this.plan = p; this.updateDisplayedColumns(); });
+      this.monthlyPlan.finalizeMonthlyPlan(this.plan.id).subscribe(p => { this.plan = p; this.updateDisplayedColumns(); });
     }
   }
 
@@ -214,13 +216,13 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
 
   reopenPlan(): void {
     if (this.plan) {
-      this.api.reopenMonthlyPlan(this.plan.id).subscribe(p => { this.plan = p; this.updateDisplayedColumns(); });
+      this.monthlyPlan.reopenMonthlyPlan(this.plan.id).subscribe(p => { this.plan = p; this.updateDisplayedColumns(); });
     }
   }
 
   downloadPdf(): void {
     if (!this.plan) return;
-    this.api.downloadMonthlyPlanPdf(this.plan.id).subscribe(blob => {
+    this.monthlyPlan.downloadMonthlyPlanPdf(this.plan.id).subscribe(blob => {
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -235,7 +237,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     const ref = this.dialog.open(SendPlanDialogComponent, { data: { members: this.members } });
     ref.afterClosed().subscribe((ids: number[]) => {
       if (ids && ids.length > 0) {
-        this.api.emailMonthlyPlan(this.plan!.id, ids).subscribe({
+        this.monthlyPlan.emailMonthlyPlan(this.plan!.id, ids).subscribe({
           next: () => this.snackBar.open('E-Mail gesendet.', 'OK', { duration: 3000 }),
           error: () => this.snackBar.open('Fehler beim Versenden der E-Mail.', 'Schließen', { duration: 4000 })
         });
@@ -278,7 +280,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   createPlan(): void {
-    this.api.createMonthlyPlan(this.selectedYear, this.selectedMonth).subscribe(plan => {
+    this.monthlyPlan.createMonthlyPlan(this.selectedYear, this.selectedMonth).subscribe(plan => {
       this.plan = plan;
       this.loadPlan(plan.year, plan.month);
     });

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { RouterModule } from '@angular/router';
 import { ApiService } from '@core/services/api.service';
+import { MonthlyPlanService } from '@core/services/monthly-plan.service';
 import { Event } from '@core/models/event';
 import { PlanEntry } from '@core/models/plan-entry';
 import { AuthService } from '@core/services/auth.service';
@@ -41,7 +42,7 @@ export class MyCalendarComponent implements OnInit {
   @ViewChild('eventList') eventList?: ElementRef<HTMLElement>;
   @ViewChild(MatCalendar) calendar?: MatCalendar<Date>;
 
-  constructor(private api: ApiService, private auth: AuthService) {}
+  constructor(private api: ApiService, private monthlyPlan: MonthlyPlanService, private auth: AuthService) {}
 
   ngOnInit(): void {
     this.auth.isAdmin$.subscribe(v => (this.isAdmin = v));
@@ -75,7 +76,7 @@ export class MyCalendarComponent implements OnInit {
     const key = `${year}-${month}`;
     if (this.loadedPlanMonths.has(key)) return;
     this.loadedPlanMonths.add(key);
-    this.api.getMonthlyPlan(year, month).subscribe(plan => {
+    this.monthlyPlan.getMonthlyPlan(year, month).subscribe(plan => {
       if (!plan) return;
       for (const entry of plan.entries || []) {
         const dKey = new Date(entry.date).toISOString().substring(0, 10);


### PR DESCRIPTION
## Summary
- add `MonthlyPlanService` for monthly plan endpoints
- expand `PieceService` with image helpers
- refactor `ApiService` to use new services
- update components to call specialized services

## Testing
- `npm test` *(fails: No ChromeHeadless binary)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68760aaf0cd48320b41d5a1ac10a0662