### PR TITLE
Move month navigation above tabs

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -9,20 +9,21 @@
   </mat-form-field>
 </div>
 
+<div class="month-nav">
+  <button mat-button color="primary" (click)="previousMonth()">
+    <mat-icon>chevron_left</mat-icon>
+    {{ prevMonthLabel }}
+  </button>
+  <button mat-button color="primary" (click)="nextMonth()">
+    {{ nextMonthLabel }}
+    <mat-icon>chevron_right</mat-icon>
+  </button>
+</div>
+
 <mat-tab-group>
   <mat-tab label="Dienstplan">
     <div class="plan" *ngIf="plan; else noPlan">
-  <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
-  <div class="month-nav">
-    <button mat-button color="primary" (click)="previousMonth()">
-      <mat-icon>chevron_left</mat-icon>
-      {{ prevMonthLabel }}
-    </button>
-    <button mat-button color="primary" (click)="nextMonth()">
-      {{ nextMonthLabel }}
-      <mat-icon>chevron_right</mat-icon>
-    </button>
-  </div>
+      <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
   <div class="actions">
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEntryDialog()">Eintrag hinzufügen</button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
@@ -123,16 +124,6 @@
   </mat-tab>
 </mat-tab-group>
 <ng-template #noPlan>
-  <div class="month-nav">
-    <button mat-button color="primary" (click)="previousMonth()">
-      <mat-icon>chevron_left</mat-icon>
-      {{ prevMonthLabel }}
-    </button>
-    <button mat-button color="primary" (click)="nextMonth()">
-      {{ nextMonthLabel }}
-      <mat-icon>chevron_right</mat-icon>
-    </button>
-  </div>
   <p>Kein Dienstplan für diesen Monat vorhanden.</p>
   <button *ngIf="isChoirAdmin" mat-raised-button color="primary" (click)="createPlan()">Plan erstellen</button>
 </ng-template>


### PR DESCRIPTION
## Summary
- show month navigation above the tab group
- share navigation for duty schedule and availability view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e651ffb688320b4c0dd50a6d5720b