### PR TITLE
Add filter and translated role column

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -1,5 +1,10 @@
 <div class="toolbar">
   <button mat-flat-button color="primary" (click)="addUser()">Benutzer hinzufügen</button>
+  <span class="spacer"></span>
+  <mat-form-field appearance="outline" class="filter-field">
+    <mat-label>Filter</mat-label>
+    <input matInput [value]="filterValue" (input)="applyFilter($event.target.value)">
+  </mat-form-field>
 </div>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
@@ -15,7 +20,7 @@
 
   <ng-container matColumnDef="role">
     <th mat-header-cell *matHeaderCellDef>Rolle</th>
-    <td mat-cell *matCellDef="let element">{{ element.role }}</td>
+    <td mat-cell *matCellDef="let element">{{ element.role | userRoleLabel }}</td>
   </ng-container>
 
   <ng-container matColumnDef="choirs">

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
@@ -3,5 +3,15 @@
 }
 
 .toolbar {
+  display: flex;
+  align-items: center;
   margin-bottom: 1rem;
+}
+
+.toolbar .spacer {
+  flex: 1 1 auto;
+}
+
+.filter-field {
+  width: 200px;
 }

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from 'src/app/core/services/api.service';
 import { User } from 'src/app/core/models/user';
@@ -7,11 +8,12 @@ import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserDialogComponent } from './user-dialog/user-dialog.component';
+import { UserRoleLabelPipe } from '@shared/pipes/user-role-label.pipe';
 
 @Component({
   selector: 'app-manage-users',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [CommonModule, FormsModule, MaterialModule, UserRoleLabelPipe],
   templateUrl: './manage-users.component.html',
   styleUrls: ['./manage-users.component.scss']
 })
@@ -19,10 +21,18 @@ export class ManageUsersComponent implements OnInit {
   users: User[] = [];
   displayedColumns = ['name', 'email', 'role', 'choirs', 'lastLogin', 'actions'];
   dataSource = new MatTableDataSource<User>();
+  filterValue = '';
 
   constructor(private api: ApiService, private dialog: MatDialog, private snack: MatSnackBar) {}
 
   ngOnInit(): void {
+    this.dataSource.filterPredicate = (data, filter) => {
+      const term = filter.trim().toLowerCase();
+      return (
+        (data.name && data.name.toLowerCase().includes(term)) ||
+        data.email.toLowerCase().includes(term)
+      );
+    };
     this.loadUsers();
   }
 
@@ -68,5 +78,10 @@ export class ManageUsersComponent implements OnInit {
   choirList(user: any): string {
     if (!user.choirs) return '';
     return user.choirs.map((c: any) => c.name).join(', ');
+  }
+
+  applyFilter(value: string): void {
+    this.filterValue = value;
+    this.dataSource.filter = value.trim().toLowerCase();
   }
 }

--- a/choir-app-frontend/src/app/shared/pipes/user-role-label.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/user-role-label.pipe.ts
@@ -1,0 +1,30 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Wandelt Benutzerrollen in ihre deutschen Bezeichnungen um.
+ */
+@Pipe({
+  name: 'userRoleLabel',
+  standalone: true
+})
+export class UserRoleLabelPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+    switch (value) {
+      case 'director':
+        return 'Dirigent';
+      case 'choir_admin':
+        return 'Chor-Admin';
+      case 'admin':
+        return 'Administrator';
+      case 'demo':
+        return 'Demo';
+      case 'singer':
+        return 'Sänger';
+      default:
+        return value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- filter admin user table by email or name
- translate role names in admin user list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f9785afdc832092230e9af185ef7c