### PR TITLE
Fix active sidenav text color

### DIFF
--- a/choir-app-frontend/src/app/shared/components/menu-list-item/menu-list-item.component.scss
+++ b/choir-app-frontend/src/app/shared/components/menu-list-item/menu-list-item.component.scss
@@ -26,10 +26,8 @@
         nak.$choir-app-primary,
         default
       ) !important;
-      color: mat.m2-get-contrast-color-from-palette(
-        nak.$choir-app-primary,
-        default
-      ) !important;
+      // Selected SideNav entries should always use white text
+      color: white !important;
       border-radius: 0px;
     }
 


### PR DESCRIPTION
## Summary
- tweak the active sidenav item styling so it always uses white text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879564291508320922a8cd44897faaa