### PR TITLE
Fix main layout title extraction

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -141,10 +141,10 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
 
   private getDeepestTitle(route: ActivatedRoute): string | null {
     let child = route.firstChild;
-    let title = child?.snapshot.data['title'];
+    let title = child?.snapshot?.data?.['title'];
     while (child?.firstChild) {
       child = child.firstChild;
-      if (child.snapshot.data && child.snapshot.data['title']) {
+      if (child.snapshot?.data && child.snapshot.data['title']) {
         title = child.snapshot.data['title'];
       }
     }


### PR DESCRIPTION
## Summary
- guard against undefined route snapshots when resolving titles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd7dc94e88320a531ab905104e64c