### PR TITLE
Expand event piece autocomplete

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -32,7 +32,7 @@ exports.lookup = async (req, res) => {
                 {
                     model: db.collection,
                     as: 'collections',
-                    attributes: ['prefix'],
+                    attributes: ['prefix', 'title'],
                     through: {
                         model: db.collection_piece,
                         attributes: ['numberInCollection']
@@ -46,12 +46,14 @@ exports.lookup = async (req, res) => {
         const lookupResults = pieces.map(piece => {
             const plainPiece = piece.get({ plain: true });
             let referenceString = null;
+            let collectionTitle = null;
 
             // Erstellen Sie den Referenz-String, falls das Stück in einer Sammlung ist.
             if (plainPiece.collections && plainPiece.collections.length > 0) {
                 const ref = plainPiece.collections[0]; // Nehmen Sie die erste Referenz
                 const num = ref.collection_piece.numberInCollection;
                 referenceString = `${ref.prefix || ''}${num}`;
+                collectionTitle = ref.title || null;
             }
 
             // Geben Sie ein sauberes Objekt zurück, das nur das Nötigste enthält.
@@ -59,7 +61,8 @@ exports.lookup = async (req, res) => {
                 id: plainPiece.id,
                 title: plainPiece.title,
                 composerName: plainPiece.composer?.name || '',
-                reference: referenceString // z.B. "CB45" oder null
+                reference: referenceString, // z.B. "CB45" oder null
+                collectionTitle
             };
         });
 

--- a/choir-app-frontend/src/app/core/models/lookup-piece.ts
+++ b/choir-app-frontend/src/app/core/models/lookup-piece.ts
@@ -3,5 +3,6 @@ export interface LookupPiece {
   id: number;
   title: string;
   composerName: string;
+  collectionTitle: string | null;
   reference: string | null;
 }

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -13,6 +13,7 @@ export interface PieceNote {
 
 export interface CollectionReference {
   prefix: string;
+  title?: string;
   collection_piece: { // The name of the through model in Sequelize
     numberInCollection: string;
   };

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -43,15 +43,20 @@
             #pieceInput
           >
           <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayPiece" (optionSelected)="selected($event)">
+            <mat-option disabled class="option-header">
+              <div class="option-grid">
+                <span>Ref</span>
+                <span>Titel</span>
+                <span>Komponist</span>
+                <span>Sammlung</span>
+              </div>
+            </mat-option>
             <mat-option *ngFor="let piece of filteredPieces$ | async" [value]="piece">
-              <div class="option-layout">
-                <!-- Zeigt den Titel und den Komponisten an -->
-                <div class="option-main">
-                  <span class="option-title">{{ piece.title }}</span>
-                  <small class="composer-hint"> - {{ piece.composerName }}</small>
-                </div>
-                <!-- Zeigt die Referenz an, wenn eine vorhanden ist -->
-                <span *ngIf="piece.reference" class="option-reference">{{ piece.reference }}</span>
+              <div class="option-grid">
+                <span class="col-reference">{{ piece.reference }}</span>
+                <span class="col-title">{{ piece.title }}</span>
+                <span class="col-composer">{{ piece.composerName }}</span>
+                <span class="col-collection">{{ piece.collectionTitle }}</span>
               </div>
             </mat-option>
           </mat-autocomplete>

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.scss
@@ -17,13 +17,20 @@ h3.mat-subheading-2 {
 }
 
 // Styling für die Autocomplete-Optionen
-.option-layout {
-    display: flex;
-    justify-content: space-between;
+.option-grid {
+    display: grid;
+    grid-template-columns: 5rem 1fr 1fr 1fr;
+    gap: 0.5rem;
     width: 100%;
+    align-items: center;
 }
 
-.option-reference {
+.option-header {
+    font-weight: bold;
+    pointer-events: none;
+}
+
+.col-reference {
     font-style: italic;
     color: #888;
 }
@@ -42,12 +49,17 @@ h3.mat-subheading-2 {
 }
 
 // Neuer Container für die Stück-Suche
+
 .autocomplete-container {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 1rem;
     flex-wrap: wrap;
+
+    .search-box {
+        width: 100%;
+    }
 
     .add-custom {
         font-size: 0.875rem;

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -200,6 +200,11 @@ export class EventDialogComponent implements OnInit {
                                           .numberInCollection
                                   }`
                                 : null,
+                        collectionTitle:
+                            newPiece.collections &&
+                            newPiece.collections.length > 0
+                                ? newPiece.collections[0].title || null
+                                : null,
                     };
                     this.allRepertoirePieces.push(lookup);
                     this.selectedPieces = [...this.selectedPieces, lookup];
@@ -227,6 +232,10 @@ export class EventDialogComponent implements OnInit {
                               .numberInCollection
                       }`
                     : '',
+            collectionTitle:
+                p.collections && p.collections.length > 0
+                    ? p.collections[0].title || null
+                    : null,
         }));
         this.selectedPiecesDataSource.data = this.selectedPieces;
     }


### PR DESCRIPTION
## Summary
- expand piece search field in event dialog
- show lookup results in four columns
- provide collection titles from the backend

## Testing
- `npm install --prefix choir-app-frontend`
- `npm install --prefix choir-app-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f2b3c95083208b4a62129c055277