### PR TITLE
Add multi-collection filter

### DIFF
--- a/choir-app-frontend/src/app/core/models/repertoire-filter.ts
+++ b/choir-app-frontend/src/app/core/models/repertoire-filter.ts
@@ -3,6 +3,12 @@ export interface RepertoireFilter {
   name: string;
   visibility: 'personal' | 'local' | 'global';
   data: {
+    /**
+     * New multi collection filter. When present this replaces the legacy
+     * single `collectionId` field. Empty array means no filter.
+     */
+    collectionIds?: number[];
+    /** Legacy single collection filter retained for backwards compatibility */
     collectionId?: number | null;
     categoryIds?: number[];
     onlySingable?: boolean;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -80,7 +80,7 @@ export class ApiService {
   getMyRepertoire(
     composerId?: number,
     categoryIds?: number[],
-    collectionId?: number,
+    collectionIds?: number[],
     sortBy?:
       | 'title'
       | 'reference'
@@ -100,7 +100,7 @@ export class ApiService {
     // composerId not yet supported by PieceService, pass as part of search/filter when implemented
     return this.pieceService.getMyRepertoire(
       categoryIds,
-      collectionId,
+      collectionIds,
       sortBy,
       page,
       limit,

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -17,7 +17,7 @@ export class PieceService {
 
   getMyRepertoire(
     categoryIds?: number[],
-    collectionId?: number,
+    collectionIds?: number[],
     sortBy?:
       | 'title'
       | 'reference'
@@ -38,7 +38,9 @@ export class PieceService {
     if (categoryIds && categoryIds.length > 0) {
       params = params.set('categoryIds', categoryIds.join(','));
     }
-    if (collectionId) params = params.set('collectionId', collectionId.toString());
+    if (collectionIds && collectionIds.length > 0) {
+      params = params.set('collectionIds', collectionIds.join(','));
+    }
     if (sortBy) params = params.set('sortBy', sortBy);
     params = params.set('page', page.toString());
     params = params.set('limit', limit.toString());

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -10,9 +10,8 @@
         <mat-hint>Anführungszeichen für Wortgruppen verwenden</mat-hint>
       </mat-form-field>
       <mat-form-field appearance="outline">
-        <mat-label>Sammlung</mat-label>
-        <mat-select [value]="filterByCollectionId$.value" (selectionChange)="onCollectionFilterChange($event.value)">
-          <mat-option [value]="null">Alle</mat-option>
+        <mat-label>Sammlungen</mat-label>
+        <mat-select multiple [value]="filterByCollectionIds$.value" (selectionChange)="onCollectionFilterChange($event.value)">
           <mat-option *ngFor="let collection of collections$ | async" [value]="collection.id">
             {{ collection.title }}
           </mat-option>


### PR DESCRIPTION
## Summary
- allow selecting multiple collections when filtering the repertoire
- restrict collection list to those adopted by the choir
- extend filter presets and storage to support collectionIds
- accept `collectionIds` array on the backend

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_6879619010748320b605ad318f06dd9e