### PR TITLE
Update log viewer sorting

### DIFF
--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.ts
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.ts
@@ -60,8 +60,20 @@ export class LogViewerComponent implements OnInit {
       if (!map.has(day)) map.set(day, []);
       map.get(day)!.push(e);
     }
-    const array: LogGroup[] = Array.from(map.entries()).map(([date, items]) => ({ date, items }));
-    array.sort((a,b) => this.descending ? (a.date < b.date ? 1 : -1) : (a.date > b.date ? 1 : -1));
+
+    const array: LogGroup[] = Array.from(map.entries()).map(([date, items]) => {
+      items.sort((a, b) => {
+        const ta = new Date(a.timestamp || a.date || 0).getTime();
+        const tb = new Date(b.timestamp || b.date || 0).getTime();
+        return tb - ta;
+      });
+      return { date, items };
+    });
+
+    array.sort((a, b) =>
+      this.descending ? (a.date < b.date ? 1 : -1) : (a.date > b.date ? 1 : -1)
+    );
+
     this.groups = array;
   }
 }


### PR DESCRIPTION
## Summary
- keep most recent log messages at the top for each day

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687769d5d41883208b6b3d5e3dab644e