### PR TITLE
Refactor piece controller to delegate CRUD operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,29 @@ manual error handling.
 See `src/controllers/example.controller.js` for a minimal controller using this
 approach.
 
+## Reusable CRUD controller
+
+Standard CRUD operations are implemented once in `src/controllers/baseCrud.controller.js`.
+Controllers instantiate this helper and either use the generic handlers directly
+or call `base.service` for custom logic. Example:
+
+```javascript
+const BaseCrudController = require('./baseCrud.controller');
+const base = new BaseCrudController(Category);
+
+exports.findAll = async (req, res) => {
+    const categories = await base.service.findAll({ order: [['name', 'ASC']] });
+    res.status(200).send(categories);
+};
+
+exports.findById = base.findById;
+exports.update = base.update;
+exports.delete = base.delete;
+```
+
+`piece.controller.js` now delegates its basic operations to this controller so
+that only the piece-specific logic remains.
+
 ## Deployment
 
 Use `deploy.sh` on Unix systems or `deploy.ps1` on Windows to upload the backend

--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -5,8 +5,8 @@ const Category = db.category;
 const Author = db.author;
 const path = require('path');
 const fs = require('fs/promises');
-const CrudService = require("../services/crud.service");
-const pieceService = new CrudService(Piece);
+const BaseCrudController = require('./baseCrud.controller');
+const base = new BaseCrudController(Piece);
 
 /**
  * @description Create a new global piece.
@@ -33,7 +33,7 @@ exports.create = async (req, res) => {
             resolvedAuthorId = author.id;
         }
 
-        const newPiece = await db.piece.create({
+        const newPiece = await base.service.create({
             title, composerId, categoryId, voicing, key, timeSignature,
             lyrics, imageIdentifier, license, opus,
             lyricsSource,
@@ -64,7 +64,7 @@ exports.create = async (req, res) => {
  * when adding pieces to a collection.
  */
 exports.findAll = async (req, res) => {
-    const pieces = await pieceService.findAll({
+    const pieces = await base.service.findAll({
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] }
@@ -81,7 +81,7 @@ exports.findAll = async (req, res) => {
 exports.findOne = async (req, res) => {
     const id = req.params.id;
 
-    const piece = await pieceService.findById(id, {
+    const piece = await base.service.findById(id, {
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] },
@@ -111,7 +111,7 @@ exports.update = async (req, res) => {
             return res.status(202).send({ message: 'Change proposal created.' });
     }
 
-    const num = await pieceService.update(id, req.body);
+    const num = await base.service.update(id, req.body);
 
     if (num == 1) {
         res.send({ message: "Piece was updated successfully." });
@@ -129,7 +129,7 @@ exports.update = async (req, res) => {
 exports.delete = async (req, res) => {
     const id = req.params.id;
 
-    const num = await pieceService.delete(id);
+    const num = await base.service.delete(id);
 
     if (num == 1) {
         res.send({

--- a/choir-app-backend/tests/piece.controller.test.js
+++ b/choir-app-backend/tests/piece.controller.test.js
@@ -11,9 +11,11 @@ const controller = require('../src/controllers/piece.controller');
   try {
     await db.sequelize.sync({ force: true });
 
-    // create composer and author
+    // create composer, author and users
     const composer = await db.composer.create({ name: 'Test Composer' });
     const author = await db.author.create({ name: 'Test Author' });
+    const user = await db.user.create({ email: 'user@example.com' });
+    const admin = await db.user.create({ email: 'admin@example.com', role: 'admin' });
 
     const req = {
       body: {
@@ -24,19 +26,51 @@ const controller = require('../src/controllers/piece.controller');
     };
 
     let statusCode;
-    const res = {
-      status(code) { statusCode = code; return this; },
-      send(data) { this.data = data; },
-    };
+  const res = {
+    status(code) { statusCode = code; return this; },
+    send(data) { this.data = data; if (!statusCode) statusCode = 200; },
+  };
 
-    await controller.create(req, res);
+  await controller.create(req, res);
 
-    assert.strictEqual(statusCode, 201, 'should return 201');
-    const created = await db.piece.findByPk(res.data.id);
-    assert.strictEqual(created.composerId, composer.id);
-    assert.strictEqual(created.authorId, author.id);
+  assert.strictEqual(statusCode, 201, 'should return 201');
+  const created = await db.piece.findByPk(res.data.id);
+  assert.strictEqual(created.composerId, composer.id);
+  assert.strictEqual(created.authorId, author.id);
 
-    console.log('piece.controller create test passed');
+  // non-admin update should create change request
+  await controller.update({
+    params: { id: created.id },
+    body: { title: 'New' },
+    userRole: 'user',
+    userId: user.id
+  }, res);
+  assert.strictEqual(statusCode, 202, 'non-admin update returns 202');
+  const changes = await db.piece_change.count();
+  assert.strictEqual(changes, 1, 'change request stored');
+  const unchanged = await db.piece.findByPk(created.id);
+  assert.strictEqual(unchanged.title, 'Test Piece');
+
+  // admin update should modify the record
+  statusCode = undefined;
+  await controller.update({
+    params: { id: created.id },
+    body: { title: 'Updated' },
+    userRole: 'admin',
+    userId: admin.id
+  }, res);
+  assert.strictEqual(statusCode, 200, 'admin update returns 200');
+  const updated = await db.piece.findByPk(created.id);
+  assert.strictEqual(updated.title, 'Updated');
+
+  // delete piece
+  statusCode = undefined;
+  await controller.delete({ params: { id: created.id } }, res);
+  assert.strictEqual(res.data.message.includes('deleted'), true);
+  const deleted = await db.piece.findByPk(created.id);
+  assert.strictEqual(deleted, null);
+
+    console.log('piece.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- document reusable BaseCrudController
- update piece controller to use BaseCrudController
- extend piece controller tests

## Testing
- `node choir-app-backend/tests/piece.controller.test.js`
- `npm run check --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_68763463dd948320bfdabffcdd20272a