### PR TITLE
Fix publisher dialog form submission

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-publishers/manage-publishers.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-publishers/manage-publishers.component.ts
@@ -78,7 +78,10 @@ export class ManagePublishersComponent implements OnInit, AfterViewInit {
     const ref = this.dialog.open(PublisherDialogComponent, { width: '400px' });
     ref.afterClosed().subscribe(result => {
       if (result) {
-        this.publisherService.createPublisher(result).subscribe(() => this.loadPublishers());
+        this.publisherService.createPublisher(result).subscribe(() => {
+          this.selectedLetter = 'Alle';
+          this.loadPublishers();
+        });
       }
     });
   }
@@ -87,7 +90,10 @@ export class ManagePublishersComponent implements OnInit, AfterViewInit {
     const ref = this.dialog.open(PublisherDialogComponent, { width: '400px', data: publisher });
     ref.afterClosed().subscribe(result => {
       if (result) {
-        this.publisherService.updatePublisher(publisher.id, result).subscribe(() => this.loadPublishers());
+        this.publisherService.updatePublisher(publisher.id, result).subscribe(() => {
+          this.selectedLetter = 'Alle';
+          this.loadPublishers();
+        });
       }
     });
   }

--- a/choir-app-frontend/src/app/features/admin/manage-publishers/publisher-dialog/publisher-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-publishers/publisher-dialog/publisher-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>{{ title }}</h1>
-<form [formGroup]="form" (ngSubmit)="onSave()" mat-dialog-content>
+<form [formGroup]="form" id="publisher-form" (ngSubmit)="onSave()" mat-dialog-content>
   <mat-form-field appearance="outline">
     <mat-label>Name</mat-label>
     <input matInput formControlName="name" />
@@ -7,5 +7,5 @@
 </form>
 <mat-dialog-actions align="end">
   <button mat-button (click)="onCancel()">Abbrechen</button>
-  <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid">Speichern</button>
+  <button mat-flat-button color="primary" type="submit" form="publisher-form" [disabled]="form.invalid">Speichern</button>
 </mat-dialog-actions>


### PR DESCRIPTION
## Summary
- ensure the save button submits `publisher-dialog` form so the dialog closes

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687e4dc4eb0483208784c9d836b7f1ed