### PR TITLE
Fix circular dependency between models

### DIFF
--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -1,4 +1,10 @@
-import { Piece } from "./piece";
+
+export interface EventPiece {
+  id: number;
+  title: string;
+  composer?: { name: string };
+  collections?: { prefix: string; collection_piece: { numberInCollection: string } }[];
+}
 
 export interface Event {
   id: number;
@@ -18,7 +24,7 @@ export interface Event {
   finalized?: boolean;
   version?: number;
   monthlyPlan?: { year: number; month: number; finalized: boolean; version: number } | null;
-  pieces: Piece[];
+  pieces: EventPiece[];
 }
 
 export interface CreateEventResponse {

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -2,7 +2,6 @@ import { Composer } from './composer';
 import { Category } from './category';
 import { Author } from './author';
 import { PieceLink } from './piece-link';
-import { Event } from './event';
 
 export interface PieceNote {
   id: number;
@@ -43,7 +42,7 @@ export interface Piece {
   author?: Author;
   arrangers?: Composer[];
   links?: PieceLink[];
-  events?: Event[];
+  events?: import('./event').EventPiece[];
   notes?: PieceNote[];
   lastSung?: string | null;
   lastRehearsed?: string | null;


### PR DESCRIPTION
## Summary
- break circular import between Piece and Event models by using separate EventPiece interface

## Testing
- `npx madge --extensions ts --ts-config choir-app-frontend/tsconfig.json --circular choir-app-frontend/src`
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68764c07ffac8320ad31f14f9920d615