### PR TITLE
Fix counter plan dates and highlight first column

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -1,3 +1,5 @@
+@use "@angular/material" as mat;
+@use "../../../themes/_nak-theme" as nak;
 
 .actions {
   margin-top: 1rem;
@@ -17,6 +19,10 @@
     border: 1px solid #ddd;
     padding: 4px;
     text-align: center;
+  }
+
+  th:first-child, td:first-child {
+    background-color: mat.m2-get-color-from-palette(nak.$choir-app-primary, 50);
   }
 }
 

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -69,7 +69,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   private dateKey(date: string): string {
-    return new Date(date).toISOString().substring(0, 10);
+    return date.split('T')[0];
   }
 
   isAvailable(userId: number, date: string): boolean {
@@ -89,7 +89,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   private updateCounterPlan(): void {
-    const dateKeys = Array.from(new Set(this.entries.map(e => new Date(e.date).toISOString().substring(0, 10)))).sort();
+    const dateKeys = Array.from(new Set(this.entries.map(e => this.dateKey(e.date)))).sort();
     this.counterPlanDateKeys = dateKeys;
     this.counterPlanDates = dateKeys.map(d => new Date(d));
 
@@ -104,7 +104,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     }
 
     for (const entry of this.entries) {
-      const key = new Date(entry.date).toISOString().substring(0, 10);
+      const key = this.dateKey(entry.date);
       if (entry.director) {
         const row = this.counterPlanRows.find(r => r.user.id === entry.director!.id);
         if (row) row.assignments[key] = row.assignments[key] ? row.assignments[key] + ', Chorleitung' : 'Chorleitung';


### PR DESCRIPTION
## Summary
- show correct dates in counter plan by keeping the date string
- highlight the name column in the counter plan using a light primary color

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_6879277d4ed88320ad1f1b6230204793