### PR TITLE
Fix month nav visibility

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -123,6 +123,16 @@
   </mat-tab>
 </mat-tab-group>
 <ng-template #noPlan>
+  <div class="month-nav">
+    <button mat-button color="primary" (click)="previousMonth()">
+      <mat-icon>chevron_left</mat-icon>
+      {{ prevMonthLabel }}
+    </button>
+    <button mat-button color="primary" (click)="nextMonth()">
+      {{ nextMonthLabel }}
+      <mat-icon>chevron_right</mat-icon>
+    </button>
+  </div>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>
   <button *ngIf="isChoirAdmin" mat-raised-button color="primary" (click)="createPlan()">Plan erstellen</button>
 </ng-template>


### PR DESCRIPTION
## Summary
- ensure month navigation arrows show even when no monthly plan exists

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687e622d01d08320961a100e513307b5