### PR TITLE
Load next month's plan entries in calendar

### DIFF
--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -71,9 +71,14 @@ export class MyCalendarComponent implements OnInit {
         this.auth.currentUser$.subscribe((u) => {
             this.currentUserId = u?.id || null;
             if (this.currentUserId) {
+                const year = this.selectedDate.getFullYear();
+                const month = this.selectedDate.getMonth() + 1;
+                this.loadPlanEntriesForMonth(year, month);
+
+                const next = new Date(year, month, 1);
                 this.loadPlanEntriesForMonth(
-                    this.selectedDate.getFullYear(),
-                    this.selectedDate.getMonth() + 1
+                    next.getFullYear(),
+                    next.getMonth() + 1
                 );
             }
         });


### PR DESCRIPTION
## Summary
- extend initialization of MyCalendar to pre-load plan entries for the following month

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-bridge-2.0.so.0)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68849db2adf48320a90a050410734dc4