### PR TITLE
Add palette viewer for admins

### DIFF
--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -18,6 +18,7 @@ export const adminRoutes: Routes = [
       { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent) },
       { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent) },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent) },
+      { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent) },
     ],
   },
 ];

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.html
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.html
@@ -1,0 +1,35 @@
+<h2>Primäre Palette</h2>
+<table mat-table [dataSource]="primaryColors" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Farbname</th>
+    <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+  </ng-container>
+  <ng-container matColumnDef="preview">
+    <th mat-header-cell *matHeaderCellDef>Farbe</th>
+    <td mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</td>
+  </ng-container>
+  <ng-container matColumnDef="scss">
+    <th mat-header-cell *matHeaderCellDef>SCSS</th>
+    <td mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="['name','preview','scss']"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['name','preview','scss']"></tr>
+</table>
+
+<h2>Akzent-Palette</h2>
+<table mat-table [dataSource]="accentColors" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Farbname</th>
+    <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+  </ng-container>
+  <ng-container matColumnDef="preview">
+    <th mat-header-cell *matHeaderCellDef>Farbe</th>
+    <td mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</td>
+  </ng-container>
+  <ng-container matColumnDef="scss">
+    <th mat-header-cell *matHeaderCellDef>SCSS</th>
+    <td mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="['name','preview','scss']"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['name','preview','scss']"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.scss
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.scss
@@ -1,0 +1,11 @@
+.color-box {
+  display: inline-block;
+  width: 2rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+  border: 1px solid #ccc;
+}
+
+h2 {
+  margin-top: 2rem;
+}

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.ts
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+
+interface PaletteColor {
+  name: string;
+  hex: string;
+  scss: string;
+}
+
+@Component({
+  selector: 'app-develop',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './develop.component.html',
+  styleUrls: ['./develop.component.scss']
+})
+export class DevelopComponent implements OnInit {
+  primaryColors: PaletteColor[] = [];
+  accentColors: PaletteColor[] = [];
+
+  ngOnInit(): void {
+    this.primaryColors = [
+      { name: '50', hex: '#e0f1fa', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 50)' },
+      { name: '100', hex: '#b3dff4', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 100)' },
+      { name: '200', hex: '#80caf0', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 200)' },
+      { name: '300', hex: '#4db4eb', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 300)' },
+      { name: '400', hex: '#26a4e7', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 400)' },
+      { name: '500', hex: '#0093e4', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 500)' },
+      { name: '600', hex: '#008be2', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 600)' },
+      { name: '700', hex: '#007fde', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 700)' },
+      { name: '800', hex: '#0074da', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 800)' },
+      { name: '900', hex: '#0060d2', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 900)' },
+      { name: 'A100', hex: '#ffffff', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, A100)' },
+      { name: 'A200', hex: '#d7e9ff', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, A200)' },
+      { name: 'A400', hex: '#a4cfff', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, A400)' },
+      { name: 'A700', hex: '#8bc3ff', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, A700)' },
+      { name: 'default-contrast', hex: '#ffffff', scss: 'mat.m2-get-contrast-color-from-palette(nak.$choir-app-primary, default)' }
+    ];
+
+    this.accentColors = [
+      { name: '50', hex: '#fff8e5', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 50)' },
+      { name: '100', hex: '#ffefbf', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 100)' },
+      { name: '200', hex: '#ffe694', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 200)' },
+      { name: '300', hex: '#ffdc69', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 300)' },
+      { name: '400', hex: '#ffd547', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 400)' },
+      { name: '500', hex: '#ffce2c', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 500)' },
+      { name: '600', hex: '#ffca2c', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 600)' },
+      { name: '700', hex: '#ffc52c', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 700)' },
+      { name: '800', hex: '#ffc12c', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 800)' },
+      { name: '900', hex: '#ffb82c', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, 900)' },
+      { name: 'A100', hex: '#ffffff', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, A100)' },
+      { name: 'A200', hex: '#fff9f6', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, A200)' },
+      { name: 'A400', hex: '#ffede3', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, A400)' },
+      { name: 'A700', hex: '#ffe3d3', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, A700)' },
+      { name: 'default-contrast', hex: '#000000', scss: 'mat.m2-get-contrast-color-from-palette(nak.$choir-app-accent, default)' }
+    ];
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -227,6 +227,10 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
           {
             displayName: 'Protokolle',
             route: '/admin/protocols',
+          },
+          {
+            displayName: 'Develop',
+            route: '/admin/develop',
           }
         ]
       }


### PR DESCRIPTION
## Summary
- add a new admin route `/admin/develop`
- show color palettes with names and SCSS snippet
- extend admin navigation with a Develop entry

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68795b47a6c483208ea3b01968997a84