### PR TITLE
Add deployment completion timestamp

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -149,3 +149,5 @@ Write-Host "Deployment completed."
 if (-not $sshUsePlink) {
     & ssh @SshOptions -O exit $Remote
 }
+
+Write-Host "[$(Get-Date -Format 'HH:mm:ss')] Successully deployed"

--- a/deploy.sh
+++ b/deploy.sh
@@ -118,3 +118,5 @@ if [[ $USE_SSHPASS == true ]]; then
 else
     ssh $SSH_OPTIONS -O exit $REMOTE
 fi
+
+printf "[%s] Successully deployed\n" "$(date '+%H:%M:%S')"


### PR DESCRIPTION
## Summary
- print a timestamped message after deployment in deploy.sh
- print a timestamped message after deployment in deploy.ps1

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_6879442da7e483208fa58890b1020521