### PR TITLE
Enable monthly login attempt view

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -1,6 +1,7 @@
 const db = require("../models");
 const crypto = require('crypto');
 const emailService = require('../services/email.service');
+const { Op } = require('sequelize');
 
 // Holt alle Entitäten eines bestimmten Typs für die Admin-Tabellen
 exports.getAll = (model) => async (req, res) => {
@@ -199,8 +200,16 @@ exports.sendPasswordReset = async (req, res) => {
 };
 
 exports.getLoginAttempts = async (req, res) => {
+    const year = parseInt(req.query.year, 10);
+    const month = parseInt(req.query.month, 10);
+    const where = {};
+    if (!isNaN(year) && !isNaN(month)) {
+        const start = new Date(year, month - 1, 1);
+        const end = new Date(year, month, 1);
+        where.createdAt = { [Op.gte]: start, [Op.lt]: end };
+    }
     try {
-        const attempts = await db.login_attempt.findAll({ order: [['createdAt', 'DESC']] });
+        const attempts = await db.login_attempt.findAll({ where, order: [['createdAt', 'DESC']] });
         res.status(200).send(attempts);
     } catch (err) {
         res.status(500).send({ message: err.message });

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -72,8 +72,13 @@ export class AdminService {
     return this.http.post(`${this.apiUrl}/admin/users/${id}/send-password-reset`, {});
   }
 
-  getLoginAttempts(): Observable<LoginAttempt[]> {
-    return this.http.get<LoginAttempt[]>(`${this.apiUrl}/admin/login-attempts`);
+  getLoginAttempts(year?: number, month?: number): Observable<LoginAttempt[]> {
+    const params: any = {};
+    if (year !== undefined && month !== undefined) {
+      params.year = year;
+      params.month = month;
+    }
+    return this.http.get<LoginAttempt[]>(`${this.apiUrl}/admin/login-attempts`, { params });
   }
 
   listLogs(): Observable<string[]> {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -558,8 +558,8 @@ export class ApiService {
     return this.adminService.sendPasswordReset(id);
   }
 
-  getLoginAttempts(): Observable<LoginAttempt[]> {
-    return this.adminService.getLoginAttempts();
+  getLoginAttempts(year?: number, month?: number): Observable<LoginAttempt[]> {
+    return this.adminService.getLoginAttempts(year, month);
   }
 
   listLogs(): Observable<string[]> {

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
@@ -1,3 +1,13 @@
+<div class="month-nav">
+  <button mat-icon-button (click)="previousMonth()">
+    <mat-icon>chevron_left</mat-icon>
+  </button>
+  <span>{{ monthLabel }}</span>
+  <button mat-icon-button (click)="nextMonth()">
+    <mat-icon>chevron_right</mat-icon>
+  </button>
+</div>
+
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="email">
     <th mat-header-cell *matHeaderCellDef>E-Mail</th>

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.scss
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.scss
@@ -1,0 +1,7 @@
+
+.month-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.ts
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.ts
@@ -19,6 +19,7 @@ export class LoginAttemptsComponent implements OnInit {
   attempts: LoginAttempt[] = [];
   displayedColumns = ['email', 'success', 'ipAddress', 'userAgent', 'createdAt'];
   dataSource = new MatTableDataSource<LoginAttempt>();
+  currentMonth = new Date();
 
   constructor(private api: ApiService, private dialog: MatDialog, private snack: MatSnackBar) {}
 
@@ -26,11 +27,27 @@ export class LoginAttemptsComponent implements OnInit {
     this.loadAttempts();
   }
 
+  get monthLabel(): string {
+    return this.currentMonth.toLocaleDateString('de-DE', { month: 'long', year: 'numeric' });
+  }
+
   loadAttempts(): void {
-    this.api.getLoginAttempts().subscribe(data => {
+    const year = this.currentMonth.getFullYear();
+    const month = this.currentMonth.getMonth() + 1;
+    this.api.getLoginAttempts(year, month).subscribe(data => {
       this.attempts = data;
       this.dataSource.data = data;
     });
+  }
+
+  previousMonth(): void {
+    this.currentMonth = new Date(this.currentMonth.getFullYear(), this.currentMonth.getMonth() - 1, 1);
+    this.loadAttempts();
+  }
+
+  nextMonth(): void {
+    this.currentMonth = new Date(this.currentMonth.getFullYear(), this.currentMonth.getMonth() + 1, 1);
+    this.loadAttempts();
   }
 
   openUser(email: string): void {


### PR DESCRIPTION
## Summary
- filter login attempts by month on the backend
- expose year & month params in Angular services
- navigate login logs by month on the frontend

## Testing
- `npm test` *(fails: ChromeHeadless missing)*
- `npm run check-backend`

------
https://chatgpt.com/codex/tasks/task_e_6876513ebdb08320a5776d432eab33a2