### PR TITLE
Add month navigation in monthly plan

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="manual-inputs">
   <mat-form-field appearance="fill">
     <mat-label>Monat</mat-label>
     <input matInput type="number" [(ngModel)]="selectedMonth" min="1" max="12" (change)="monthChanged()" />
@@ -13,6 +13,16 @@
   <mat-tab label="Dienstplan">
     <div class="plan" *ngIf="plan; else noPlan">
   <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
+  <div class="month-nav">
+    <button mat-button color="primary" (click)="previousMonth()">
+      <mat-icon>chevron_left</mat-icon>
+      {{ prevMonthLabel }}
+    </button>
+    <button mat-button color="primary" (click)="nextMonth()">
+      {{ nextMonthLabel }}
+      <mat-icon>chevron_right</mat-icon>
+    </button>
+  </div>
   <div class="actions">
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEntryDialog()">Eintrag hinzufügen</button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -44,3 +44,26 @@ mat-tab-group {
   vertical-align: middle;
   margin-left: 4px;
 }
+
+.month-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 1rem 0;
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+}
+
+.manual-inputs {
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 599px) {
+  .manual-inputs {
+    display: none;
+  }
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -181,6 +181,41 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     this.loadAvailabilities(this.selectedYear, this.selectedMonth);
   }
 
+  get monthLabel(): string {
+    return new Date(this.selectedYear, this.selectedMonth - 1, 1)
+      .toLocaleDateString('de-DE', { month: 'long', year: 'numeric' });
+  }
+
+  get prevMonthLabel(): string {
+    return new Date(this.selectedYear, this.selectedMonth - 2, 1)
+      .toLocaleDateString('de-DE', { month: 'long' });
+  }
+
+  get nextMonthLabel(): string {
+    return new Date(this.selectedYear, this.selectedMonth, 1)
+      .toLocaleDateString('de-DE', { month: 'long' });
+  }
+
+  previousMonth(): void {
+    if (this.selectedMonth === 1) {
+      this.selectedMonth = 12;
+      this.selectedYear--;
+    } else {
+      this.selectedMonth--;
+    }
+    this.monthChanged();
+  }
+
+  nextMonth(): void {
+    if (this.selectedMonth === 12) {
+      this.selectedMonth = 1;
+      this.selectedYear++;
+    } else {
+      this.selectedMonth++;
+    }
+    this.monthChanged();
+  }
+
   updateDirector(ev: PlanEntry, userId: number | null): void {
     this.api.updatePlanEntry(ev.id, {
       date: ev.date,


### PR DESCRIPTION
## Summary
- add navigation buttons for previous and next month in monthly plan
- hide manual month/year inputs on mobile screens
- implement helper methods for month navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e4d5071248320b06f0cdc6696df9c