### PR TITLE
Add expandable list of pieces for composers and authors

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -64,7 +64,13 @@ exports.create = async (req, res) => {
  * when adding pieces to a collection.
  */
 exports.findAll = async (req, res) => {
+    const { composerId, authorId } = req.query;
+    const where = {};
+    if (composerId) where.composerId = composerId;
+    if (authorId) where.authorId = authorId;
+
     const pieces = await base.service.findAll({
+            where,
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -148,8 +148,8 @@ export class ApiService {
    * Gets the master list of all pieces in the system, independent of any choir.
    * Useful for lookups when creating collections.
    */
-  getGlobalPieces(): Observable<Piece[]> {
-    return this.pieceService.getGlobalPieces();
+  getGlobalPieces(filters?: { composerId?: number; authorId?: number }): Observable<Piece[]> {
+    return this.pieceService.getGlobalPieces(filters);
   }
 
   /**

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -74,8 +74,15 @@ export class PieceService {
     return this.http.delete(`${this.apiUrl}/repertoire/notes/${noteId}`);
   }
 
-  getGlobalPieces(): Observable<Piece[]> {
-    return this.http.get<Piece[]>(`${this.apiUrl}/pieces`);
+  getGlobalPieces(filters?: { composerId?: number; authorId?: number }): Observable<Piece[]> {
+    let params = new HttpParams();
+    if (filters?.composerId) {
+      params = params.set('composerId', filters.composerId.toString());
+    }
+    if (filters?.authorId) {
+      params = params.set('authorId', filters.authorId.toString());
+    }
+    return this.http.get<Piece[]>(`${this.apiUrl}/pieces`, { params });
   }
 
   createGlobalPiece(pieceData: any): Observable<Piece> {

--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
@@ -14,7 +14,7 @@
   </button>
 </div>
 
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" multiTemplateDataRows>
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">{{ element.name }}</td>
@@ -45,8 +45,22 @@
     </td>
   </ng-container>
 
+  <ng-container matColumnDef="expandedDetail">
+    <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+      <div class="piece-list" *ngIf="expandedPerson?.id === element.id">
+        <div *ngIf="expandedPieces.length; else none">
+          <ul>
+            <li *ngFor="let p of expandedPieces">{{ p.title }}</li>
+          </ul>
+        </div>
+        <ng-template #none>Keine Stücke vorhanden.</ng-template>
+      </div>
+    </td>
+  </ng-container>
+
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleRow(row)" class="creator-row"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
 </table>
 
 <mat-paginator [length]="totalPeople"

--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.scss
@@ -2,6 +2,14 @@ table {
   width: 100%;
 }
 
+.creator-row {
+  cursor: pointer;
+}
+
+.detail-row td {
+  padding: 0 16px 16px;
+}
+
 .toolbar {
   margin-bottom: 1rem;
   display: flex;

--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
@@ -10,6 +10,8 @@ import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { PaginatorService } from '@core/services/paginator.service';
+import { PieceService } from '@core/services/piece.service';
+import { Piece } from 'src/app/core/models/piece';
 import { ComposerDialogComponent } from '@features/composers/composer-dialog/composer-dialog.component';
 // ...
 @Component({
@@ -34,12 +36,16 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
   pageSizeOptions: number[] = [10, 25, 50];
   pageSize = 10;
 
+  expandedPerson: Composer | Author | null = null;
+  expandedPieces: Piece[] = [];
+
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
   constructor(private composerService: ComposerService,
               private authorService: AuthorService,
               private dialog: MatDialog,
-              private paginatorService: PaginatorService) {
+              private paginatorService: PaginatorService,
+              private pieceService: PieceService) {
     this.pageSize = this.paginatorService.getPageSize('manage-creators', this.pageSizeOptions[0]);
   }
 
@@ -137,6 +143,21 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
         this.people[idx] = { ...person, ...updated } as Composer | Author;
         this.applyFilter();
       }
+    });
+  }
+
+  toggleRow(person: Composer | Author): void {
+    if (this.expandedPerson && this.expandedPerson.id === person.id) {
+      this.expandedPerson = null;
+      this.expandedPieces = [];
+      return;
+    }
+    const filter = this.mode === 'composer'
+      ? { composerId: person.id }
+      : { authorId: person.id };
+    this.pieceService.getGlobalPieces(filter).subscribe(pieces => {
+      this.expandedPerson = person;
+      this.expandedPieces = pieces;
     });
   }
 }


### PR DESCRIPTION
## Summary
- filter pieces by composer or author in backend
- allow optional filters in piece service and api service
- expand rows in admin creators table showing the composer's or author's pieces

## Testing
- `npm run check-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687919d9958c8320b55409c80c56d8d5