### PR TITLE
Disable add button when non-admin

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -4,7 +4,9 @@
     <h1>Sammlungen</h1>
     <p class="subtitle">Verwalten von globalen Sammlungen und Hinzufügen zum Chorrepertoire.</p>
   </div>
-  <button mat-flat-button color="accent" routerLink="/collections/new">
+  <button mat-flat-button color="accent" routerLink="/collections/new"
+          [disabled]="!isChoirAdmin && !isAdmin"
+          matTooltip="{{ !isChoirAdmin && !isAdmin ? 'Zum Hinzufügen müssen Sie als Chor-Administrator eingeloggt sein.' : '' }}">
     <mat-icon>add</mat-icon>
     <span>Neue Sammlung</span>
   </button>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
@@ -3,6 +3,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { AuthService } from '@core/services/auth.service';
+import { ApiService } from '@core/services/api.service';
 
 import { CollectionListComponent } from './collection-list.component';
 
@@ -17,7 +20,9 @@ describe('CollectionListComponent', () => {
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useValue: {} },
-        { provide: MatSnackBar, useValue: { open: () => {} } }
+        { provide: MatSnackBar, useValue: { open: () => {} } },
+        { provide: AuthService, useValue: { isAdmin$: of(false) } },
+        { provide: ApiService, useValue: { getCollections: () => of([]), checkChoirAdminStatus: () => of({ isChoirAdmin: false }) } }
       ]
     })
     .compileComponents();

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -9,6 +9,7 @@ import { Collection } from '@core/models/collection';
 import { forkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { RouterLink, Router } from '@angular/router'; // Import RouterLink and Router
+import { AuthService } from '@core/services/auth.service';
 
 @Component({
   selector: 'app-collection-list',
@@ -24,6 +25,8 @@ import { RouterLink, Router } from '@angular/router'; // Import RouterLink and R
 export class CollectionListComponent implements OnInit {
   public dataSource = new MatTableDataSource<Collection>();
   public isLoading = true;
+  public isChoirAdmin = false;
+  public isAdmin = false;
   private _sort!: MatSort;
   @ViewChild(MatSort) set sort(sort: MatSort) {
     if (sort) {
@@ -37,11 +40,14 @@ export class CollectionListComponent implements OnInit {
   constructor(
     public apiService: ApiService,
     private snackBar: MatSnackBar,
-    private router: Router
+    private router: Router,
+    private authService: AuthService
   ) { }
 
   ngOnInit(): void {
     this.loadCollections();
+    this.apiService.checkChoirAdminStatus().subscribe(r => this.isChoirAdmin = r.isChoirAdmin);
+    this.authService.isAdmin$.subscribe(v => this.isAdmin = v);
   }
 
   loadCollections(): void {


### PR DESCRIPTION
## Summary
- make add button for collections respect choir admin permission
- update collection list spec for new providers

## Testing
- `npm install --prefix choir-app-frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876bd6116f88320ba25458ac8889baf