### PR TITLE
Update ManageChoirResolver to respect admin choirId

### DIFF
--- a/choir-app-backend/src/middleware/auth.middleware.js
+++ b/choir-app-backend/src/middleware/auth.middleware.js
@@ -8,8 +8,12 @@ const optionalAuth = (req, res, next) => {
   jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
     if (!err) {
       req.userId = decoded.id;
-      req.activeChoirId = decoded.activeChoirId;
       req.userRole = decoded.role;
+      const choirParam = parseInt(req.query.choirId, 10);
+      req.activeChoirId =
+        decoded.role === 'admin' && !isNaN(choirParam)
+          ? choirParam
+          : decoded.activeChoirId;
     }
     next();
   });
@@ -29,10 +33,13 @@ const verifyToken = (req, res, next) => {
     if (err) {
       return res.status(401).send({ message: "Unauthorized!" });
     }
-    // Add user and choir id from token payload to the request
     req.userId = decoded.id;
-    req.activeChoirId = decoded.activeChoirId;
     req.userRole = decoded.role;
+    const choirParam = parseInt(req.query.choirId, 10);
+    req.activeChoirId =
+      decoded.role === 'admin' && !isNaN(choirParam)
+        ? choirParam
+        : decoded.activeChoirId;
     next();
   });
 };

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -367,8 +367,8 @@ export class ApiService {
   }
 
   // --- Plan Rule Methods ---
