### PR TITLE
Add collection update option

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -63,10 +63,9 @@
             <button
               mat-stroked-button
               color="primary"
-              (click)="addCollectionToChoir(collection); $event.stopPropagation()"
-              [disabled]="collection.isAdded">
-                <mat-icon>add_circle_outline</mat-icon>
-                <span>Zum Repertoire hinzufügen</span>
+              (click)="syncCollection(collection); $event.stopPropagation()">
+                <mat-icon>{{ collection.isAdded ? 'sync' : 'add_circle_outline' }}</mat-icon>
+                <span>{{ collection.isAdded ? 'Aktualisieren' : 'Zum Repertoire hinzufügen' }}</span>
             </button>
             <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
                 <mat-icon>edit</mat-icon>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -68,18 +68,20 @@ export class CollectionListComponent implements OnInit {
   }
 
 
-  addCollectionToChoir(collection: Collection): void {
+  syncCollection(collection: Collection): void {
     this.apiService.addCollectionToChoir(collection.id).subscribe({
       next: () => {
-        this.snackBar.open(`Sammlung '${collection.title}' wurde zum Chorrepertoire hinzugefügt.`, 'OK', {
+        const msg = collection.isAdded
+          ? `Sammlung '${collection.title}' wurde aktualisiert.`
+          : `Sammlung '${collection.title}' wurde zum Chorrepertoire hinzugefügt.`;
+        this.snackBar.open(msg, 'OK', {
           duration: 3000,
           verticalPosition: 'top'
         });
-        // Simply reload the list to get the updated 'isAdded' status.
         this.loadCollections();
       },
       error: (err) => {
-        this.snackBar.open(`Fehler beim Hinzufügen der Sammlung: ${err.message}`, 'Schließen', {
+        this.snackBar.open(`Fehler beim Aktualisieren der Sammlung: ${err.message}`, 'Schließen', {
           duration: 5000,
           verticalPosition: 'top'
         });


### PR DESCRIPTION
## Summary
- sync collection changes with choir repertoire
- show "Aktualisieren" button when a collection is already part of the choir repertoire

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6876bb2c9b6083208736729e8fa9b194