### PR TITLE
Fix missing import for collection edit page header

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -35,6 +35,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { PaginatorService } from '@core/services/paginator.service';
 import { MatSort } from '@angular/material/sort';
 import { Publisher } from '@core/models/publisher';
+import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 
 interface SelectedPieceWithNumber {
     piece: Piece;
@@ -50,6 +51,9 @@ interface SelectedPieceWithNumber {
         MaterialModule,
         MatAutocompleteModule,
         RouterModule,
+        PageHeaderComponent,
+        PieceDialogComponent,
+        ImportDialogComponent,
     ],
     templateUrl: './collection-edit.component.html',
     styleUrls: ['./collection-edit.component.scss'],


### PR DESCRIPTION
## Summary
- include PageHeaderComponent in CollectionEditComponent
- add PieceDialogComponent and ImportDialogComponent to its imports

## Testing
- `npm run check-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fcab124688320bf3c27edd4cb033f