### PR TITLE
Fix missing author name on piece edit

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -122,6 +122,11 @@ export class PieceDialogComponent implements OnInit {
             .subscribe(list => {
                 this.allAuthors = list;
                 this.initializeAuthorAutocomplete();
+                const authorId = this.pieceForm.get('authorId')?.value;
+                if (authorId && !this.authorCtrl.value) {
+                    const found = this.allAuthors.find(a => a.id === authorId);
+                    if (found) this.authorCtrl.setValue(found);
+                }
             });
 
         this.categories$ = this.refreshComposers$.pipe(


### PR DESCRIPTION
## Summary
- fill author autocomplete control after loading authors list

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6879553483148320bfc8e39ad0f05d74