### PR TITLE
Add availability-request mail template editor

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -1,62 +1,92 @@
-<form [formGroup]="form" (ngSubmit)="save()" class="mail-form">
-  <h3>Einladung</h3>
-  <mat-form-field appearance="fill">
-    <mat-label>Betreff</mat-label>
-    <input matInput formControlName="inviteSubject" />
-  </mat-form-field>
-  <div class="editor-group">
-    <div class="editor-header">
-      <label class="editor-label">Text (HTML erlaubt)</label>
-      <mat-slide-toggle
-        class="html-toggle"
-        [checked]="inviteHtmlMode"
-        (change)="toggleInviteHtml()"
-        >HTML bearbeiten</mat-slide-toggle
-      >
-    </div>
-    <div [hidden]="inviteHtmlMode" #inviteEditor class="quill-editor"></div>
-    <textarea
-      *ngIf="inviteHtmlMode"
-      class="html-editor"
-      formControlName="inviteBody"
-    ></textarea>
-    <p class="hint">
-      Folgende Platzhalter werden ersetzt:
-      {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
-    </p>
-  </div>
-  <div class="actions">
-    <button mat-raised-button color="accent" type="button" (click)="sendTest('invite')">Testmail</button>
-  </div>
-  <h3>Passwort vergessen</h3>
-  <mat-form-field appearance="fill">
-    <mat-label>Betreff</mat-label>
-    <input matInput formControlName="resetSubject" />
-  </mat-form-field>
-  <div class="editor-group">
-    <div class="editor-header">
-      <label class="editor-label">Text (HTML erlaubt)</label>
-      <mat-slide-toggle
-        class="html-toggle"
-        [checked]="resetHtmlMode"
-        (change)="toggleResetHtml()"
-        >HTML bearbeiten</mat-slide-toggle
-      >
-    </div>
-    <div [hidden]="resetHtmlMode" #resetEditor class="quill-editor"></div>
-    <textarea
-      *ngIf="resetHtmlMode"
-      class="html-editor"
-      formControlName="resetBody"
-    ></textarea>
-    <p class="hint">
-      Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
-    </p>
-  </div>
-  <div class="actions">
-    <button mat-raised-button color="accent" type="button" (click)="sendTest('reset')">Testmail</button>
-  </div>
-  <div class="actions">
-    <button mat-raised-button color="primary" type="submit">Speichern</button>
-  </div>
+<form [formGroup]="form" class="mail-form">
+  <mat-tab-group>
+    <mat-tab label="Einladung">
+      <mat-form-field appearance="fill">
+        <mat-label>Betreff</mat-label>
+        <input matInput formControlName="inviteSubject" />
+      </mat-form-field>
+      <div class="editor-group">
+        <div class="editor-header">
+          <label class="editor-label">Text (HTML erlaubt)</label>
+          <mat-slide-toggle
+            class="html-toggle"
+            [checked]="inviteHtmlMode"
+            (change)="toggleInviteHtml()"
+            >HTML bearbeiten</mat-slide-toggle>
+        </div>
+        <div [hidden]="inviteHtmlMode" #inviteEditor class="quill-editor"></div>
+        <textarea
+          *ngIf="inviteHtmlMode"
+          class="html-editor"
+          formControlName="inviteBody"
+        ></textarea>
+        <p class="hint">
+          Folgende Platzhalter werden ersetzt:
+          {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+        </p>
+      </div>
+      <div class="actions">
+        <button mat-raised-button color="accent" type="button" (click)="sendTest('invite')">Testmail</button>
+        <button mat-raised-button color="primary" type="button" (click)="save('invite')">Speichern</button>
+      </div>
+    </mat-tab>
+    <mat-tab label="Passwort vergessen">
+      <mat-form-field appearance="fill">
+        <mat-label>Betreff</mat-label>
+        <input matInput formControlName="resetSubject" />
+      </mat-form-field>
+      <div class="editor-group">
+        <div class="editor-header">
+          <label class="editor-label">Text (HTML erlaubt)</label>
+          <mat-slide-toggle
+            class="html-toggle"
+            [checked]="resetHtmlMode"
+            (change)="toggleResetHtml()"
+            >HTML bearbeiten</mat-slide-toggle>
+        </div>
+        <div [hidden]="resetHtmlMode" #resetEditor class="quill-editor"></div>
+        <textarea
+          *ngIf="resetHtmlMode"
+          class="html-editor"
+          formControlName="resetBody"
+        ></textarea>
+        <p class="hint">
+          Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+        </p>
+      </div>
+      <div class="actions">
+        <button mat-raised-button color="accent" type="button" (click)="sendTest('reset')">Testmail</button>
+        <button mat-raised-button color="primary" type="button" (click)="save('reset')">Speichern</button>
+      </div>
+    </mat-tab>
+    <mat-tab label="Verfügbarkeitsanfrage">
+      <mat-form-field appearance="fill">
+        <mat-label>Betreff</mat-label>
+        <input matInput formControlName="availabilitySubject" />
+      </mat-form-field>
+      <div class="editor-group">
+        <div class="editor-header">
+          <label class="editor-label">Text (HTML erlaubt)</label>
+          <mat-slide-toggle
+            class="html-toggle"
+            [checked]="availabilityHtmlMode"
+            (change)="toggleAvailabilityHtml()"
+            >HTML bearbeiten</mat-slide-toggle>
+        </div>
+        <div [hidden]="availabilityHtmlMode" #availabilityEditor class="quill-editor"></div>
+        <textarea
+          *ngIf="availabilityHtmlMode"
+          class="html-editor"
+          formControlName="availabilityBody"
+        ></textarea>
+        <p class="hint">
+          Folgende Platzhalter werden ersetzt: {{'{{month}}'}}, {{'{{year}}'}}, {{'{{list}}'}}, {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+        </p>
+      </div>
+      <div class="actions">
+        <button mat-raised-button color="accent" type="button" (click)="sendTest('availability-request')">Testmail</button>
+        <button mat-raised-button color="primary" type="button" (click)="save('availability-request')">Speichern</button>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
 </form>


### PR DESCRIPTION
## Summary
- split each mail template into its own tab with individual save buttons
- allow editing of availability request template

## Testing
- `npm test`
- `npm run check --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687eb229bf688320b84a81b54f3a79c2