### PR TITLE
Add edit option to piece detail view

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -1,8 +1,21 @@
 <div class="piece-detail" *ngIf="piece">
-  <h2>{{ piece.title }}</h2>
+  <h2>
+    {{ piece.title }}
+    <button mat-icon-button color="primary" (click)="openEditPieceDialog()" aria-label="Stück bearbeiten">
+      <mat-icon>edit</mat-icon>
+    </button>
+  </h2>
   <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
+  <div *ngIf="piece.collections?.length">
+    <p><strong>Enthalten in:</strong></p>
+    <ul>
+      <li *ngFor="let c of piece.collections">
+        {{ c.title }} ({{ c.prefix }}{{ c.collection_piece.numberInCollection }})
+      </li>
+    </ul>
+  </div>
   <p>
     <strong>Status im Chor:</strong>
     <mat-select [value]="piece.choir_repertoire?.status" (selectionChange)="onStatusChange($event.value)">

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -5,6 +5,8 @@ import { of } from 'rxjs';
 import { PieceDetailComponent } from './piece-detail.component';
 import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 describe('PieceDetailComponent', () => {
   let component: PieceDetailComponent;
@@ -19,7 +21,9 @@ describe('PieceDetailComponent', () => {
         {
           provide: AuthService,
           useValue: { currentUser$: of(null), isAdmin$: of(false) }
-        }
+        },
+        { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(false) }) } },
+        { provide: MatSnackBar, useValue: { open: () => {} } }
       ]
     })
     .compileComponents();


### PR DESCRIPTION
## Summary
- enhance piece detail page with edit button
- show collection references for a piece
- update piece detail component tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f3f47d9c832084d61af23eae9b6b