### PR TITLE
Implement availability request feature

### DIFF
--- a/choir-app-backend/src/routes/monthlyPlan.routes.js
+++ b/choir-app-backend/src/routes/monthlyPlan.routes.js
@@ -10,6 +10,7 @@ router.use(auth.verifyToken);
 // avoid conflicts like GET /1/pdf being handled as year=1, month='pdf'.
 router.get("/:id/pdf", wrap(controller.downloadPdf));
 router.post("/:id/email", role.requireChoirAdmin, wrap(controller.emailPdf));
+router.post("/:id/request-availability", role.requireChoirAdmin, wrap(controller.requestAvailability));
 router.get("/:year/:month", wrap(controller.findByMonth));
 router.post("/", role.requireChoirAdmin, wrap(controller.create));
 router.put("/:id/finalize", role.requireChoirAdmin, wrap(controller.finalize));

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -58,6 +58,14 @@ async function seedDatabase(options = {}) {
                     body: '<p>Click <a href="{{link}}">here</a> to set a new password.</p>'
                 }
             });
+
+            await db.mail_template.findOrCreate({
+                where: { type: 'availability-request' },
+                defaults: {
+                    subject: 'Verfügbarkeitsanfrage {{month}}/{{year}}',
+                    body: '<p>Bitte teile uns deine Verfügbarkeit für {{month}}/{{year}} mit.</p>{{list}}<p><a href="{{link}}">Verfügbarkeit eintragen</a></p>'
+                }
+            });
             console.log("Initial seeding completed successfully.");
         } else {
             console.log("Database already seeded. Skipping initial setup.");

--- a/choir-app-frontend/src/app/core/guards/auth-guard.ts
+++ b/choir-app-frontend/src/app/core/guards/auth-guard.ts
@@ -18,7 +18,7 @@ export class AuthGuard implements CanActivate {
    * Diese Methode wird vom Angular Router aufgerufen, bevor eine Route aktiviert wird.
    * Sie entscheidet, ob die Navigation zur angeforderten Route erlaubt ist.
    */
-  canActivate(): Observable<boolean | UrlTree> {
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
 
     // Wir verwenden das `isLoggedIn$`-Observable aus dem AuthService.
     // `isLoggedIn$` gibt `true` zurück, wenn ein gültiger Token im localStorage vorhanden ist.
@@ -33,7 +33,7 @@ export class AuthGuard implements CanActivate {
           // 1. Wir erstellen eine "UrlTree", die auf die '/login'-Seite verweist.
           // 2. Der Router wird diese Anweisung ausführen und den Benutzer umleiten.
           // Dies ist der empfohlene Weg, um Umleitungen in Guards durchzuführen.
-          return this.router.createUrlTree(['/login']);
+          return this.router.createUrlTree(['/login'], { queryParams: { returnUrl: state.url } });
         }
       })
     );

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -386,6 +386,10 @@ export class ApiService {
     return this.monthlyPlanService.emailMonthlyPlan(id, recipients);
   }
 
