### PR TITLE
Fix cancel button in collection edit

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -13,7 +13,7 @@ import {
     Validators,
     FormControl,
 } from '@angular/forms';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Router, ActivatedRoute, RouterModule } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { map, startWith, switchMap, tap } from 'rxjs/operators';
 import {
@@ -48,6 +48,7 @@ interface SelectedPieceWithNumber {
         ReactiveFormsModule,
         MaterialModule,
         MatAutocompleteModule,
+        RouterModule,
     ],
     templateUrl: './collection-edit.component.html',
     styleUrls: ['./collection-edit.component.scss'],


### PR DESCRIPTION
## Summary
- enable `routerLink` directive in collection edit by importing `RouterModule`

## Testing
- `npm install --prefix choir-app-frontend`
- `npm test --prefix choir-app-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6876bac751b08320b7bcf5f87a6e53b4