### PR TITLE
Notify admins when piece changes are proposed

### DIFF
--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -66,6 +66,14 @@ async function seedDatabase(options = {}) {
                     body: '<p>Bitte teile uns deine Verfügbarkeit für {{month}}/{{year}} mit.</p>{{list}}<p><a href="{{link}}">Verfügbarkeit eintragen</a></p>'
                 }
             });
+
+            await db.mail_template.findOrCreate({
+                where: { type: 'piece-change' },
+                defaults: {
+                    subject: 'Neuer Änderungsvorschlag zu {{piece}}',
+                    body: '<p>{{proposer}} hat eine Änderung zu <b>{{piece}}</b> vorgeschlagen.</p><p><a href="{{link}}">Änderung ansehen</a></p>'
+                }
+            });
             console.log("Initial seeding completed successfully.");
         } else {
             console.log("Database already seeded. Skipping initial setup.");

--- a/choir-app-backend/tests/piece.controller.test.js
+++ b/choir-app-backend/tests/piece.controller.test.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 // Use in-memory SQLite for testing
 process.env.DB_DIALECT = 'sqlite';
 process.env.DB_NAME = ':memory:';
+process.env.DISABLE_EMAIL = 'true';
 
 const db = require('../src/models');
 const controller = require('../src/controllers/piece.controller');

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -88,5 +88,34 @@
         <button mat-raised-button color="primary" type="button" (click)="save('availability-request')">Speichern</button>
       </div>
     </mat-tab>
+    <mat-tab label="Änderungsvorschlag">
+      <mat-form-field appearance="fill">
+        <mat-label>Betreff</mat-label>
+        <input matInput formControlName="changeSubject" />
+      </mat-form-field>
+      <div class="editor-group">
+        <div class="editor-header">
+          <label class="editor-label">Text (HTML erlaubt)</label>
+          <mat-slide-toggle
+            class="html-toggle"
+            [checked]="changeHtmlMode"
+            (change)="toggleChangeHtml()"
+            >HTML bearbeiten</mat-slide-toggle>
+        </div>
+        <div [hidden]="changeHtmlMode" #changeEditor class="quill-editor"></div>
+        <textarea
+          *ngIf="changeHtmlMode"
+          class="html-editor"
+          formControlName="changeBody"
+        ></textarea>
+        <p class="hint">
+          Folgende Platzhalter werden ersetzt: {{'{{piece}}'}}, {{'{{proposer}}'}}, {{'{{link}}'}}, {{'{{date}}'}}
+        </p>
+      </div>
+      <div class="actions">
+        <button mat-raised-button color="accent" type="button" (click)="sendTest('piece-change')">Testmail</button>
+        <button mat-raised-button color="primary" type="button" (click)="save('piece-change')">Speichern</button>
+      </div>
+    </mat-tab>
   </mat-tab-group>
 </form>


### PR DESCRIPTION
## Summary
- send emails to all admins whenever a piece change is suggested
- seed default template for these mails
- allow editing the new template in the admin UI
- skip email sending during backend tests

## Testing
- `npm test --silent` *(frontend)*
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_687ebaf2f5a48320ab7338b76aba7af6