### PR TITLE
Filter categories by selected collections

### DIFF
--- a/choir-app-backend/src/controllers/category.controller.js
+++ b/choir-app-backend/src/controllers/category.controller.js
@@ -1,5 +1,6 @@
 const db = require("../models");
 const Category = db.category;
+const { Op } = require('sequelize');
 const BaseCrudController = require("./baseCrud.controller");
 const base = new BaseCrudController(Category);
 
@@ -17,13 +18,40 @@ exports.create = async (req, res, next) => {
 };
 
 exports.findAll = async (req, res, next) => {
+    const { collectionIds } = req.query;
     try {
+        if (collectionIds) {
+            let ids = Array.isArray(collectionIds) ? collectionIds : String(collectionIds).split(',');
+            ids = ids.map(id => parseInt(id, 10)).filter(id => !isNaN(id));
+            if (ids.length) {
+                const categories = await Category.findAll({
+                    include: [{
+                        model: db.piece,
+                        as: 'pieces',
+                        attributes: [],
+                        include: [{
+                            model: db.collection,
+                            as: 'collections',
+                            attributes: [],
+                            through: { attributes: [] },
+                            where: { id: { [Op.in]: ids } },
+                            required: true
+                        }],
+                        required: true
+                    }],
+                    group: ['category.id'],
+                    order: [['name', 'ASC']]
+                });
+                return res.status(200).send(categories);
+            }
+        }
         const categories = await base.service.findAll({ order: [['name', 'ASC']] });
         res.status(200).send(categories);
     } catch (err) {
         if (next) return next(err);
         res.status(500).send({ message: err.message });
-    }};
+    }
+};
 
 // expose generic handlers for completeness
 exports.findById = base.findById;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -254,8 +254,8 @@ export class ApiService {
 
   // --- Category (Rubrik) Methods ---
 
-  getCategories(): Observable<Category[]> {
-    return this.categoryService.getCategories();
+  getCategories(collectionIds?: number[]): Observable<Category[]> {
+    return this.categoryService.getCategories(collectionIds);
   }
 
   createCategory(name: string): Observable<Category> {

--- a/choir-app-frontend/src/app/core/services/category.service.ts
+++ b/choir-app-frontend/src/app/core/services/category.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { Category } from '../models/category';
@@ -10,8 +10,12 @@ export class CategoryService {
 
   constructor(private http: HttpClient) {}
 
-  getCategories(): Observable<Category[]> {
-    return this.http.get<Category[]>(`${this.apiUrl}/categories`);
+  getCategories(collectionIds?: number[]): Observable<Category[]> {
+    let params = new HttpParams();
+    if (collectionIds && collectionIds.length) {
+      params = params.set('collectionIds', collectionIds.join(','));
+    }
+    return this.http.get<Category[]>(`${this.apiUrl}/categories`, { params });
   }
 
   createCategory(name: string): Observable<Category> {

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -111,7 +111,10 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     this.updateDisplayedColumns();
     // Pre-fetch data for the filter dropdowns - only collections present in the choir
     this.collections$ = this.apiService.getChoirCollections();
-    this.categories$ = this.apiService.getCategories();
+    this.categories$ = this.filterByCollectionIds$.pipe(
+      startWith(this.filterByCollectionIds$.value),
+      switchMap(ids => this.apiService.getCategories(ids.length ? ids : undefined))
+    );
     this.loadPresets();
     this.apiService.checkChoirAdminStatus().subscribe(s => this.isChoirAdmin = s.isChoirAdmin);
     this.authService.isAdmin$.subscribe(a => this.isAdmin = a);
@@ -168,7 +171,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     const page$ = this._paginator.page.pipe(tap(e => this.paginatorService.setPageSize('literature-list', e.pageSize)));
     const search$ = this.searchControl.valueChanges.pipe(startWith(this.searchControl.value || ''));
 
-    merge(this.refresh$, this.filterByCollectionId$, this.filterByCategoryIds$, this.status$, sort$, page$, search$)
+    merge(this.refresh$, this.filterByCollectionIds$, this.filterByCategoryIds$, this.status$, sort$, page$, search$)
       .pipe(
         startWith({}),
         tap(() => {


### PR DESCRIPTION
## Summary
- show repertoire categories filtered by selected collections
- support collectionIds in backend category query

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_6879644db7d88320a411f7d4218ac298