### PR TITLE
Allow admin-managed choir operations

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -371,16 +371,23 @@ export class ApiService {
     return this.planRuleService.getPlanRules(options?.choirId);
   }
 
-  createPlanRule(data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
-    return this.planRuleService.createPlanRule(data);
+  createPlanRule(
+    data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null },
+    options?: { choirId?: number }
+  ): Observable<PlanRule> {
+    return this.planRuleService.createPlanRule(data, options?.choirId);
   }
 
-  updatePlanRule(id: number, data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
-    return this.planRuleService.updatePlanRule(id, data);
+  updatePlanRule(
+    id: number,
+    data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null },
+    options?: { choirId?: number }
+  ): Observable<PlanRule> {
+    return this.planRuleService.updatePlanRule(id, data, options?.choirId);
   }
 
-  deletePlanRule(id: number): Observable<any> {
-    return this.planRuleService.deletePlanRule(id);
+  deletePlanRule(id: number, options?: { choirId?: number }): Observable<any> {
+    return this.planRuleService.deletePlanRule(id, options?.choirId);
   }
 
   // --- Availability Methods ---

--- a/choir-app-frontend/src/app/core/services/plan-rule.service.ts
+++ b/choir-app-frontend/src/app/core/services/plan-rule.service.ts
@@ -15,15 +15,25 @@ export class PlanRuleService {
     return this.http.get<PlanRule[]>(`${this.apiUrl}/plan-rules`, { params });
   }
 
-  createPlanRule(data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
-    return this.http.post<PlanRule>(`${this.apiUrl}/plan-rules`, data);
+  createPlanRule(
+    data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null },
+    choirId?: number
+  ): Observable<PlanRule> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.post<PlanRule>(`${this.apiUrl}/plan-rules`, data, { params });
   }
 
-  updatePlanRule(id: number, data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null }): Observable<PlanRule> {
-    return this.http.put<PlanRule>(`${this.apiUrl}/plan-rules/${id}`, data);
+  updatePlanRule(
+    id: number,
+    data: { dayOfWeek: number; weeks?: number[] | null; notes?: string | null },
+    choirId?: number
+  ): Observable<PlanRule> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.put<PlanRule>(`${this.apiUrl}/plan-rules/${id}`, data, { params });
   }
 
-  deletePlanRule(id: number): Observable<any> {
-    return this.http.delete(`${this.apiUrl}/plan-rules/${id}`);
+  deletePlanRule(id: number, choirId?: number): Observable<any> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.delete(`${this.apiUrl}/plan-rules/${id}`, { params });
   }
 }


### PR DESCRIPTION
## Summary
- include choirId when modifying plan rules
- support choirId option in API service plan rule methods
- capture admin choirId in ManageChoirComponent and pass to API calls

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687760ae99b0832080a15667cd3937cd