### PR TITLE
Fix duplicate page headers

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -1,5 +1,5 @@
 <div class="form-container">
-  <app-page-header [title]="pageTitle">
+  <div class="header-actions">
     <button
       *ngIf="isEditMode && isAdmin"
       mat-stroked-button
@@ -8,7 +8,7 @@
       <mat-icon>upload_file</mat-icon>
       Import aus CSV
     </button>
-  </app-page-header>
+  </div>
   <p class="subtitle">{{ pageSubtitle }}</p>
 
   <!-- This is the main form, wrapping everything -->

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -3,6 +3,12 @@
     margin: 0 auto;
 }
 
+.header-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+}
+
 .edit-form {
     display: flex;
     flex-direction: column;

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -35,7 +35,6 @@ import { MatPaginator } from '@angular/material/paginator';
 import { PaginatorService } from '@core/services/paginator.service';
 import { MatSort } from '@angular/material/sort';
 import { Publisher } from '@core/models/publisher';
-import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 
 interface SelectedPieceWithNumber {
     piece: Piece;
@@ -51,7 +50,6 @@ interface SelectedPieceWithNumber {
         MaterialModule,
         MatAutocompleteModule,
         RouterModule,
-        PageHeaderComponent,
         PieceDialogComponent,
         ImportDialogComponent,
     ],
@@ -63,7 +61,6 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     addPieceForm: FormGroup;
     isEditMode = false;
     private collectionId: number | null = null;
-    pageTitle = 'Neue Sammlung erstellen';
     pageSubtitle =
         "Beschreibung der Sammlung, Hinzufügen von Stücken.";
     public pieceLinkColumns: string[] = ['number', 'title', 'actions'];
@@ -154,7 +151,6 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
                     if (id) {
                         this.isEditMode = true;
                         this.collectionId = +id;
-                        this.pageTitle = 'Sammlung bearbeiten';
                         this.pageSubtitle =
                             "Update the collection's details and manage its pieces.";
                         return this.apiService.getCollectionById(

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -1,12 +1,12 @@
 
-<app-page-header title="Sammlungen">
+<div class="header-actions">
   <button mat-flat-button color="accent" routerLink="/collections/new"
           [disabled]="!isChoirAdmin && !isAdmin"
           matTooltip="{{ !isChoirAdmin && !isAdmin ? 'Zum Hinzufügen müssen Sie als Chor-Administrator eingeloggt sein.' : '' }}">
     <mat-icon>add</mat-icon>
     <span>Neue Sammlung</span>
   </button>
-</app-page-header>
+</div>
 <p class="subtitle">Verwalten von globalen Sammlungen und Hinzufügen zum Chorrepertoire.</p>
 
 <div class="table-wrapper mat-elevation-z8">

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -5,6 +5,12 @@
     margin-bottom: 2rem;
 }
 
+.header-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+}
+
 .collection-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -10,7 +10,6 @@ import { Collection } from '@core/models/collection';
 import { forkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { RouterLink, Router } from '@angular/router';
-import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 import { AuthService } from '@core/services/auth.service';
 import { PaginatorService } from '@core/services/paginator.service';
 
@@ -20,8 +19,7 @@ import { PaginatorService } from '@core/services/paginator.service';
   imports: [
     CommonModule,
     MaterialModule,
-    RouterLink,
-    PageHeaderComponent
+    RouterLink
   ],
   templateUrl: './collection-list.component.html',
   styleUrls: ['./collection-list.component.scss']

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -36,12 +36,12 @@
   </mat-drawer>
   <mat-drawer-content>
     <div class="page">
-      <app-page-header title="Chorrepertoire">
+      <div class="header-actions">
         <button mat-flat-button color="primary" (click)="openAddPieceDialog()">
           <mat-icon>add</mat-icon>
           <span>Stück hinzufügen</span>
         </button>
-      </app-page-header>
+      </div>
       <div class="filter-bar">
         <button mat-icon-button (click)="drawer.toggle()" aria-label="Filter ein-/ausblenden">
           <mat-icon>filter_list</mat-icon>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.scss
@@ -6,6 +6,12 @@
   overflow: hidden;
 }
 
+.header-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
 .drawer-container {
   height: 80vh;
 }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -25,12 +25,11 @@ import { ErrorService } from '@core/services/error.service';
 import { UserPreferencesService } from '@core/services/user-preferences.service';
 import { UserPreferences } from '@core/models/user-preferences';
 import { Router, RouterModule } from '@angular/router';
-import { PageHeaderComponent } from '@shared/components/page-header/page-header.component';
 
 @Component({
   selector: 'app-literature-list',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MaterialModule, RouterModule, PageHeaderComponent],
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule, RouterModule],
   templateUrl: './literature-list.component.html',
   styleUrls: ['./literature-list.component.scss']
 })


### PR DESCRIPTION
## Summary
- remove inline page headers from several pages
- drop unused `PageHeaderComponent` imports
- keep page-specific actions using new `.header-actions` classes

## Testing
- `npx -y @angular/cli test --watch=false --no-progress` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68849d4105e88320aa36e1424bee39db