-  getPlanRules(): Observable<PlanRule[]> {
-    return this.planRuleService.getPlanRules();
+  getPlanRules(options?: { choirId?: number }): Observable<PlanRule[]> {
+    return this.planRuleService.getPlanRules(options?.choirId);
   }
 
   createPlanRule(data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
@@ -444,24 +444,33 @@ export class ApiService {
     return this.pieceService.getRepertoirePiece(id);
   }
 
-  getMyChoirDetails(): Observable<Choir> {
-    return this.choirService.getMyChoirDetails();
+  getMyChoirDetails(options?: { choirId?: number }): Observable<Choir> {
+    return this.choirService.getMyChoirDetails(options?.choirId);
   }
 
-  updateMyChoir(choirData: Partial<Choir>): Observable<any> {
-    return this.choirService.updateMyChoir(choirData);
+  updateMyChoir(choirData: Partial<Choir>, options?: { choirId?: number }): Observable<any> {
+    return this.choirService.updateMyChoir(choirData, options?.choirId);
   }
 
-  getChoirMembers(): Observable<UserInChoir[]> {
-    return this.choirService.getChoirMembers();
+  getChoirMembers(options?: { choirId?: number }): Observable<UserInChoir[]> {
+    return this.choirService.getChoirMembers(options?.choirId);
   }
 
-  inviteUserToChoir(email: string, rolesInChoir: string[], isOrganist?: boolean): Observable<{ message: string }> {
-    return this.choirService.inviteUserToChoir(email, rolesInChoir, isOrganist);
+  inviteUserToChoir(
+    email: string,
+    rolesInChoir: string[],
+    isOrganist?: boolean,
+    options?: { choirId?: number }
+  ): Observable<{ message: string }> {
+    return this.choirService.inviteUserToChoir(email, rolesInChoir, isOrganist, options?.choirId);
   }
 
-  updateChoirMember(userId: number, data: { rolesInChoir?: string[]; isOrganist?: boolean }): Observable<any> {
-    return this.choirService.updateMember(userId, data);
+  updateChoirMember(
+    userId: number,
+    data: { rolesInChoir?: string[]; isOrganist?: boolean },
+    options?: { choirId?: number }
+  ): Observable<any> {
+    return this.choirService.updateMember(userId, data, options?.choirId);
   }
 
   getInvitation(token: string): Observable<any> {
@@ -488,16 +497,16 @@ export class ApiService {
     return this.userService.joinChoir(token, data);
   }
 
-  removeUserFromChoir(userId: number): Observable<any> {
-    return this.choirService.removeUserFromChoir(userId);
+  removeUserFromChoir(userId: number, options?: { choirId?: number }): Observable<any> {
+    return this.choirService.removeUserFromChoir(userId, options?.choirId);
   }
 
-  getChoirCollections(): Observable<Collection[]> {
-    return this.choirService.getChoirCollections();
+  getChoirCollections(options?: { choirId?: number }): Observable<Collection[]> {
+    return this.choirService.getChoirCollections(options?.choirId);
   }
 
-  removeCollectionFromChoir(collectionId: number): Observable<any> {
-    return this.choirService.removeCollectionFromChoir(collectionId);
+  removeCollectionFromChoir(collectionId: number, options?: { choirId?: number }): Observable<any> {
+    return this.choirService.removeCollectionFromChoir(collectionId, options?.choirId);
   }
 
   // --- Admin Methods ---

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { Choir } from '../models/choir';
@@ -12,36 +12,44 @@ export class ChoirService {
 
   constructor(private http: HttpClient) {}
 
-  getMyChoirDetails(): Observable<Choir> {
-    return this.http.get<Choir>(`${this.apiUrl}/choir-management`);
+  getMyChoirDetails(choirId?: number): Observable<Choir> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get<Choir>(`${this.apiUrl}/choir-management`, { params });
   }
 
-  updateMyChoir(choirData: Partial<Choir>): Observable<any> {
-    return this.http.put(`${this.apiUrl}/choir-management`, choirData);
+  updateMyChoir(choirData: Partial<Choir>, choirId?: number): Observable<any> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.put(`${this.apiUrl}/choir-management`, choirData, { params });
   }
 
-  getChoirMembers(): Observable<UserInChoir[]> {
-    return this.http.get<UserInChoir[]>(`${this.apiUrl}/choir-management/members`);
+  getChoirMembers(choirId?: number): Observable<UserInChoir[]> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get<UserInChoir[]>(`${this.apiUrl}/choir-management/members`, { params });
   }
 
-  inviteUserToChoir(email: string, rolesInChoir: string[], isOrganist?: boolean): Observable<{ message: string }> {
-    return this.http.post<{ message: string }>(`${this.apiUrl}/choir-management/members`, { email, rolesInChoir, isOrganist });
+  inviteUserToChoir(email: string, rolesInChoir: string[], isOrganist?: boolean, choirId?: number): Observable<{ message: string }> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.post<{ message: string }>(`${this.apiUrl}/choir-management/members`, { email, rolesInChoir, isOrganist }, { params });
   }
 
-  updateMember(userId: number, data: { rolesInChoir?: string[]; isOrganist?: boolean }): Observable<any> {
-    return this.http.put(`${this.apiUrl}/choir-management/members/${userId}`, data);
+  updateMember(userId: number, data: { rolesInChoir?: string[]; isOrganist?: boolean }, choirId?: number): Observable<any> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.put(`${this.apiUrl}/choir-management/members/${userId}`, data, { params });
   }
 
-  removeUserFromChoir(userId: number): Observable<any> {
-    const options = { body: { userId } };
+  removeUserFromChoir(userId: number, choirId?: number): Observable<any> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    const options = { params, body: { userId } };
     return this.http.delete(`${this.apiUrl}/choir-management/members`, options);
   }
 
-  getChoirCollections(): Observable<Collection[]> {
-    return this.http.get<Collection[]>(`${this.apiUrl}/choir-management/collections`);
+  getChoirCollections(choirId?: number): Observable<Collection[]> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get<Collection[]>(`${this.apiUrl}/choir-management/collections`, { params });
   }
 
-  removeCollectionFromChoir(collectionId: number): Observable<any> {
-    return this.http.delete(`${this.apiUrl}/choir-management/collections/${collectionId}`);
+  removeCollectionFromChoir(collectionId: number, choirId?: number): Observable<any> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.delete(`${this.apiUrl}/choir-management/collections/${collectionId}`, { params });
   }
 }

--- a/choir-app-frontend/src/app/core/services/plan-rule.service.ts
+++ b/choir-app-frontend/src/app/core/services/plan-rule.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { PlanRule } from '../models/plan-rule';
@@ -10,8 +10,9 @@ export class PlanRuleService {
 
   constructor(private http: HttpClient) {}
 
-  getPlanRules(): Observable<PlanRule[]> {
-    return this.http.get<PlanRule[]>(`${this.apiUrl}/plan-rules`);
+  getPlanRules(choirId?: number): Observable<PlanRule[]> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get<PlanRule[]>(`${this.apiUrl}/plan-rules`, { params });
   }
 
   createPlanRule(data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -23,16 +23,19 @@ export class ManageChoirResolver implements Resolve<any> {
 
     return this.authService.isAdmin$.pipe(
       switchMap(isAdmin => {
-        const choirId = route.queryParamMap.get('choirId');
+        const choirIdParam = route.queryParamMap.get('choirId');
+        const choirId = choirIdParam ? parseInt(choirIdParam, 10) : null;
         console.log('ManageChoirResolver: Resolving data for choirId:', choirId);
 
-        const choirDetails$ = this.apiService.getMyChoirDetails();
-        const collections$ = this.apiService.getChoirCollections();
-        const planRules$ = this.apiService.getPlanRules();
+        const opts = isAdmin && choirId ? { choirId } : undefined;
+
+        const choirDetails$ = this.apiService.getMyChoirDetails(opts);
+        const collections$ = this.apiService.getChoirCollections(opts);
+        const planRules$ = this.apiService.getPlanRules(opts);
         if (isAdmin) {
           return forkJoin({
             choirDetails: choirDetails$,
-            members: this.apiService.getChoirMembers(),
+            members: this.apiService.getChoirMembers(opts),
             collections: collections$,
             planRules: planRules$,
             isChoirAdmin: of(true)


### PR DESCRIPTION
## Summary
- support choir selection via query parameter for admins
- forward choirId in client API calls
- allow backend middleware to override active choir per request

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68774686b1c883208f2109ac5cfc0b14