### PR TITLE
Enable choir posts with notifications

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -69,6 +69,7 @@ const planRuleRoutes = require("./routes/planRule.routes");
 const planEntryRoutes = require("./routes/planEntry.routes");
 const availabilityRoutes = require("./routes/availability.routes");
 const clientErrorRoutes = require("./routes/client-error.routes");
+const postRoutes = require("./routes/post.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -96,6 +97,7 @@ app.use("/api/plan-rules", planRuleRoutes);
 app.use("/api/plan-entries", planEntryRoutes);
 app.use("/api/availabilities", availabilityRoutes);
 app.use("/api/client-errors", clientErrorRoutes);
+app.use("/api/posts", postRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/post.controller.js
+++ b/choir-app-backend/src/controllers/post.controller.js
@@ -1,0 +1,100 @@
+const db = require('../models');
+const Post = db.post;
+const emailService = require('../services/email.service');
+
+function stripHtml(text) {
+  return text.replace(/<[^>]*>/g, '');
+}
+
+async function isChoirAdmin(req) {
+  if (req.userRole === 'admin') return true;
+  const assoc = await db.user_choir.findOne({ where: { userId: req.userId, choirId: req.activeChoirId } });
+  return assoc && Array.isArray(assoc.rolesInChoir) && assoc.rolesInChoir.includes('choir_admin');
+}
+
+exports.create = async (req, res) => {
+  const { title, text } = req.body;
+  if (!title || !text) return res.status(400).send({ message: 'title and text required' });
+  try {
+    const sanitizedTitle = stripHtml(title);
+    const sanitizedText = stripHtml(text);
+    const post = await Post.create({
+      title: sanitizedTitle,
+      text: sanitizedText,
+      choirId: req.activeChoirId,
+      userId: req.userId
+    });
+    const full = await Post.findByPk(post.id, { include: [{ model: db.user, as: 'author', attributes: ['id','name'] }] });
+
+    const members = await db.user.findAll({
+      include: [{ model: db.choir, where: { id: req.activeChoirId } }]
+    });
+    const emails = members.map(u => u.email).filter(e => e);
+    if (emails.length > 0) {
+      await emailService.sendPostNotificationMail(emails, sanitizedTitle, sanitizedText);
+    }
+
+    res.status(201).send(full);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.findAll = async (req, res) => {
+  try {
+    const posts = await Post.findAll({
+      where: { choirId: req.activeChoirId },
+      include: [{ model: db.user, as: 'author', attributes: ['id','name'] }],
+      order: [['createdAt', 'DESC']]
+    });
+    res.status(200).send(posts);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.findLatest = async (req, res) => {
+  try {
+    const post = await Post.findOne({
+      where: { choirId: req.activeChoirId },
+      include: [{ model: db.user, as: 'author', attributes: ['id','name'] }],
+      order: [['createdAt', 'DESC']]
+    });
+    res.status(200).send(post);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.update = async (req, res) => {
+  const id = req.params.id;
+  const { title, text } = req.body;
+  if (!title || !text) return res.status(400).send({ message: 'title and text required' });
+  try {
+    const post = await Post.findByPk(id);
+    if (!post || post.choirId !== req.activeChoirId) return res.status(404).send({ message: 'Post not found' });
+    const admin = await isChoirAdmin(req);
+    if (post.userId !== req.userId && !admin) return res.status(403).send({ message: 'Not allowed' });
+    const sanitizedTitle = stripHtml(title);
+    const sanitizedText = stripHtml(text);
+    await post.update({ title: sanitizedTitle, text: sanitizedText });
+    const full = await Post.findByPk(id, { include: [{ model: db.user, as: 'author', attributes: ['id','name'] }] });
+    res.status(200).send(full);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.remove = async (req, res) => {
+  const id = req.params.id;
+  try {
+    const post = await Post.findByPk(id);
+    if (!post || post.choirId !== req.activeChoirId) return res.status(404).send({ message: 'Post not found' });
+    const admin = await isChoirAdmin(req);
+    if (post.userId !== req.userId && !admin) return res.status(403).send({ message: 'Not allowed' });
+    await post.destroy();
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -39,6 +39,7 @@ db.login_attempt = require("./login_attempt.model.js")(sequelize, Sequelize);
 db.mail_setting = require("./mail_setting.model.js")(sequelize, Sequelize);
 db.mail_template = require("./mail_template.model.js")(sequelize, Sequelize);
 db.system_setting = require("./system_setting.model.js")(sequelize, Sequelize);
+db.post = require("./post.model.js")(sequelize, Sequelize);
 
 // --- Define Associations ---
 // A Choir has many Users
@@ -131,6 +132,12 @@ db.user.hasMany(db.repertoire_filter, { as: 'repertoireFilters' });
 db.repertoire_filter.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
 db.choir.hasMany(db.repertoire_filter, { as: 'repertoireFilters' });
 db.repertoire_filter.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
+
+// Posts written by choir members
+db.choir.hasMany(db.post, { as: 'posts' });
+db.post.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
+db.user.hasMany(db.post, { as: 'posts' });
+db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
 
 
 module.exports = db;

--- a/choir-app-backend/src/models/post.model.js
+++ b/choir-app-backend/src/models/post.model.js
@@ -1,0 +1,13 @@
+module.exports = (sequelize, DataTypes) => {
+  const Post = sequelize.define('post', {
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    text: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    }
+  });
+  return Post;
+};

--- a/choir-app-backend/src/routes/post.routes.js
+++ b/choir-app-backend/src/routes/post.routes.js
@@ -1,0 +1,16 @@
+const authJwt = require('../middleware/auth.middleware');
+const controller = require('../controllers/post.controller');
+const validate = require('../validators/validate');
+const { postValidation } = require('../validators/post.validation');
+const { handler: wrap } = require('../utils/async');
+const router = require('express').Router();
+
+router.use(authJwt.verifyToken);
+
+router.get('/latest', wrap(controller.findLatest));
+router.get('/', wrap(controller.findAll));
+router.post('/', postValidation, validate, wrap(controller.create));
+router.put('/:id', postValidation, validate, wrap(controller.update));
+router.delete('/:id', wrap(controller.remove));
+
+module.exports = router;

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -199,3 +199,22 @@ exports.sendPieceChangeProposalMail = async (to, piece, proposer, link) => {
     throw err;
   }
 };
+
+exports.sendPostNotificationMail = async (recipients, title, text) => {
+  if (emailDisabled() || !Array.isArray(recipients) || recipients.length === 0) return;
+  const settings = await db.mail_setting.findByPk(1);
+  const transporter = await createTransporter(settings);
+  try {
+    await transporter.sendMail({
+      from: getFromAddress(settings),
+      to: recipients,
+      subject: title,
+      text,
+      html: `<p>${text.replace(/\n/g, '<br>')}</p>`
+    });
+  } catch (err) {
+    logger.error(`Error sending post mail: ${err.message}`);
+    logger.error(err.stack);
+    throw err;
+  }
+};

--- a/choir-app-backend/src/validators/post.validation.js
+++ b/choir-app-backend/src/validators/post.validation.js
@@ -1,0 +1,10 @@
+const { body } = require('express-validator');
+
+function noHtml(value) {
+  return !/<[^>]+>/.test(value);
+}
+
+exports.postValidation = [
+  body('title').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
+  body('text').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed')
+];

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -32,6 +32,7 @@ const db = require('../src/models');
     checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
+    checkFields(db.post, ['title', 'text']);
 
     // Basic association checks
     assert(db.user.associations.choirs, 'User should have choirs association');

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -110,6 +110,11 @@ export const routes: Routes = [
                 canActivate: [AuthGuard]
             },
             {
+                path: 'posts',
+                loadComponent: () => import('./features/posts/post-list.component').then(m => m.PostListComponent),
+                canActivate: [AuthGuard]
+            },
+            {
                 path: 'stats',
                 component: StatisticsComponent,
                 canActivate: [AuthGuard]

--- a/choir-app-frontend/src/app/core/models/post.ts
+++ b/choir-app-frontend/src/app/core/models/post.ts
@@ -1,0 +1,10 @@
+export interface Post {
+  id: number;
+  title: string;
+  text: string;
+  choirId: number;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+  author?: { id: number; name: string };
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -17,6 +17,7 @@ import { Publisher } from '@core/models/publisher';
 import { Choir } from '@core/models/choir';
 import { PlanRule } from '@core/models/plan-rule';
 import { PieceChange } from '../models/piece-change';
+import { Post } from '../models/post';
 import { PieceService } from './piece.service';
 import { ComposerService } from './composer.service';
 import { AuthorService } from './author.service';
@@ -42,6 +43,7 @@ import { MemberAvailability } from '../models/member-availability';
 import { AvailabilityService } from './availability.service';
 import { SearchService } from './search.service';
 import { MonthlyPlanService } from './monthly-plan.service';
+import { PostService } from './post.service';
 
 @Injectable({
   providedIn: 'root'
@@ -66,7 +68,8 @@ export class ApiService {
               private planRuleService: PlanRuleService,
               private availabilityService: AvailabilityService,
               private searchService: SearchService,
-              private monthlyPlanService: MonthlyPlanService) {
+              private monthlyPlanService: MonthlyPlanService,
+              private postService: PostService) {
 
   }
 
@@ -669,6 +672,27 @@ export class ApiService {
   registerDonation(): Observable<any> {
         return this.userService.registerDonation();
     }
+
+  // --- Post Methods ---
+  getPosts(): Observable<Post[]> {
+    return this.postService.getPosts();
+  }
+
+  getLatestPost(): Observable<Post | null> {
+    return this.postService.getLatestPost();
+  }
+
+  createPost(data: { title: string; text: string }): Observable<Post> {
+    return this.postService.createPost(data);
+  }
+
+  updatePost(id: number, data: { title: string; text: string }): Observable<Post> {
+    return this.postService.updatePost(id, data);
+  }
+
+  deletePost(id: number): Observable<any> {
+    return this.postService.deletePost(id);
+  }
 
   // --- Filter Preset Methods ---
   getRepertoireFilters(): Observable<RepertoireFilter[]> {

--- a/choir-app-frontend/src/app/core/services/post.service.ts
+++ b/choir-app-frontend/src/app/core/services/post.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { Post } from '../models/post';
+
+@Injectable({ providedIn: 'root' })
+export class PostService {
+  private apiUrl = environment.apiUrl;
+  constructor(private http: HttpClient) {}
+
+  getPosts(): Observable<Post[]> {
+    return this.http.get<Post[]>(`${this.apiUrl}/posts`);
+  }
+
+  getLatestPost(): Observable<Post | null> {
+    return this.http.get<Post | null>(`${this.apiUrl}/posts/latest`);
+  }
+
+  createPost(data: { title: string; text: string }): Observable<Post> {
+    return this.http.post<Post>(`${this.apiUrl}/posts`, data);
+  }
+
+  updatePost(id: number, data: { title: string; text: string }): Observable<Post> {
+    return this.http.put<Post>(`${this.apiUrl}/posts/${id}`, data);
+  }
+
+  deletePost(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/posts/${id}`);
+  }
+}

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -19,6 +19,13 @@
   </app-event-card>
 </div>
 
+<div class="latest-post" *ngIf="latestPost$ | async as post">
+  <h2>Neuster Beitrag</h2>
+  <h3>{{ post.title }}</h3>
+  <p>{{ post.text }}</p>
+  <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
+</div>
+
 <div class="upcoming-section">
   <h2>Nächste Termine</h2>
   <mat-slide-toggle [(ngModel)]="showOnlyMine" (change)="onToggleMine()">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
@@ -26,3 +26,5 @@ mat-card-content h3 {
   height: 100px;
   color: #999;
 }
+
+.latest-post{margin-top:1rem;}

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -16,6 +16,7 @@ import { EventCardComponent } from '../event-card/event-card.component';
 import { AuthService } from '@core/services/auth.service';
 import { Choir } from '@core/models/choir';
 import { PieceChange } from '@core/models/piece-change';
+import { Post } from '@core/models/post';
 import { HelpService } from '@core/services/help.service';
 import { HelpWizardComponent } from '@shared/components/help-wizard/help-wizard.component';
 import { UserPreferencesService } from '@core/services/user-preferences.service';
@@ -43,6 +44,7 @@ export class DashboardComponent implements OnInit {
   activeChoir$: Observable<Choir | null>;
   pieceChanges$!: Observable<PieceChange[]>;
   nextEvents$!: Observable<Event[]>;
+  latestPost$!: Observable<import('@core/models/post').Post | null>;
   showOnlyMine = false;
   isAdmin$: Observable<boolean | false>;
 
@@ -70,6 +72,10 @@ export class DashboardComponent implements OnInit {
 
     this.nextEvents$ = this.refresh$.pipe(
       switchMap(() => this.apiService.getNextEvents(5, this.showOnlyMine))
+    );
+
+    this.latestPost$ = this.refresh$.pipe(
+      switchMap(() => this.apiService.getLatestPost())
     );
 
     this.pieceChanges$ = this.authService.isAdmin$.pipe(

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.html
@@ -1,0 +1,17 @@
+<h1 mat-dialog-title>{{ isEdit ? 'Beitrag bearbeiten' : 'Neuer Beitrag' }}</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form">
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Titel</mat-label>
+      <input matInput formControlName="title">
+    </mat-form-field>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Text</mat-label>
+      <textarea matInput rows="5" formControlName="text"></textarea>
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-flat-button color="primary" (click)="save()" [disabled]="form.invalid">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { Post } from '@core/models/post';
+
+@Component({
+  selector: 'app-post-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MaterialModule],
+  templateUrl: './post-dialog.component.html'
+})
+export class PostDialogComponent {
+  form: FormGroup;
+  isEdit = false;
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<PostDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { post?: Post } | null
+  ) {
+    this.form = this.fb.group({
+      title: ['', Validators.required],
+      text: ['', Validators.required]
+    });
+    if (data?.post) {
+      this.isEdit = true;
+      this.form.patchValue({ title: data.post.title, text: data.post.text });
+    }
+  }
+
+  save(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -1,0 +1,17 @@
+<div class="post-header">
+  <h1>Beiträge</h1>
+  <button mat-flat-button color="primary" (click)="addPost()">Neuer Beitrag</button>
+</div>
+<mat-list>
+  <mat-list-item *ngFor="let p of posts">
+    <div class="full-width">
+      <h3>{{ p.title }}</h3>
+      <p>{{ p.text }}</p>
+      <small>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }}</small>
+    </div>
+    <div *ngIf="canEdit(p)" class="actions">
+      <button mat-icon-button (click)="editPost(p)" matTooltip="Bearbeiten"><mat-icon>edit</mat-icon></button>
+      <button mat-icon-button (click)="deletePost(p)" matTooltip="Löschen"><mat-icon>delete</mat-icon></button>
+    </div>
+  </mat-list-item>
+</mat-list>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.scss
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.scss
@@ -1,0 +1,13 @@
+.post-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.actions {
+  display: flex;
+  gap: 8px;
+}
+.full-width {
+  flex: 1;
+}

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MaterialModule } from '@modules/material.module';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Post } from '@core/models/post';
+import { ApiService } from '@core/services/api.service';
+import { AuthService } from '@core/services/auth.service';
+import { PostDialogComponent } from './post-dialog.component';
+import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+
+@Component({
+  selector: 'app-post-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule, MaterialModule, PostDialogComponent, ConfirmDialogComponent],
+  templateUrl: './post-list.component.html'
+})
+export class PostListComponent implements OnInit {
+  posts: Post[] = [];
+  currentUserId: number | null = null;
+  isChoirAdmin = false;
+  constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {}
+
+  ngOnInit(): void {
+    this.loadPosts();
+    this.auth.currentUser$.subscribe(u => this.currentUserId = u?.id || null);
+    this.api.checkChoirAdminStatus().subscribe(r => this.isChoirAdmin = r.isChoirAdmin);
+  }
+
+  loadPosts(): void {
+    this.api.getPosts().subscribe(p => this.posts = p);
+  }
+
+  canEdit(post: Post): boolean {
+    return this.isChoirAdmin || post.userId === this.currentUserId;
+  }
+
+  addPost(): void {
+    const ref = this.dialog.open(PostDialogComponent, { width: '600px' });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.api.createPost(result).subscribe({
+          next: () => { this.snackBar.open('Beitrag erstellt', 'OK', { duration: 3000 }); this.loadPosts(); },
+          error: () => this.snackBar.open('Fehler beim Speichern', 'Schließen', { duration: 4000 })
+        });
+      }
+    });
+  }
+
+  editPost(post: Post): void {
+    const ref = this.dialog.open(PostDialogComponent, { width: '600px', data: { post } });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.api.updatePost(post.id, result).subscribe({
+          next: () => { this.snackBar.open('Beitrag aktualisiert', 'OK', { duration: 3000 }); this.loadPosts(); },
+          error: () => this.snackBar.open('Fehler beim Aktualisieren', 'Schließen', { duration: 4000 })
+        });
+      }
+    });
+  }
+
+  deletePost(post: Post): void {
+    const data: ConfirmDialogData = { title: 'Beitrag löschen?', message: 'Möchten Sie diesen Beitrag wirklich löschen?' };
+    const ref = this.dialog.open(ConfirmDialogComponent, { data });
+    ref.afterClosed().subscribe(confirmed => {
+      if (confirmed) {
+        this.api.deletePost(post.id).subscribe({
+          next: () => { this.snackBar.open('Beitrag gelöscht', 'OK', { duration: 3000 }); this.loadPosts(); },
+          error: () => this.snackBar.open('Fehler beim Löschen', 'Schließen', { duration: 4000 })
+        });
+      }
+    });
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -176,6 +176,11 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
         visibleSubject: this.isLoggedIn$,
       },
       {
+        displayName: 'Beiträge',
+        route: '/posts',
+        visibleSubject: this.isLoggedIn$,
+      },
+      {
         displayName: 'Statistik',
         route: '/stats',
         visibleSubject: this.isLoggedIn$,


### PR DESCRIPTION
## Summary
- add `post` model and associations
- implement post controller and REST routes
- send notification emails to choir members
- support posts in frontend with list and dialog
- display latest post on dashboard and add menu link
- include tests for new model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fa09aee8c83209dc0f4e6c02dabd5