### PR TITLE
Fix choir collections query

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -241,9 +241,16 @@ exports.getChoirCollections = async (req, res, next) => {
         const collections = await choir.getCollections({
             attributes: {
                 include: [
-                    [db.sequelize.literal(`(SELECT COUNT(*) FROM "collection_pieces" AS cp WHERE cp."collectionId" = "collection"."id")`), 'pieceCount']
+                    [db.sequelize.fn('COUNT', db.sequelize.col('pieces->collection_piece.collectionId')), 'pieceCount']
                 ]
             },
+            include: [{
+                model: db.piece,
+                attributes: [],
+                through: { attributes: [] },
+                required: false
+            }],
+            group: ['collection.id'],
             order: [['title', 'ASC']]
         });
 


### PR DESCRIPTION
## Summary
- fix the collection query in choir-management controller so it works on all SQL dialects

## Testing
- `npm test --prefix choir-app-backend` *(fails: director should not change modules)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877291118a883208cc8a8af46505053