### PR TITLE
Add global page header

### DIFF
--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -73,77 +73,92 @@ export const routes: Routes = [
                 path: 'dashboard',
                 component: DashboardComponent,
                 canActivate: [AuthGuard],
+                data: { title: 'Home' },
             },
             {
                 path: 'repertoire',
                 component: LiteratureListComponent,
                 canActivate: [AuthGuard],
+                data: { title: 'Repertoire' },
             },
             {
                 path: 'collections',
                 component: CollectionListComponent,
                 canActivate: [AuthGuard],
+                data: { title: 'Sammlungen' },
             },
             {
                 path: 'collections/new',
                 component: CollectionEditComponent,
                 canActivate: [AuthGuard],
+                data: { title: 'Neue Sammlung' },
             },
             {
                 path: 'collections/edit/:id',
                 component: CollectionEditComponent,
                 canActivate: [AuthGuard],
+                data: { title: 'Sammlung bearbeiten' },
             },
             {
                 path: 'events',
                 component: EventListComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Ereignisse' }
             },
             {
                 path: 'dienstplan',
                 component: MonthlyPlanComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Dienstplan' }
             },
             {
                 path: 'termine',
                 component: MyCalendarComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Meine Termine' }
             },
             {
                 path: 'posts',
                 loadComponent: () => import('./features/posts/post-list.component').then(m => m.PostListComponent),
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Beiträge' }
             },
             {
                 path: 'stats',
                 component: StatisticsComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Statistik' }
             },
             {
                 path: 'pieces/:id',
                 component: PieceDetailComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Stückdetails' }
             },
             {
                 path: 'search',
                 component: SearchResultsComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Suche' }
             },
             {
                 path: 'profile',
                 component: ProfileComponent,
                 canActivate: [AuthGuard],
+                data: { title: 'Profil' },
             },
             {
                 path: 'members',
                 component: ChoirMembersComponent,
-                canActivate: [AuthGuard]
+                canActivate: [AuthGuard],
+                data: { title: 'Chormitglieder' }
             },
             {
                 path: 'manage-choir',
                 component: ManageChoirComponent,
                 canActivate: [AuthGuard],
-                resolve: {pageData: ManageChoirResolver }
+                resolve: {pageData: ManageChoirResolver },
+                data: { title: 'Mein Chor' }
             },
         ],
     },

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -11,15 +11,16 @@ export const adminRoutes: Routes = [
       {
         path: 'general',
         loadComponent: () => import('./general/general-settings.component').then(m => m.GeneralSettingsComponent),
-        canDeactivate: [PendingChangesGuard]
+        canDeactivate: [PendingChangesGuard],
+        data: { title: 'Admin – Allgemein' }
       },
-      { path: 'creators', loadComponent: () => import('./manage-creators/manage-creators.component').then(m => m.ManageCreatorsComponent) },
-      { path: 'publishers', loadComponent: () => import('./manage-publishers/manage-publishers.component').then(m => m.ManagePublishersComponent) },
-      { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent) },
-      { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent) },
-      { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent) },
-      { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent) },
-      { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent) },
+      { path: 'creators', loadComponent: () => import('./manage-creators/manage-creators.component').then(m => m.ManageCreatorsComponent), data: { title: 'Admin – Komponisten' } },
+      { path: 'publishers', loadComponent: () => import('./manage-publishers/manage-publishers.component').then(m => m.ManagePublishersComponent), data: { title: 'Admin – Verlage' } },
+      { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent), data: { title: 'Admin – Chöre' } },
+      { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent), data: { title: 'Admin – Benutzer' } },
+      { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent), data: { title: 'Admin – Änderungen' } },
+      { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent), data: { title: 'Admin – Protokolle' } },
+      { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent), data: { title: 'Admin – Develop' } },
     ],
   },
 ];

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -1,5 +1,5 @@
 <div class="manage-container">
-  <h1>Chorinformationen</h1>
+
 
   <!-- Card für die Chor-Details -->
   <mat-card class="form-card">

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -1,4 +1,3 @@
-<h1>Chormitglieder</h1>
 <div class="table-container mat-elevation-z4">
   <table mat-table [dataSource]="dataSource">
     <ng-container matColumnDef="name">

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -1,10 +1,5 @@
 <div class="form-container">
-  <div class="page-header">
-    <div>
-      <h1>{{ pageTitle }}</h1>
-      <p class="subtitle">{{ pageSubtitle }}</p>
-    </div>
-    <!-- Fügen Sie den Button nur im Edit-Modus hinzu -->
+  <app-page-header [title]="pageTitle">
     <button
       *ngIf="isEditMode && isAdmin"
       mat-stroked-button
@@ -13,7 +8,8 @@
       <mat-icon>upload_file</mat-icon>
       Import aus CSV
     </button>
-  </div>
+  </app-page-header>
+  <p class="subtitle">{{ pageSubtitle }}</p>
 
   <!-- This is the main form, wrapping everything -->
   <form [formGroup]="collectionForm" (ngSubmit)="onSave()" class="edit-form">

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -59,13 +59,6 @@ mat-card-actions button mat-icon {
   }
 }
 
