### PR TITLE
Enable lyric searching in repertoire

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -146,6 +146,7 @@ exports.findMyRepertoire = async (req, res) => {
                     { title: { [Op.iLike]: `%${t}%` } },
                     { '$composer.name$': { [Op.iLike]: `%${t}%` } },
                     { '$category.name$': { [Op.iLike]: `%${t}%` } },
+                    { lyrics: { [Op.iLike]: `%${t}%` } },
                     literal(`${refSub} ILIKE '%${t}%'`)
                 ]
             }));

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -6,7 +6,7 @@
     <div class="filter-controls">
       <mat-form-field appearance="outline">
         <mat-label>Suche</mat-label>
-        <input matInput [formControl]="searchControl" placeholder="Repertoire durchsuchen" />
+        <input matInput [formControl]="searchControl" placeholder="Repertoire durchsuchen (inkl. Liedtext)" />
         <mat-hint>Anführungszeichen für Wortgruppen verwenden</mat-hint>
       </mat-form-field>
       <mat-form-field appearance="outline">


### PR DESCRIPTION
## Summary
- support searching by lyrics in repertoire filter
- clarify search placeholder text that lyrics are included

## Testing
- `npm run check-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ebfeb237483208ff8f0f3ed190a83