### PR TITLE
Improve login error handling

### DIFF
--- a/choir-app-backend/src/routes/auth.routes.js
+++ b/choir-app-backend/src/routes/auth.routes.js
@@ -11,4 +11,9 @@ router.post("/signin", wrap(controller.signin));
 router.post("/switch-choir/:choirId", verifyToken, wrap(controller.switchChoir));
 router.get("/check-choir-admin", verifyToken, wrap(controller.checkChoirAdminStatus));
 
+// Returns 200 when the provided token is valid
+router.get('/check-token', verifyToken, (req, res) => {
+  res.status(200).send({ valid: true });
+});
+
 module.exports = router;

--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -11,6 +11,9 @@ export class ErrorInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
       catchError((error) => {
+        if (req.url.includes('/auth/signin')) {
+          return throwError(() => error);
+        }
         const message = error.name === 'TimeoutError'
           ? 'Die Anfrage hat zu lange gedauert.'
           : (error instanceof HttpErrorResponse ? (error.error?.message || error.message) : 'Unbekannter Fehler');

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { map, tap, catchError } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { environment } from 'src/environments/environment';
 import { User } from '../models/user';
@@ -54,6 +54,23 @@ export class AuthService {
 
   getToken(): string | null {
     return localStorage.getItem(TOKEN_KEY);
+  }
+
+  /**
+   * Check if the currently stored token is still valid.
+   * Returns an observable that emits true when the server
+   * accepts the token and false otherwise.
+   */
+  isTokenValid(): Observable<boolean> {
+    const token = this.getToken();
+    if (!token) {
+      return of(false);
+    }
+
+    return this.http.get<{ valid: boolean }>(`${environment.apiUrl}/auth/check-token`).pipe(
+      map(() => true),
+      catchError(() => of(false))
+    );
   }
 
   login(credentials: any): Observable<User> {

--- a/choir-app-frontend/src/app/features/login/login.component.html
+++ b/choir-app-frontend/src/app/features/login/login.component.html
@@ -8,6 +8,7 @@
     </header>
     <div class="login-body">
       <p *ngIf="sessionExpired" class="session-expired">Letzte Sitzung abgelaufen.</p>
+      <p *ngIf="loginError" class="login-error">{{ loginError }}</p>
       <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="login-pf-settings">
         <mat-form-field appearance="outline">
           <mat-label>E-Mail</mat-label>

--- a/choir-app-frontend/src/app/features/login/login.component.scss
+++ b/choir-app-frontend/src/app/features/login/login.component.scss
@@ -31,6 +31,12 @@ mat-form-field {
   margin-bottom: 1rem;
 }
 
+.login-error {
+  color: red;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
 .login-page {
   padding-top: 20px;
 

--- a/choir-app-frontend/src/app/features/login/login.component.spec.ts
+++ b/choir-app-frontend/src/app/features/login/login.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { LoginComponent } from './login.component';
 
@@ -16,8 +15,7 @@ describe('LoginComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
-        { provide: MatDialog, useValue: {} },
-        { provide: MatSnackBar, useValue: { open: () => {} } }
+        { provide: MatDialog, useValue: {} }
       ]
     })
     .compileComponents();

--- a/choir-app-frontend/src/app/features/login/login.component.ts
+++ b/choir-app-frontend/src/app/features/login/login.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { AuthService } from 'src/app/core/services/auth.service';
 import { MaterialModule } from '@modules/material.module';
@@ -23,12 +22,12 @@ export class LoginComponent implements OnInit {
   loginForm: FormGroup;
   isLoading = false;
   sessionExpired = false;
+  loginError: string | null = null;
 
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
     private router: Router, // Injizieren Sie den Angular Router
-    private snackBar: MatSnackBar,
     private route: ActivatedRoute
   ) {
     this.loginForm = this.fb.group({
@@ -41,6 +40,13 @@ export class LoginComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParamMap.subscribe(params => {
       this.sessionExpired = params.has('sessionExpired');
+      if (!this.sessionExpired) {
+        this.authService.isTokenValid().subscribe(valid => {
+          if (!valid && this.authService.getToken()) {
+            this.sessionExpired = true;
+          }
+        });
+      }
     });
   }
 
@@ -50,6 +56,7 @@ export class LoginComponent implements OnInit {
       return;
     }
 
+    this.loginError = null;
     this.isLoading = true;
 
     // Rufen Sie den AuthService auf, um den Benutzer anzumelden
@@ -64,12 +71,12 @@ export class LoginComponent implements OnInit {
       // --- DIES IST DER FEHLERFALL ---
       error: (err) => {
         this.isLoading = false;
-        // Zeigen Sie dem Benutzer eine freundliche Fehlermeldung
-        const errorMessage = err.error?.message || 'Anmeldung fehlgeschlagen. Bitte überprüfe deine Zugangsdaten.';
-        this.snackBar.open(errorMessage, 'Schließen', {
-          duration: 5000,
-          verticalPosition: 'top'
-        });
+        const status = err.status;
+        if (status === 401 || status === 404 || status === 403) {
+          this.loginError = 'Benutzer oder Passwort ungültig';
+        } else {
+          this.loginError = err.error?.message || 'Anmeldung fehlgeschlagen';
+        }
         console.error('Login failed', err);
       },
       // --- WIRD IMMER AUSGEFÜHRT ---


### PR DESCRIPTION
## Summary
- add `/auth/check-token` backend route
- add token validation method to `AuthService`
- simplify login component error display
- show inline login errors instead of Snackbar and dialog
- skip global error overlay for login failures

## Testing
- `npm test`
- `npm test --prefix choir-app-backend` *(fails: director should not change modules)*

------
https://chatgpt.com/codex/tasks/task_e_6876ba5ac8a88320a33d1fae6dfd24fe