### PR TITLE
Adjust piece dialog width

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -326,7 +326,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
         this.pieceCtrl.setValue('');
         const pieceDialogRef = this.dialog.open(PieceDialogComponent, {
             width: '90vw',
-            maxWidth: '800px',
+            maxWidth: '1000px',
             disableClose: true,
             data: { pieceId: null },
         });
@@ -345,7 +345,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     openEditPieceDialog(pieceId: number): void {
         const dialogRef = this.dialog.open(PieceDialogComponent, {
             width: '90vw',
-            maxWidth: '800px',
+            maxWidth: '1000px',
             disableClose: true,
             data: { pieceId }
         });

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -180,7 +180,7 @@ export class EventDialogComponent implements OnInit {
     openAddPieceDialog(): void {
         const dialogRef = this.dialog.open(PieceDialogComponent, {
             width: '90vw',
-            maxWidth: '800px',
+            maxWidth: '1000px',
             data: { pieceId: null },
         });
 

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -378,7 +378,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   openAddPieceDialog(): void {
     const dialogRef = this.dialog.open(PieceDialogComponent, {
       width: '90vw',
-      maxWidth: '800px',
+      maxWidth: '1000px',
       data: { pieceId: null }
     });
 
@@ -456,7 +456,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   openEditPieceDialog(pieceId: number): void {
     const dialogRef = this.dialog.open(PieceDialogComponent, {
       width: '90vw',
-      maxWidth: '800px',
+      maxWidth: '1000px',
       data: { pieceId: pieceId }
     });
 

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -107,7 +107,7 @@ export class PieceDetailComponent implements OnInit {
     if (!this.piece) return;
     const dialogRef = this.dialog.open(PieceDialogComponent, {
       width: '90vw',
-      maxWidth: '800px',
+      maxWidth: '1000px',
       data: { pieceId: this.piece.id }
     });
 

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
@@ -29,7 +29,7 @@
 }
 
 mat-sidenav-container.dialog-container {
-  max-width: 800px;
+  max-width: 1000px;
   height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- widen the Piece dialog by increasing the `maxWidth` to 1000px
- adjust all dialog openings to respect the new width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791b0125c083208a6b43f45c811444