### PR TITLE
Implement HTML links in monthly plan emails

### DIFF
--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -158,12 +158,16 @@ exports.sendTemplatePreviewMail = async (to, type, name) => {
 exports.sendMonthlyPlanMail = async (recipients, pdfBuffer, year, month) => {
   const settings = await db.mail_setting.findByPk(1);
   const transporter = await createTransporter(settings);
+  const linkBase = process.env.FRONTEND_URL || 'https://nak-chorleiter.de';
+  const link = `${linkBase}/dienstplan?year=${year}&month=${month}`;
   try {
     await transporter.sendMail({
       from: getFromAddress(settings),
       to: recipients,
       subject: `Dienstplan ${month}/${year}`,
-      text: 'Im Anhang befindet sich der aktuelle Dienstplan.',
+      text: `Im Anhang befindet sich der aktuelle Dienstplan. ${link}`,
+      html: `<p>Im Anhang befindet sich der aktuelle Dienstplan.<br>` +
+            `<a href="${link}">Dienstplan online ansehen</a></p>`,
       attachments: [{ filename: `dienstplan-${year}-${month}.pdf`, content: pdfBuffer }]
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- add link to monthly plan page in mail text and HTML

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend`


------
https://chatgpt.com/codex/tasks/task_e_687f4d29423083208b9667840d8ba43d