-.page-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem; // Abstand zwischen Icon und Text
-  justify-self: space-between; // Verteilt den Platz zwischen Icon und Text
-  margin-bottom: 1rem;
-}
 
 .cover-upload {
   margin-top: 1rem;

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -1,16 +1,13 @@
 
-<div class="header-container">
-  <div>
-    <h1>Sammlungen</h1>
-    <p class="subtitle">Verwalten von globalen Sammlungen und Hinzufügen zum Chorrepertoire.</p>
-  </div>
+<app-page-header title="Sammlungen">
   <button mat-flat-button color="accent" routerLink="/collections/new"
           [disabled]="!isChoirAdmin && !isAdmin"
           matTooltip="{{ !isChoirAdmin && !isAdmin ? 'Zum Hinzufügen müssen Sie als Chor-Administrator eingeloggt sein.' : '' }}">
     <mat-icon>add</mat-icon>
     <span>Neue Sammlung</span>
   </button>
-</div>
+</app-page-header>
+<p class="subtitle">Verwalten von globalen Sammlungen und Hinzufügen zum Chorrepertoire.</p>
 
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -1,15 +1,8 @@
-.header-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center; // Vertically align items
+.subtitle {
+    font-size: 1rem;
+    color: #666;
+    margin-top: -0.5rem;
     margin-bottom: 2rem;
-    h1 {
-        margin-bottom: 0.25rem;
-    }
-    .subtitle {
-        font-size: 1rem;
-        color: #666;
-    }
 }
 
 .collection-grid {

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -9,7 +9,8 @@ import { ApiService } from '@core/services/api.service';
 import { Collection } from '@core/models/collection';
 import { forkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { RouterLink, Router } from '@angular/router'; // Import RouterLink and Router
+import { RouterLink, Router } from '@angular/router';
+import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 import { AuthService } from '@core/services/auth.service';
 import { PaginatorService } from '@core/services/paginator.service';
 
@@ -19,7 +20,8 @@ import { PaginatorService } from '@core/services/paginator.service';
   imports: [
     CommonModule,
     MaterialModule,
-    RouterLink // Add RouterLink to imports
+    RouterLink,
+    PageHeaderComponent
   ],
   templateUrl: './collection-list.component.html',
   styleUrls: ['./collection-list.component.scss']

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -36,13 +36,12 @@
   </mat-drawer>
   <mat-drawer-content>
     <div class="page">
-      <div class="page-header">
-        <h1>Chorrepertoire</h1>
+      <app-page-header title="Chorrepertoire">
         <button mat-flat-button color="primary" (click)="openAddPieceDialog()">
           <mat-icon>add</mat-icon>
           <span>Stück hinzufügen</span>
         </button>
-      </div>
+      </app-page-header>
       <div class="filter-bar">
         <button mat-icon-button (click)="drawer.toggle()" aria-label="Filter ein-/ausblenden">
           <mat-icon>filter_list</mat-icon>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -19,13 +19,6 @@
 }
 
 // Header der Seite (Titel und Button)
-.page-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-  flex-shrink: 0;
-}
 
 .filter-bar {
   display: flex;

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -25,11 +25,12 @@ import { ErrorService } from '@core/services/error.service';
 import { UserPreferencesService } from '@core/services/user-preferences.service';
 import { UserPreferences } from '@core/models/user-preferences';
 import { Router, RouterModule } from '@angular/router';
+import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 
 @Component({
   selector: 'app-literature-list',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MaterialModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule, RouterModule, PageHeaderComponent],
   templateUrl: './literature-list.component.html',
   styleUrls: ['./literature-list.component.scss']
 })

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -1,7 +1,6 @@
-<div class="post-header">
-  <h1>Beiträge</h1>
+<app-page-header title="Beiträge">
   <button mat-flat-button color="primary" (click)="addPost()">Neuer Beitrag</button>
-</div>
+</app-page-header>
 <mat-list>
   <mat-list-item *ngFor="let p of posts">
     <div class="full-width">

--- a/choir-app-frontend/src/app/features/posts/post-list.component.scss
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.scss
@@ -1,9 +1,3 @@
-.post-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1rem;
-}
 .actions {
   display: flex;
   gap: 8px;

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -9,11 +9,12 @@ import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { PostDialogComponent } from './post-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 
 @Component({
   selector: 'app-post-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, MaterialModule, PostDialogComponent, ConfirmDialogComponent],
+  imports: [CommonModule, RouterModule, MaterialModule, PostDialogComponent, ConfirmDialogComponent, PageHeaderComponent],
   templateUrl: './post-list.component.html'
 })
 export class PostListComponent implements OnInit {

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -1,5 +1,5 @@
 <div class="profile-container">
-  <h1>Benutzerprofil</h1>
+
 
   <div *ngIf="isLoading; else profileContent" class="loading-state">
     <mat-spinner diameter="50"></mat-spinner>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -79,6 +79,7 @@
 
     <main class="main-content">
       <div class="container">
+        <app-page-header *ngIf="pageTitle$ | async as pageTitle" [title]="pageTitle"></app-page-header>
         <router-outlet></router-outlet>
       </div>
     </main>

--- a/choir-app-frontend/src/app/shared/components/page-header/page-header.component.html
+++ b/choir-app-frontend/src/app/shared/components/page-header/page-header.component.html
@@ -1,0 +1,4 @@
+<div class="page-header">
+  <h1>{{ title }}</h1>
+  <ng-content></ng-content>
+</div>

--- a/choir-app-frontend/src/app/shared/components/page-header/page-header.component.scss
+++ b/choir-app-frontend/src/app/shared/components/page-header/page-header.component.scss
@@ -1,0 +1,10 @@
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+h1 {
+  margin: 0;
+}

--- a/choir-app-frontend/src/app/shared/components/page-header/page-header.component.ts
+++ b/choir-app-frontend/src/app/shared/components/page-header/page-header.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-page-header',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './page-header.component.html',
+  styleUrls: ['./page-header.component.scss']
+})
+export class PageHeaderComponent {
+  @Input() title: string = '';
+}


### PR DESCRIPTION
## Summary
- create page header component for section titles
- show header in the main layout
- supply titles via router data
- clean up h1 headers in various feature templates

## Testing
- `npm run check-backend`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fbcc8e430832092778598860287c4