### PR TITLE
Replace piece detail dialog with page

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -210,7 +210,7 @@
           <ng-container matColumnDef="title">
             <th mat-header-cell *matHeaderCellDef> Titel </th>
             <td mat-cell *matCellDef="let piece">
-              <a href="#" (click)="openPieceDetailDialog(piece.id); $event.preventDefault()" class="title-link">{{ piece.title }}</a>
+              <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
             </td>
           </ng-container>
           <ng-container matColumnDef="composer">

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -17,7 +17,6 @@ import { Piece } from 'src/app/core/models/piece';
 import { InviteUserDialogComponent } from '../invite-user-dialog/invite-user-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { ActivatedRoute } from '@angular/router';
-import { PieceDetailDialogComponent } from '@features/literature/piece-detail-dialog/piece-detail-dialog.component';
 import { environment } from 'src/environments/environment';
 
 
@@ -311,12 +310,6 @@ export class ManageChoirComponent implements OnInit {
     });
   }
 
-  openPieceDetailDialog(pieceId: number): void {
-    this.dialog.open(PieceDetailDialogComponent, {
-      width: '600px',
-      data: { pieceId }
-    });
-  }
 
   private loadRehearsalPieces(): void {
     this.apiService

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -100,7 +100,7 @@
               <!-- mat-sort-header tells the table this column is sortable. 'title' must match the column name. -->
               <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
               <td mat-cell *matCellDef="let piece">
-                <a href="#" (click)="openPieceDetailDialog(piece.id); $event.preventDefault()" class="title-link">{{ piece.title }}</a>
+                <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
               </td>
             </ng-container>
 

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -17,7 +17,6 @@ import { Piece } from 'src/app/core/models/piece';
 import { Collection } from 'src/app/core/models/collection';
 import { Category } from 'src/app/core/models/category';
 import { PieceDialogComponent } from '../piece-dialog/piece-dialog.component';
-import { PieceDetailDialogComponent } from '../piece-detail-dialog/piece-detail-dialog.component';
 import { RepertoireFilter } from '@core/models/repertoire-filter';
 import { FilterPresetService } from '@core/services/filter-preset.service';
 import { AuthService } from '@core/services/auth.service';
@@ -392,12 +391,6 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     });
   }
 
-  openPieceDetailDialog(pieceId: number): void {
-    this.dialog.open(PieceDetailDialogComponent, {
-      width: '600px',
-      data: { pieceId }
-    });
-  }
 
   // =======================================================================
   // === MISSING FUNCTION 2: onStatusChange ================================


### PR DESCRIPTION
## Summary
- link to the existing piece detail page instead of opening a dialog
- drop unused dialog references in components

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_68794617a7dc83208302a229fde678e1