+  requestAvailability(id: number, recipients: number[]): Observable<any> {
+    return this.monthlyPlanService.requestAvailability(id, recipients);
+  }
+
   // --- Plan Rule Methods ---
   getPlanRules(options?: { choirId?: number }): Observable<PlanRule[]> {
     return this.planRuleService.getPlanRules(options?.choirId);

--- a/choir-app-frontend/src/app/core/services/monthly-plan.service.ts
+++ b/choir-app-frontend/src/app/core/services/monthly-plan.service.ts
@@ -33,4 +33,8 @@ export class MonthlyPlanService {
   emailMonthlyPlan(id: number, recipients: number[]): Observable<any> {
     return this.http.post(`${this.apiUrl}/monthly-plans/${id}/email`, { recipients });
   }
+
+  requestAvailability(id: number, recipients: number[]): Observable<any> {
+    return this.http.post(`${this.apiUrl}/monthly-plans/${id}/request-availability`, { recipients });
+  }
 }

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -9,7 +9,7 @@
   </mat-form-field>
 </div>
 
-<mat-tab-group>
+<mat-tab-group [selectedIndex]="selectedTab" (selectedIndexChange)="tabChanged($event)">
   <mat-tab label="Dienstplan">
     <div class="plan" *ngIf="plan; else noPlan">
   <h2>Dienstplan {{ plan.month }}/{{ plan.year }}</h2>
@@ -29,6 +29,7 @@
     <button *ngIf="isChoirAdmin && plan.finalized" mat-raised-button color="primary" (click)="reopenPlan()">Plan erneut öffnen</button>
     <button mat-raised-button color="accent" (click)="downloadPdf()">PDF herunterladen</button>
     <button mat-raised-button color="accent" (click)="openEmailDialog()">Per E-Mail senden</button>
+    <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="accent" (click)="openAvailabilityDialog()">Verfügbarkeit anfragen</button>
   </div>
   <table mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">

--- a/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.html
@@ -1,0 +1,13 @@
+<h1 mat-dialog-title>Verfügbarkeit anfragen</h1>
+<div mat-dialog-content>
+  <p>Empfänger auswählen:</p>
+  <mat-selection-list (selectionChange)="toggle($event.options[0].value, $event.options[0].selected)">
+    <mat-list-option *ngFor="let m of data.members" [value]="m.id">
+      {{ m.name }} ({{ m.email }})
+    </mat-list-option>
+  </mat-selection-list>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" (click)="send()" [disabled]="selected.size===0">Mail senden</button>
+</div>

--- a/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.scss
@@ -1,0 +1,4 @@
+mat-selection-list {
+  max-height: 300px;
+  overflow: auto;
+}

--- a/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.ts
@@ -1,0 +1,37 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { UserInChoir } from '@core/models/user';
+
+export interface RequestAvailabilityDialogData {
+  members: UserInChoir[];
+}
+
+@Component({
+  selector: 'app-request-availability-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './request-availability-dialog.component.html',
+  styleUrls: ['./request-availability-dialog.component.scss']
+})
+export class RequestAvailabilityDialogComponent {
+  selected = new Set<number>();
+
+  constructor(
+    public dialogRef: MatDialogRef<RequestAvailabilityDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: RequestAvailabilityDialogData
+  ) {}
+
+  toggle(id: number, checked: boolean): void {
+    if (checked) this.selected.add(id); else this.selected.delete(id);
+  }
+
+  send(): void {
+    this.dialogRef.close(Array.from(this.selected));
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/features/user/login/login.component.ts
+++ b/choir-app-frontend/src/app/features/user/login/login.component.ts
@@ -23,6 +23,7 @@ export class LoginComponent implements OnInit {
   isLoading = false;
   sessionExpired = false;
   loginError: string | null = null;
+  returnUrl: string | null = null;
 
   constructor(
     private fb: FormBuilder,
@@ -40,6 +41,7 @@ export class LoginComponent implements OnInit {
   ngOnInit(): void {
     this.route.queryParamMap.subscribe(params => {
       this.sessionExpired = params.has('sessionExpired');
+      this.returnUrl = params.get('returnUrl');
       if (!this.sessionExpired) {
         this.authService.isTokenValid().subscribe(valid => {
           if (!valid && this.authService.getToken()) {
@@ -63,10 +65,8 @@ export class LoginComponent implements OnInit {
     this.authService.login(this.loginForm.value).subscribe({
       // --- DIES IST DER ERFOLGSFALL ---
       next: () => {
-        // Wenn der Login erfolgreich war, navigieren Sie zum Dashboard.
-        // Die Route '/dashboard' ist in Ihrer app-routing.module.ts definiert.
-        console.log('Login successful, navigating to dashboard...');
-        this.router.navigate(['/dashboard']);
+        const target = this.returnUrl || '/dashboard';
+        this.router.navigateByUrl(target);
       },
       // --- DIES IST DER FEHLERFALL ---
       error: (err) => {


### PR DESCRIPTION
## Summary
- extend seed data with availability-request mail template
- add email service to send availability requests
- allow monthly plan to trigger availability request emails
- expose new backend route for availability requests
- store redirect target during login
- include return URL in AuthGuard
- let monthly plan page handle query params and add request availability dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e64ba1020832088967ec37471a956