### PR TITLE
Fix piece selection after creation in collection edit

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -336,6 +336,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
                 if (newPiece) {
                     this.allPieces.push(newPiece);
                     this.addPieceForm.patchValue({ piece: newPiece });
+                    this.pieceCtrl.setValue(newPiece);
                     this.proposeNextNumber();
                 }
             });


### PR DESCRIPTION
## Summary
- ensure newly created pieces are immediately selected when editing a collection
- run frontend tests

## Testing
- `npm ci --prefix choir-app-frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791472f4948320bab188c0b3bf4e7b