### PR TITLE
Fix timezone handling for plan dates

### DIFF
--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -1,3 +1,5 @@
+const { isoDateString } = require('../utils/date.utils');
+
 function escape(text) {
   return text.replace(/[\\()]/g, c => '\\' + c);
 }
@@ -50,7 +52,7 @@ function monthlyPlanPdf(plan) {
 
   // Table rows
   for (const e of plan.entries) {
-    lines.push(cellCenter(left, col2, new Date(e.date).toISOString().substring(0,10), y));
+    lines.push(cellCenter(left, col2, isoDateString(new Date(e.date)), y));
     lines.push(cellCenter(col2, col3, e.director?.name || '', y));
     lines.push(cellCenter(col3, col4, e.organist?.name || '', y));
     lines.push(cellCenter(col4, right, e.notes || '', y));

--- a/choir-app-backend/src/utils/date.utils.js
+++ b/choir-app-backend/src/utils/date.utils.js
@@ -1,5 +1,8 @@
 function isoDateString(date) {
-    return date.toISOString().split('T')[0];
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
 }
 
 function datesForRule(year, month, rule) {


### PR DESCRIPTION
## Summary
- ensure `isoDateString` uses local timezone
- show local date in monthly plan PDFs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1d258cf4832098df77e6b40d8893