### PR TITLE
Show 5 upcoming events

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -185,11 +185,15 @@ exports.findAll = async (req, res) => {
 };
 
 exports.findNext = async (req, res) => {
-    const limit = parseInt(req.query.limit, 10) || 3;
+    const limit = parseInt(req.query.limit, 10) || 5;
     const mine = req.query.mine === 'true';
+
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+
     const where = {
         choirId: req.activeChoirId,
-        date: { [Op.gte]: new Date() }
+        date: { [Op.gte]: startOfToday }
     };
     if (mine) {
         where[Op.or] = [

--- a/choir-app-frontend/src/app/core/services/event.service.ts
+++ b/choir-app-frontend/src/app/core/services/event.service.ts
@@ -26,7 +26,7 @@ export class EventService {
     return this.http.get<Event[]>(`${this.apiUrl}/events`, { params });
   }
 
-  getNextEvents(limit: number = 3, mine: boolean = false): Observable<Event[]> {
+  getNextEvents(limit: number = 5, mine: boolean = false): Observable<Event[]> {
     let params = new HttpParams().set('limit', limit);
     if (mine) params = params.set('mine', 'true');
     return this.http.get<Event[]>(`${this.apiUrl}/events/next`, { params });

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -69,7 +69,7 @@ export class DashboardComponent implements OnInit {
     );
 
     this.nextEvents$ = this.refresh$.pipe(
-      switchMap(() => this.apiService.getNextEvents(3, this.showOnlyMine))
+      switchMap(() => this.apiService.getNextEvents(5, this.showOnlyMine))
     );
 
     this.pieceChanges$ = this.authService.isAdmin$.pipe(


### PR DESCRIPTION
## Summary
- extend backend to return events from today onwards
- update Angular event service default limit
- display up to five upcoming events on the dashboard

## Testing
- `npm test --prefix choir-app-frontend`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687e1c905e788320ba2157717a074019