### PR TITLE
Add scroll reset to help wizard

### DIFF
--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
@@ -1,6 +1,6 @@
 <h1 mat-dialog-title>Willkommen</h1>
-<div mat-dialog-content>
-  <mat-vertical-stepper>
+<div mat-dialog-content #content>
+  <mat-vertical-stepper #stepper (selectionChange)="resetScroll()">
     <mat-step>
       <ng-template matStepLabel>Willkommen</ng-template>
       <p>Sch&ouml;n, dass du den Chorleiter nutzt. Dieses kurze Tutorial zeigt dir die wichtigsten Funktionen.</p>

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, AfterViewInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatDialogRef } from '@angular/material/dialog';
-import { MatStepperModule } from '@angular/material/stepper';
+import { MatDialogRef, MatDialogContent } from '@angular/material/dialog';
+import { MatStepperModule, MatStepper } from '@angular/material/stepper';
 import { MaterialModule } from '@modules/material.module';
 
 @Component({
@@ -11,8 +11,18 @@ import { MaterialModule } from '@modules/material.module';
   templateUrl: './help-wizard.component.html',
   styleUrls: ['./help-wizard.component.scss']
 })
-export class HelpWizardComponent {
+export class HelpWizardComponent implements AfterViewInit {
+  @ViewChild('content', { read: MatDialogContent }) content!: MatDialogContent;
+  @ViewChild('stepper') stepper!: MatStepper;
   constructor(public dialogRef: MatDialogRef<HelpWizardComponent>) {}
+
+  ngAfterViewInit(): void {
+    this.resetScroll();
+  }
+
+  resetScroll(): void {
+    (this.content as any)._elementRef.nativeElement.scrollTop = 0;
+  }
 
   close(): void {
     this.dialogRef.close();


### PR DESCRIPTION
## Summary
- reset scroll position in the Help Wizard when switching steps

## Testing
- `npm test`
- `npm test --prefix choir-app-backend` *(fails: director should not change modules)*

------
https://chatgpt.com/codex/tasks/task_e_68772c799e888320907df32d7fe9ee2e