### PR TITLE
Enable sticky collection table with paginator

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -12,7 +12,8 @@
   </button>
 </div>
 
-<div class="table-container mat-elevation-z8">
+<div class="table-wrapper mat-elevation-z8">
+  <div class="table-scroll-container">
   <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
 
     <!-- Cover Column -->
@@ -75,11 +76,16 @@
         </td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+        Es wurden noch keine Sammlungen erstellt.
+      </td>
+    </tr>
   </table>
-
-  <div *ngIf="dataSource.data.length === 0" class="empty-state">
-      <p>Es wurden noch keine Sammlungen erstellt.</p>
   </div>
+  <mat-paginator [pageSizeOptions]="pageSizeOptions"
+                 [pageSize]="pageSize"
+                 showFirstLastButtons></mat-paginator>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -62,16 +62,35 @@ mat-card-actions button mat-icon {
     object-fit: cover;
 }
 
-.table-container .mat-row {
+.table-wrapper {
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    max-height: 70vh;
+}
+
+.table-scroll-container {
+    flex: 1 1 auto;
+    overflow-y: auto;
+}
+
+.table-wrapper .mat-row {
     cursor: pointer;
 }
 
-.table-container .mat-row:hover {
+.table-wrapper .mat-row:hover {
     background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (prefers-color-scheme: dark) {
-    .table-container .mat-row:hover {
+    .table-wrapper .mat-row:hover {
         background-color: rgba(255, 255, 255, 0.08);
     }
+}
+
+mat-paginator {
+    flex-shrink: 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
 }


### PR DESCRIPTION
## Summary
- keep the collections table header sticky and scroll only the body
- add paginator to collections list and save its page size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791ebfa6648320b6f637c5a6fa4849