### PR TITLE
Use Mein Chor for admin editing

### DIFF
--- a/choir-app-backend/src/controllers/auth.controller.js
+++ b/choir-app-backend/src/controllers/auth.controller.js
@@ -135,11 +135,13 @@ exports.switchChoir = async (req, res) => {
         const user = await User.findByPk(userId, { include: [Choir] });
         // Sicherheitsprüfung: Gehört der Chor dem Benutzer überhaupt?
         const hasChoir = user.choirs.some(choir => choir.id === newActiveChoirId);
-        if (!hasChoir) {
+        if (!hasChoir && user.role !== 'admin') {
             return res.status(403).send({ message: "Forbidden: User is not a member of this choir." });
         }
 
-        const activeChoir = user.choirs.find(choir => choir.id === newActiveChoirId);
+        const activeChoir = hasChoir
+            ? user.choirs.find(choir => choir.id === newActiveChoirId)
+            : await Choir.findByPk(newActiveChoirId);
 
         // Erstellen Sie ein neues Token mit der neuen aktiven Chor-ID
         const token = jwt.sign(

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
@@ -5,6 +5,8 @@ import { ApiService } from 'src/app/core/services/api.service';
 import { Choir } from 'src/app/core/models/choir';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
 import { ChoirDialogComponent } from './choir-dialog/choir-dialog.component';
 
 @Component({
@@ -19,7 +21,12 @@ export class ManageChoirsComponent implements OnInit {
   displayedColumns = ['name', 'location', 'memberCount', 'eventCount', 'pieceCount', 'actions'];
   dataSource = new MatTableDataSource<Choir>();
 
-  constructor(private api: ApiService, private dialog: MatDialog) {}
+  constructor(
+    private api: ApiService,
+    private dialog: MatDialog,
+    private auth: AuthService,
+    private router: Router
+  ) {}
 
   ngOnInit(): void {
     this.loadChoirs();
@@ -42,13 +49,9 @@ export class ManageChoirsComponent implements OnInit {
   }
 
   editChoir(choir: Choir): void {
-    const ref = this.dialog.open(ChoirDialogComponent, { width: '600px', data: choir });
-    ref.afterClosed().subscribe(result => {
-      if (result) {
-        this.api.updateChoir(choir.id, result).subscribe(() => this.loadChoirs());
-      } else {
-        this.loadChoirs();
-      }
+    this.auth.switchChoir(choir.id).subscribe({
+      next: () => this.router.navigate(['/manage-choir']),
+      error: () => this.loadChoirs()
     });
   }
 


### PR DESCRIPTION
## Summary
- allow admins to switch to any choir
- route edit from choir list to the normal choir management page

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6876bf44f08883208cea04fd29f9063d