### PR TITLE
Add admin setting for FRONTEND_URL

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -490,3 +490,26 @@ exports.updateMailTemplates = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+exports.getFrontendUrl = async (req, res) => {
+    try {
+        const setting = await db.system_setting.findByPk('FRONTEND_URL');
+        res.status(200).send({ value: setting?.value || null });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.updateFrontendUrl = async (req, res) => {
+    try {
+        const { value } = req.body;
+        const [setting] = await db.system_setting.findOrCreate({
+            where: { key: 'FRONTEND_URL' },
+            defaults: { value }
+        });
+        await setting.update({ value });
+        res.status(200).send({ value: setting.value });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/controllers/piece-change.controller.js
+++ b/choir-app-backend/src/controllers/piece-change.controller.js
@@ -2,6 +2,7 @@ const db = require('../models');
 const PieceChange = db.piece_change;
 const Piece = db.piece;
 const emailService = require('../services/email.service');
+const { getFrontendUrl } = require('../utils/frontend-url');
 
 exports.create = async (req, res) => {
     const { pieceId, data } = req.body;
@@ -14,7 +15,7 @@ exports.create = async (req, res) => {
         const proposer = await db.user.findByPk(req.userId);
 
         const admins = await db.user.findAll({ where: { role: 'admin' } });
-        const linkBase = process.env.FRONTEND_URL || 'http://localhost:4200';
+        const linkBase = await getFrontendUrl();
         const link = `${linkBase}/admin/piece-changes`;
         const promises = admins
             .filter(a => a.email)

--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -8,6 +8,7 @@ const fs = require('fs/promises');
 const BaseCrudController = require('./baseCrud.controller');
 const base = new BaseCrudController(Piece);
 const emailService = require('../services/email.service');
+const { getFrontendUrl } = require('../utils/frontend-url');
 
 /**
  * @description Create a new global piece.
@@ -118,7 +119,7 @@ exports.update = async (req, res) => {
             const piece = await Piece.findByPk(id);
             const proposer = await db.user.findByPk(req.userId);
             const admins = await db.user.findAll({ where: { role: 'admin' } });
-            const linkBase = process.env.FRONTEND_URL || 'http://localhost:4200';
+            const linkBase = await getFrontendUrl();
             const link = `${linkBase}/admin/piece-changes`;
             await Promise.all(
                 admins.filter(a => a.email).map(a =>

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -38,6 +38,7 @@ db.repertoire_filter = require("./repertoire_filter.model.js")(sequelize, Sequel
 db.login_attempt = require("./login_attempt.model.js")(sequelize, Sequelize);
 db.mail_setting = require("./mail_setting.model.js")(sequelize, Sequelize);
 db.mail_template = require("./mail_template.model.js")(sequelize, Sequelize);
+db.system_setting = require("./system_setting.model.js")(sequelize, Sequelize);
 
 // --- Define Associations ---
 // A Choir has many Users

--- a/choir-app-backend/src/models/system_setting.model.js
+++ b/choir-app-backend/src/models/system_setting.model.js
@@ -1,0 +1,7 @@
+module.exports = (sequelize, DataTypes) => {
+  const SystemSetting = sequelize.define('system_setting', {
+    key: { type: DataTypes.STRING, primaryKey: true },
+    value: { type: DataTypes.STRING }
+  });
+  return SystemSetting;
+};

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -44,6 +44,8 @@ router.post('/mail-settings/test', wrap(controller.sendTestMail));
 router.get('/mail-templates', wrap(controller.getMailTemplates));
 router.put('/mail-templates', wrap(controller.updateMailTemplates));
 router.post('/mail-templates/test/:type', wrap(controller.sendMailTemplateTest));
+router.get('/frontend-url', wrap(controller.getFrontendUrl));
+router.put('/frontend-url', wrap(controller.updateFrontendUrl));
 
 module.exports = router;
 

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -74,6 +74,11 @@ async function seedDatabase(options = {}) {
                     body: '<p>{{proposer}} hat eine Änderung zu <b>{{piece}}</b> vorgeschlagen.</p><p><a href="{{link}}">Änderung ansehen</a></p>'
                 }
             });
+
+            await db.system_setting.findOrCreate({
+                where: { key: 'FRONTEND_URL' },
+                defaults: { value: process.env.FRONTEND_URL || 'https://nak-chorleiter.de' }
+            });
             console.log("Initial seeding completed successfully.");
         } else {
             console.log("Database already seeded. Skipping initial setup.");

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -2,6 +2,7 @@ const nodemailer = require('nodemailer');
 
 const db = require('../models');
 const logger = require('../config/logger');
+const { getFrontendUrl } = require('../utils/frontend-url');
 
 function emailDisabled() {
   return process.env.DISABLE_EMAIL === 'true';
@@ -35,7 +36,7 @@ function replacePlaceholders(text, replacements) {
 }
 
 exports.sendInvitationMail = async (to, token, choirName, expiry, name, invitorName) => {
-  const linkBase = process.env.FRONTEND_URL || 'https://nak-chorleiter.de';
+  const linkBase = await getFrontendUrl();
   const link = `${linkBase}/register/${token}`;
   const settings = await db.mail_setting.findByPk(1);
   const template = await db.mail_template.findOne({ where: { type: 'invite' } });
@@ -71,7 +72,7 @@ exports.sendInvitationMail = async (to, token, choirName, expiry, name, invitorN
 };
 
 exports.sendPasswordResetMail = async (to, token, name) => {
-  const linkBase = process.env.FRONTEND_URL || 'https://nak-chorleiter.de';
+  const linkBase = await getFrontendUrl();
   const link = `${linkBase}/reset-password/${token}`;
   const settings = await db.mail_setting.findByPk(1);
   const template = await db.mail_template.findOne({ where: { type: 'reset' } });
@@ -186,7 +187,7 @@ exports.sendAvailabilityRequestMail = async (to, name, year, month, dates) => {
   const settings = await db.mail_setting.findByPk(1);
   const template = await db.mail_template.findOne({ where: { type: 'availability-request' } });
   const transporter = await createTransporter(settings);
-  const linkBase = process.env.FRONTEND_URL || 'https://nak-chorleiter.de';
+  const linkBase = await getFrontendUrl();
   const link = `${linkBase}/dienstplan?year=${year}&month=${month}&tab=avail`;
   try {
     const list = '<ul>' + dates.map(d => `<li>${d.date}: ${statusText(d.status)}</li>`).join('') + '</ul>';

--- a/choir-app-backend/src/utils/frontend-url.js
+++ b/choir-app-backend/src/utils/frontend-url.js
@@ -1,0 +1,8 @@
+const db = require('../models');
+
+async function getFrontendUrl() {
+  const setting = await db.system_setting.findByPk('FRONTEND_URL');
+  return setting?.value || process.env.FRONTEND_URL || 'https://nak-chorleiter.de';
+}
+
+module.exports = { getFrontendUrl };

--- a/choir-app-frontend/src/app/core/models/frontend-url.ts
+++ b/choir-app-frontend/src/app/core/models/frontend-url.ts
@@ -1,0 +1,3 @@
+export interface FrontendUrl {
+  value: string;
+}

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -8,6 +8,7 @@ import { LoginAttempt } from '../models/login-attempt';
 import { StatsSummary } from '../models/stats-summary';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
+import { FrontendUrl } from '../models/frontend-url';
 
 @Injectable({ providedIn: 'root' })
 export class AdminService {
@@ -133,5 +134,13 @@ export class AdminService {
 
   updateMailTemplates(data: MailTemplate[]): Observable<MailTemplate[]> {
     return this.http.put<MailTemplate[]>(`${this.apiUrl}/admin/mail-templates`, data);
+  }
+
+  getFrontendUrl(): Observable<FrontendUrl> {
+    return this.http.get<FrontendUrl>(`${this.apiUrl}/admin/frontend-url`);
+  }
+
+  updateFrontendUrl(data: FrontendUrl): Observable<FrontendUrl> {
+    return this.http.put<FrontendUrl>(`${this.apiUrl}/admin/frontend-url`, data);
   }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -35,6 +35,7 @@ import { StatsSummary } from '../models/stats-summary';
 import { RepertoireFilter } from '../models/repertoire-filter';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
+import { FrontendUrl } from '../models/frontend-url';
 import { FilterPresetService } from './filter-preset.service';
 import { UserAvailability } from '../models/user-availability';
 import { MemberAvailability } from '../models/member-availability';
@@ -643,6 +644,14 @@ export class ApiService {
 
   updateMailTemplates(data: MailTemplate[]): Observable<MailTemplate[]> {
     return this.adminService.updateMailTemplates(data);
+  }
+
+  getFrontendUrl(): Observable<FrontendUrl> {
+    return this.adminService.getFrontendUrl();
+  }
+
+  updateFrontendUrl(value: string): Observable<FrontendUrl> {
+    return this.adminService.updateFrontendUrl({ value });
   }
 
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {

--- a/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.html
@@ -1,0 +1,10 @@
+<form [formGroup]="form" (ngSubmit)="save()" class="frontend-form">
+  <mat-form-field appearance="fill">
+    <mat-label>Frontend URL</mat-label>
+    <input matInput formControlName="url" />
+    <mat-hint>Basisadresse des Frontend-Systems</mat-hint>
+  </mat-form-field>
+  <div class="actions">
+    <button mat-raised-button color="primary" type="submit">Speichern</button>
+  </div>
+</form>

--- a/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.scss
+++ b/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.scss
@@ -1,0 +1,16 @@
+.frontend-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  mat-form-field {
+    width: 100%;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.ts
@@ -1,0 +1,53 @@
+import { Component, HostListener, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { PendingChanges } from '@core/guards/pending-changes.guard';
+
+@Component({
+  selector: 'app-frontend-url-settings',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './frontend-url-settings.component.html',
+  styleUrls: ['./frontend-url-settings.component.scss']
+})
+export class FrontendUrlSettingsComponent implements OnInit, PendingChanges {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar) {
+    this.form = this.fb.group({
+      url: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.getFrontendUrl().subscribe(data => {
+      if (data && data.value) {
+        this.form.patchValue({ url: data.value });
+        this.form.markAsPristine();
+      }
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    this.api.updateFrontendUrl(this.form.value.url).subscribe(() => {
+      this.snack.open('Gespeichert', 'OK', { duration: 2000 });
+      this.form.markAsPristine();
+    });
+  }
+
+  hasPendingChanges(): boolean {
+    return this.form.dirty;
+  }
+
+  @HostListener('window:beforeunload', ['$event'])
+  confirmUnload(event: BeforeUnloadEvent): void {
+    if (this.hasPendingChanges()) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.html
@@ -1,6 +1,12 @@
 <mat-accordion>
   <mat-expansion-panel>
     <mat-expansion-panel-header>
+      <mat-panel-title>Frontend URL</mat-panel-title>
+    </mat-expansion-panel-header>
+    <app-frontend-url-settings></app-frontend-url-settings>
+  </mat-expansion-panel>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
       <mat-panel-title>Mail-Server</mat-panel-title>
     </mat-expansion-panel-header>
     <app-mail-settings></app-mail-settings>

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
@@ -4,21 +4,24 @@ import { MaterialModule } from '@modules/material.module';
 import { MailSettingsComponent } from '../mail-settings/mail-settings.component';
 import { MailTemplatesComponent } from '../mail-templates/mail-templates.component';
 import { BackupComponent } from '../backup/backup.component';
+import { FrontendUrlSettingsComponent } from '../frontend-url-settings/frontend-url-settings.component';
 import { PendingChanges } from '@core/guards/pending-changes.guard';
 
 @Component({
   selector: 'app-general-settings',
   standalone: true,
-  imports: [CommonModule, MaterialModule, MailSettingsComponent, MailTemplatesComponent, BackupComponent],
+  imports: [CommonModule, MaterialModule, FrontendUrlSettingsComponent, MailSettingsComponent, MailTemplatesComponent, BackupComponent],
   templateUrl: './general-settings.component.html',
   styleUrls: ['./general-settings.component.scss']
 })
 export class GeneralSettingsComponent implements PendingChanges {
+  @ViewChild(FrontendUrlSettingsComponent) frontendUrl?: FrontendUrlSettingsComponent;
   @ViewChild(MailSettingsComponent) mailSettings?: MailSettingsComponent;
   @ViewChild(MailTemplatesComponent) mailTemplates?: MailTemplatesComponent;
 
   hasPendingChanges(): boolean {
-    return (this.mailSettings?.hasPendingChanges() ?? false) ||
+    return (this.frontendUrl?.hasPendingChanges() ?? false) ||
+           (this.mailSettings?.hasPendingChanges() ?? false) ||
            (this.mailTemplates?.hasPendingChanges() ?? false);
   }
 }


### PR DESCRIPTION
## Summary
- store frontend url in a new `system_setting` table
- expose admin API endpoints to get/update the setting
- use the stored frontend url in emails and change notification links
- add Angular form to edit the frontend url in admin general settings
- wire API services for the new endpoints

## Testing
- `npm test`
- `npm run check-backend`

------
https://chatgpt.com/codex/tasks/task_e_687ebd0bb6cc83208fb3ccfa085d8130