### PR TITLE
Fix global search autocomplete behavior

### DIFF
--- a/choir-app-frontend/src/app/shared/components/search-box/search-box.component.html
+++ b/choir-app-frontend/src/app/shared/components/search-box/search-box.component.html
@@ -2,7 +2,7 @@
 <mat-form-field class="search-box" appearance="outline">
   <input matInput [formControl]="searchCtrl" [matAutocomplete]="auto" placeholder="Suche..." (keyup.enter)="goToResults()" />
 </mat-form-field>
-<mat-autocomplete #auto="matAutocomplete" autoActiveFirstOption>
+<mat-autocomplete #auto="matAutocomplete" [autoActiveFirstOption]="false">
   <ng-container *ngIf="results.pieces.length">
     <mat-optgroup label="Pieces">
       <mat-option *ngFor="let p of results.pieces" [value]="p.title">{{p.title}}</mat-option>


### PR DESCRIPTION
## Summary
- avoid selecting the first option automatically when hitting Enter in global search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687955ff2378832098dc82c14dffeb60