### PR TITLE
Add sheet music and links to piece detail

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -16,6 +16,20 @@
       </li>
     </ul>
   </div>
+  <div *ngIf="pieceImage || piece.links?.length">
+    <div *ngIf="pieceImage" class="sheet-image">
+      <h3>Notenbild</h3>
+      <img [src]="pieceImage" alt="Notenbild" />
+    </div>
+    <div *ngIf="piece.links?.length">
+      <h3>Links</h3>
+      <ul>
+        <li *ngFor="let link of piece.links">
+          <a [href]="link.url" target="_blank" rel="noopener">{{ link.description }}</a>
+        </li>
+      </ul>
+    </div>
+  </div>
   <p>
     <strong>Status im Chor:</strong>
     <mat-select [value]="piece.choir_repertoire?.status" (selectionChange)="onStatusChange($event.value)">

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
@@ -7,3 +7,8 @@
   display: flex;
   flex-direction: column;
 }
+
+.sheet-image img {
+  max-width: 100%;
+  margin-bottom: 1rem;
+}

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -31,6 +31,7 @@ export class PieceDetailComponent implements OnInit {
   editState: { [id: number]: string } = {};
   userId: number | null = null;
   isAdmin = false;
+  pieceImage: string | null = null;
 
   constructor(
     private route: ActivatedRoute,
@@ -50,6 +51,11 @@ export class PieceDetailComponent implements OnInit {
   private loadPiece(id: number): void {
     this.apiService.getRepertoirePiece(id).subscribe(p => {
       this.piece = p;
+      if (p.imageIdentifier) {
+        this.apiService.getPieceImage(p.id).subscribe(img => this.pieceImage = img);
+      } else {
+        this.pieceImage = null;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- load piece image when viewing piece detail
- show sheet music image and external links if available

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687945d33ea88320971caefa04932a7c