### PR TITLE
Add admin page for change proposals

### DIFF
--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -17,6 +17,7 @@ export const adminRoutes: Routes = [
       { path: 'publishers', loadComponent: () => import('./manage-publishers/manage-publishers.component').then(m => m.ManagePublishersComponent) },
       { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent) },
       { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent) },
+      { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent) },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent) },
       { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent) },
     ],

--- a/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
@@ -1,0 +1,26 @@
+<h2>Änderungsvorschläge</h2>
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8 full-width">
+    <ng-container matColumnDef="piece">
+        <th mat-header-cell *matHeaderCellDef>Stück</th>
+        <td mat-cell *matCellDef="let c">{{ c.piece?.title || ('Piece ' + c.pieceId) }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="createdAt">
+        <th mat-header-cell *matHeaderCellDef>Datum</th>
+        <td mat-cell *matCellDef="let c">{{ c.createdAt | date:'short' }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let c">
+            <button mat-button color="primary" (click)="approve(c)">Übernehmen</button>
+            <button mat-button color="warn" (click)="decline(c)">Ablehnen</button>
+        </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" colspan="3">Keine Vorschläge vorhanden.</td>
+    </tr>
+</table>

--- a/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.scss
@@ -1,0 +1,3 @@
+.full-width {
+    width: 100%;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { PieceChange } from '@core/models/piece-change';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+    selector: 'app-manage-piece-changes',
+    standalone: true,
+    imports: [CommonModule, MaterialModule],
+    templateUrl: './manage-piece-changes.component.html',
+    styleUrls: ['./manage-piece-changes.component.scss']
+})
+export class ManagePieceChangesComponent implements OnInit {
+    displayedColumns = ['piece', 'createdAt', 'actions'];
+    dataSource = new MatTableDataSource<PieceChange>();
+
+    constructor(private api: ApiService, private snack: MatSnackBar) {}
+
+    ngOnInit(): void {
+        this.loadChanges();
+    }
+
+    loadChanges(): void {
+        this.api.getPieceChangeRequests().subscribe(data => {
+            this.dataSource.data = data;
+        });
+    }
+
+    approve(change: PieceChange): void {
+        this.api.approvePieceChange(change.id).subscribe({
+            next: () => {
+                this.snack.open('Änderung übernommen', 'OK', { duration: 3000 });
+                this.loadChanges();
+            },
+            error: () => this.snack.open('Fehler beim Übernehmen', 'OK', { duration: 3000 })
+        });
+    }
+
+    decline(change: PieceChange): void {
+        this.api.deletePieceChange(change.id).subscribe({
+            next: () => {
+                this.snack.open('Änderung abgelehnt', 'OK', { duration: 3000 });
+                this.loadChanges();
+            },
+            error: () => this.snack.open('Fehler beim Ablehnen', 'OK', { duration: 3000 })
+        });
+    }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -225,6 +225,10 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
             route: '/admin/publishers'
           },
           {
+            displayName: 'Änderungsvorschläge',
+            route: '/admin/piece-changes'
+          },
+          {
             displayName: 'Protokolle',
             route: '/admin/protocols',
           },


### PR DESCRIPTION
## Summary
- add a new admin route and navigation item for piece change suggestions
- implement `ManagePieceChangesComponent` to approve or decline proposals

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687e676b29808320b522b7a53380370e