### PR TITLE
Add timestamp debug info for plan dates

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -23,7 +23,7 @@
   <table mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">
       <th mat-header-cell *matHeaderCellDef>Datum</th>
-      <td mat-cell *matCellDef="let ev">
+      <td mat-cell *matCellDef="let ev" [matTooltip]="timestamp(ev.date)">
         {{ ev.date | date:'shortDate' }}
         <span class="holiday" *ngIf="ev.holidayHint"> ({{ ev.holidayHint }})</span>
       </td>
@@ -89,7 +89,9 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th *ngFor="let d of counterPlanDates">{{ d | date:'dd.MM.' }}</th>
+          <th *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">
+            {{ d | date:'dd.MM.' }}
+          </th>
         </tr>
       </thead>
       <tbody>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -44,6 +44,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
 
   private userSub?: Subscription;
 
+  timestamp(date: string | Date): number {
+    return new Date(date).getTime();
+  }
+
   private updateDisplayedColumns(): void {
     const base = ['date', 'director', 'organist', 'notes'];
     this.displayedColumns = (this.isChoirAdmin && !this.plan?.finalized) ? [...base, 'actions'] : base;
@@ -124,6 +128,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
         }
       }
     }
+    if (this.isChoirAdmin) {
+      console.log('CounterPlan timestamps:',
+        this.counterPlanDateKeys.map(d => ({ date: d, ts: this.timestamp(d) })));
+    }
   }
 
   constructor(private api: ApiService,
@@ -164,6 +172,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
         this.sortEntries();
         this.updateDisplayedColumns();
         this.updateCounterPlan();
+        if (this.isChoirAdmin) {
+          console.log('Plan timestamps:',
+            this.entries.map(e => ({ id: e.id, date: e.date, ts: this.timestamp(e.date) })));
+        }
       },
       error: () => {
         this.plan = null;


### PR DESCRIPTION
## Summary
- show database timestamp on hover for service plan and counter plan dates
- log timestamps in console for admins

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687e4ce2101483208914580c482485f7