### PR TITLE
Display choir name in post list header

### DIFF
--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -1,5 +1,5 @@
 <div class="post-header">
-  <h1>Beiträge</h1>
+  <h1>Beiträge – {{ (activeChoir$ | async)?.name }}</h1>
   <button mat-flat-button color="primary" (click)="addPost()">Neuer Beitrag</button>
 </div>
 <mat-list>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -4,6 +4,8 @@ import { RouterModule } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Observable } from 'rxjs';
+import { Choir } from '@core/models/choir';
 import { Post } from '@core/models/post';
 import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
@@ -20,7 +22,10 @@ export class PostListComponent implements OnInit {
   posts: Post[] = [];
   currentUserId: number | null = null;
   isChoirAdmin = false;
-  constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {}
+  activeChoir$!: Observable<Choir | null>;
+  constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {
+    this.activeChoir$ = this.auth.activeChoir$;
+  }
 
   ngOnInit(): void {
     this.loadPosts();


### PR DESCRIPTION
## Summary
- show the current choir name alongside the `Beiträge` heading
- expose `activeChoir$` in PostListComponent for the template

## Testing
- `npm test --silent` in `choir-app-frontend`
- `npm run check` in `choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_687fbadb3964832082a62e223fe2cccb