### PR TITLE
Fix width of subject field in admin email templates

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.scss
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.scss
@@ -1,6 +1,10 @@
 .mail-form {
   display: flex;
   flex-direction: column;
+
+  mat-form-field {
+    width: 100%;
+  }
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- make "Betreff" form fields use full width in admin mail templates

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_687eb89c39408320b15735c51109fee4