### PR TITLE
Fix permissions in updateMyChoir

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -49,6 +49,15 @@ exports.updateMyChoir = async (req, res, next) => {
             return res.status(404).send({ message: "Active choir not found." });
         }
 
+        if (req.userRole !== 'admin') {
+            const association = await db.user_choir.findOne({
+                where: { userId: req.userId, choirId: req.activeChoirId }
+            });
+            if (!association || !Array.isArray(association.rolesInChoir) || !association.rolesInChoir.includes('choir_admin')) {
+                return res.status(403).send({ message: 'Require Choir Admin Role!' });
+            }
+        }
+
         // Führen Sie das Update durch. `update` gibt ein Array mit der Anzahl der betroffenen Zeilen zurück.
         const updateData = {};
         if (name !== undefined) updateData.name = name;


### PR DESCRIPTION
## Summary
- ensure only choir admins can update choir info

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68773072c3e88320937d8eb8d8666fce