### PR TITLE
Fix unused component warning

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
@@ -24,7 +24,6 @@ import { PieceDialogComponent } from '@features/literature/piece-dialog/piece-di
     CommonModule,
     FormsModule,
     MaterialModule,
-    PieceDialogComponent,
   ]
 })
 export class ManageCreatorsComponent implements OnInit, AfterViewInit {


### PR DESCRIPTION
## Summary
- stop including `PieceDialogComponent` in `ManageCreatorsComponent` imports

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879212d95588320886bf36eb5ae3428