### PR TITLE
Restrict suggestions section to admins with items

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -37,17 +37,16 @@
 </div>
 
 <div *ngIf="isAdmin$ | async">
-  <div *ngIf="pieceChanges$ | async as changes">
-    <h2>Änderungsvorschläge</h2>
-    <mat-list *ngIf="changes.length > 0; else noChanges">
-      <mat-list-item *ngFor="let c of changes">
-        <div matLine>{{ c.piece?.title || 'Piece ' + c.pieceId }}</div>
-        <button mat-button color="primary" (click)="approvePieceChange(c)">Übernehmen</button>
-        <button mat-button color="warn" (click)="declinePieceChange(c)">Ablehnen</button>
-      </mat-list-item>
-    </mat-list>
-    <ng-template #noChanges>
-      <p>Keine Vorschläge vorhanden.</p>
-    </ng-template>
-  </div>
+  <ng-container *ngIf="pieceChanges$ | async as changes">
+    <div *ngIf="changes.length > 0">
+      <h2>Änderungsvorschläge</h2>
+      <mat-list>
+        <mat-list-item *ngFor="let c of changes">
+          <div matLine>{{ c.piece?.title || 'Piece ' + c.pieceId }}</div>
+          <button mat-button color="primary" (click)="approvePieceChange(c)">Übernehmen</button>
+          <button mat-button color="warn" (click)="declinePieceChange(c)">Ablehnen</button>
+        </mat-list-item>
+      </mat-list>
+    </div>
+  </ng-container>
 </div>


### PR DESCRIPTION
## Summary
- hide the dashboard suggestion section unless the user is an admin and there are suggestions to show

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6756d7f4832081b08b0ff842fad8