### PR TITLE
Fix composer field not showing in edit dialog

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -110,6 +110,11 @@ export class PieceDialogComponent implements OnInit {
             .subscribe(list => {
                 this.allComposers = list;
                 this.initializeComposerAutocomplete();
+                const composerId = this.pieceForm.get('composerId')?.value;
+                if (composerId && !this.composerCtrl.value) {
+                    const found = this.allComposers.find(c => c.id === composerId);
+                    if (found) this.composerCtrl.setValue(found);
+                }
             });
 
         this.refreshAuthors$
@@ -369,7 +374,7 @@ export class PieceDialogComponent implements OnInit {
 
         if (piece.composer) {
             const found = this.allComposers.find(c => c.id === piece.composer!.id);
-            if (found) this.composerCtrl.setValue(found);
+            this.composerCtrl.setValue(found || piece.composer);
         }
 
         if (piece.author) {


### PR DESCRIPTION
## Summary
- fill composer autocomplete once composers load
- fallback to piece's composer object if not found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791ff9b5688320b37dc471d21b07d3