### PR TITLE
Update dashboard button with tooltip

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -2,9 +2,9 @@
   <h1 *ngIf="(activeChoir$ | async)?.name as name">
     Willkommen bei {{ name }}
   </h1>
-  <button mat-flat-button color="primary" (click)="openAddEventDialog()">
+  <button mat-flat-button color="primary" (click)="openAddEventDialog()" matTooltip="Neues Ereignis erstellen">
     <mat-icon>add</mat-icon>
-    <span>Neues Ereignis erstellen</span>
+    <span>+</span>
   </button>
   <a mat-flat-button color="accent" routerLink="/events">
     <mat-icon>list</mat-icon>


### PR DESCRIPTION
## Summary
- tweak button text to `+` with tooltip on dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6716a28c8320afd893f057143e31