### PR TITLE
Fix error interceptor

### DIFF
--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -14,6 +14,10 @@ export class ErrorInterceptor implements HttpInterceptor {
         if (req.url.includes('/auth/signin')) {
           return throwError(() => error);
         }
+        if (error.status === 0 && (error as HttpErrorResponse).error === 'abort') {
+          // The request was cancelled, e.g. due to logout. Avoid reporting an error.
+          return throwError(() => error);
+        }
         const message = error.name === 'TimeoutError'
           ? 'Die Anfrage hat zu lange gedauert.'
           : (error instanceof HttpErrorResponse ? (error.error?.message || error.message) : 'Unbekannter Fehler');


### PR DESCRIPTION
## Summary
- do not show errors for aborted HTTP requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c63934c88320861c59dd8f5e008e