### PR TITLE
Improve Mail Admin security

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -403,7 +403,9 @@ exports.deleteLog = async (req, res) => {
 
 exports.getMailSettings = async (req, res) => {
     try {
-        const settings = await db.mail_setting.findByPk(1);
+        const settings = await db.mail_setting.findByPk(1, {
+            attributes: { exclude: ['pass'] }
+        });
         res.status(200).send(settings);
     } catch (err) {
         res.status(500).send({ message: err.message });
@@ -412,12 +414,19 @@ exports.getMailSettings = async (req, res) => {
 
 exports.updateMailSettings = async (req, res) => {
     try {
+        const data = { ...req.body };
+        if (data.pass === undefined || data.pass === '') {
+            delete data.pass;
+        }
         const [settings] = await db.mail_setting.findOrCreate({
             where: { id: 1 },
-            defaults: req.body
+            defaults: data
         });
-        await settings.update(req.body);
-        res.status(200).send(settings);
+        await settings.update(data);
+        const result = await db.mail_setting.findByPk(1, {
+            attributes: { exclude: ['pass'] }
+        });
+        res.status(200).send(result);
     } catch (err) {
         res.status(500).send({ message: err.message });
     }

--- a/choir-app-frontend/src/app/core/guards/pending-changes.guard.ts
+++ b/choir-app-frontend/src/app/core/guards/pending-changes.guard.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { CanDeactivate } from '@angular/router';
 import { Observable } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 
 export interface PendingChanges {
   hasPendingChanges(): boolean;
@@ -8,9 +10,16 @@ export interface PendingChanges {
 
 @Injectable({ providedIn: 'root' })
 export class PendingChangesGuard implements CanDeactivate<PendingChanges> {
+  constructor(private dialog: MatDialog) {}
+
   canDeactivate(component: PendingChanges): boolean | Observable<boolean> {
     if (component.hasPendingChanges()) {
-      return confirm('Sie haben ungespeicherte Änderungen. Wirklich verlassen?');
+      const dialogData: ConfirmDialogData = {
+        title: 'Änderungen verwerfen?',
+        message: 'Sie haben ungespeicherte Änderungen. Wirklich verlassen?'
+      };
+      const dialogRef = this.dialog.open(ConfirmDialogComponent, { data: dialogData });
+      return dialogRef.afterClosed();
     }
     return true;
   }

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
@@ -37,24 +37,29 @@ export class MailSettingsComponent implements OnInit, PendingChanges {
   load(): void {
     this.api.getMailSettings().subscribe(settings => {
       if (settings) {
-        const encryption = settings.secure
+        const { pass, ...rest } = settings;
+        const encryption = rest.secure
           ? 'tls'
-          : settings.starttls
+          : rest.starttls
           ? 'starttls'
           : 'none';
-        this.form.patchValue({ ...settings, encryption });
+        this.form.patchValue({ ...rest, encryption });
         this.form.markAsPristine();
       }
     });
   }
 
   private prepareData(): MailSettings {
-    const { encryption, ...values } = this.form.value;
-    return {
+    const { encryption, pass, ...values } = this.form.value;
+    const data: MailSettings = {
       ...(values as MailSettings),
       secure: encryption === 'tls',
       starttls: encryption === 'starttls'
     };
+    if (pass) {
+      (data as any).pass = pass;
+    }
+    return data;
   }
 
   save(): void {


### PR DESCRIPTION
## Summary
- keep SMTP passwords secret when loading mail settings
- only send new passwords when updating mail settings
- show a styled confirmation dialog when leaving with unsaved changes

## Testing
- `npm test` *(fails: Chrome not installed)*
- `npm test --prefix choir-app-backend` *(fails: assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_68764c4123848320b01921c5a3cd92ab