### PR TITLE
Add monthly plan email template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Any errors during mail delivery are written to `logs/error.log` for troubleshoot
 
 ### Mail Templates
 
-Invitation, password reset and availability request mails are based on templates
+Invitation, password reset, monthly plan and availability request mails are based on templates
 stored in the database. Administrators can edit the subject and HTML body for
 each type under the `/admin/mail-templates` page. The availability request
 template is used when a plan administrator sends a "Verfügbarkeit anfragen"

--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -152,7 +152,7 @@ exports.emailPdf = async (req, res) => {
         });
         const emails = users.map(u => u.email);
         const buffer = monthlyPlanPdf(plan.toJSON());
-        await emailService.sendMonthlyPlanMail(emails, buffer, plan.year, plan.month);
+        await emailService.sendMonthlyPlanMail(emails, buffer, plan.year, plan.month, plan.choir?.name);
         res.status(200).send({ message: 'Mail sent.' });
     } catch (err) {
         res.status(500).send({ message: err.message || 'Could not send mail.' });

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -75,6 +75,14 @@ async function seedDatabase(options = {}) {
                 }
             });
 
+            await db.mail_template.findOrCreate({
+                where: { type: 'monthly-plan' },
+                defaults: {
+                    subject: 'Dienstplan {{month}}/{{year}}',
+                    body: '<p>Im Anhang befindet sich der aktuelle Dienstplan.</p><p><a href="{{link}}">Dienstplan online ansehen</a></p>'
+                }
+            });
+
             await db.system_setting.findOrCreate({
                 where: { key: 'FRONTEND_URL' },
                 defaults: { value: process.env.FRONTEND_URL || 'https://nak-chorleiter.de' }

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -117,5 +117,34 @@
         <button mat-raised-button color="primary" type="button" (click)="save('piece-change')">Speichern</button>
       </div>
     </mat-tab>
+    <mat-tab label="Dienstplan">
+      <mat-form-field appearance="fill">
+        <mat-label>Betreff</mat-label>
+        <input matInput formControlName="monthlySubject" />
+      </mat-form-field>
+      <div class="editor-group">
+        <div class="editor-header">
+          <label class="editor-label">Text (HTML erlaubt)</label>
+          <mat-slide-toggle
+            class="html-toggle"
+            [checked]="monthlyHtmlMode"
+            (change)="toggleMonthlyHtml()"
+            >HTML bearbeiten</mat-slide-toggle>
+        </div>
+        <div [hidden]="monthlyHtmlMode" #monthlyEditor class="quill-editor"></div>
+        <textarea
+          *ngIf="monthlyHtmlMode"
+          class="html-editor"
+          formControlName="monthlyBody"
+        ></textarea>
+        <p class="hint">
+          Folgende Platzhalter werden ersetzt: {{'{{month}}'}}, {{'{{year}}'}}, {{'{{choir}}'}}, {{'{{link}}'}}, {{'{{date}}'}}
+        </p>
+      </div>
+      <div class="actions">
+        <button mat-raised-button color="accent" type="button" (click)="sendTest('monthly-plan')">Testmail</button>
+        <button mat-raised-button color="primary" type="button" (click)="save('monthly-plan')">Speichern</button>
+      </div>
+    </mat-tab>
   </mat-tab-group>
 </form>


### PR DESCRIPTION
## Summary
- seed database with monthly plan mail template
- use monthly plan template in email service and controller
- support editing the template in the admin UI
- mention monthly plan mails in README

## Testing
- `npm test` (frontend)
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68849041acfc8320901daea0993bf782