### PR TITLE
Hide PDF and email actions until monthly plan finalized

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -29,8 +29,8 @@
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="openAddEntryDialog()">Eintrag hinzufügen</button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="primary" (click)="finalizePlan()">Plan finalisieren</button>
     <button *ngIf="isChoirAdmin && plan.finalized" mat-raised-button color="primary" (click)="reopenPlan()">Plan erneut öffnen</button>
-    <button mat-raised-button color="accent" (click)="downloadPdf()">PDF herunterladen</button>
-    <button mat-raised-button color="accent" (click)="openEmailDialog()">Per E-Mail senden</button>
+    <button *ngIf="plan.finalized" mat-raised-button color="accent" (click)="downloadPdf()">PDF herunterladen</button>
+    <button *ngIf="plan.finalized" mat-raised-button color="accent" (click)="openEmailDialog()">Per E-Mail senden</button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="accent" (click)="openAvailabilityDialog()">Verfügbarkeit anfragen</button>
   </div>
   <table mat-table [dataSource]="entries" class="mat-elevation-z2">


### PR DESCRIPTION
## Summary
- add finalization check for MonthlyPlan PDF/email buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb1724fac8320b927579b2451bd70