### PR TITLE
Fix piece title field width

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -15,7 +15,7 @@
         <ng-container [ngSwitch]="activeSection">
           <ng-container *ngSwitchCase="'general'">
             <div class="form-section">
-              <mat-form-field appearance="outline">
+              <mat-form-field appearance="outline" class="full-width">
                 <mat-label>Titel</mat-label>
                 <input matInput formControlName="title" cdkFocusInitial>
               </mat-form-field>


### PR DESCRIPTION
## Summary
- span the title input field across the full dialog width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792057d7d48320a274859bedbae796