### PR TITLE
Post header uses route data

### DIFF
--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -121,7 +121,7 @@ export const routes: Routes = [
                 path: 'posts',
                 loadComponent: () => import('./features/posts/post-list.component').then(m => m.PostListComponent),
                 canActivate: [AuthGuard],
-                data: { title: 'Beiträge' }
+                data: { title: 'Beiträge', showChoirName: true }
             },
             {
                 path: 'stats',

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -1,6 +1,6 @@
-<app-page-header title="Beiträge – {{ (activeChoir$ | async)?.name }}">
+<div class="actions">
   <button mat-flat-button color="primary" (click)="addPost()">Neuer Beitrag</button>
-</app-page-header>
+</div>
 <mat-list>
   <mat-list-item *ngFor="let p of posts">
     <div class="full-width">

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -4,28 +4,23 @@ import { RouterModule } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Observable } from 'rxjs';
-import { Choir } from '@core/models/choir';
 import { Post } from '@core/models/post';
 import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { PostDialogComponent } from './post-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
-import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 
 @Component({
   selector: 'app-post-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, MaterialModule, PostDialogComponent, ConfirmDialogComponent, PageHeaderComponent],
+  imports: [CommonModule, RouterModule, MaterialModule, PostDialogComponent, ConfirmDialogComponent],
   templateUrl: './post-list.component.html'
 })
 export class PostListComponent implements OnInit {
   posts: Post[] = [];
   currentUserId: number | null = null;
   isChoirAdmin = false;
-  activeChoir$!: Observable<Choir | null>;
   constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {
-    this.activeChoir$ = this.auth.activeChoir$;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- remove page title logic from `post-list` component
- move post page header name logic into the main routing
- compute full page header title in main layout by combining route data with choir name

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687fda3117508320bf3399dfae26a6d4