### PR TITLE
Update duty roster handling

### DIFF
--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -349,11 +349,11 @@ export class ApiService {
   }
 
   // --- Plan Entry Methods ---
-  createPlanEntry(data: { monthlyPlanId: number; date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  createPlanEntry(data: { monthlyPlanId: number; date: string; notes?: string; directorId?: number | null; organistId?: number | null }): Observable<PlanEntry> {
     return this.planEntryService.createPlanEntry(data);
   }
 
-  updatePlanEntry(id: number, data: { date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  updatePlanEntry(id: number, data: { date: string; notes?: string; directorId?: number | null; organistId?: number | null }): Observable<PlanEntry> {
     return this.planEntryService.updatePlanEntry(id, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/plan-entry.service.ts
+++ b/choir-app-frontend/src/app/core/services/plan-entry.service.ts
@@ -10,11 +10,11 @@ export class PlanEntryService {
 
   constructor(private http: HttpClient) {}
 
-  createPlanEntry(data: { monthlyPlanId: number; date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  createPlanEntry(data: { monthlyPlanId: number; date: string; notes?: string; directorId?: number | null; organistId?: number | null }): Observable<PlanEntry> {
     return this.http.post<PlanEntry>(`${this.apiUrl}/plan-entries`, data);
   }
 
-  updatePlanEntry(id: number, data: { date: string; notes?: string; directorId?: number; organistId?: number }): Observable<PlanEntry> {
+  updatePlanEntry(id: number, data: { date: string; notes?: string; directorId?: number | null; organistId?: number | null }): Observable<PlanEntry> {
     return this.http.put<PlanEntry>(`${this.apiUrl}/plan-entries/${id}`, data);
   }
 


### PR DESCRIPTION
## Summary
- allow null plan entry IDs in API service and PlanEntry service
- show `---` for unavailable dates in the counter plan
- remove assignments when `--` is selected

## Testing
- `npm test --prefix choir-app-frontend`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687e09dcaaec8320818658f95ef11003