### PR TITLE
fix: remove unused dialog components

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -50,8 +50,6 @@ interface SelectedPieceWithNumber {
         MaterialModule,
         MatAutocompleteModule,
         RouterModule,
-        PieceDialogComponent,
-        ImportDialogComponent,
     ],
     templateUrl: './collection-edit.component.html',
     styleUrls: ['./collection-edit.component.scss'],

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -13,7 +13,7 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/co
 @Component({
   selector: 'app-post-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, MaterialModule, PostDialogComponent, ConfirmDialogComponent],
+  imports: [CommonModule, RouterModule, MaterialModule],
   templateUrl: './post-list.component.html'
 })
 export class PostListComponent implements OnInit {


### PR DESCRIPTION
## Summary
- remove unused dialog components from CollectionEditComponent imports
- remove unused dialog components from PostListComponent imports

## Testing
- `npm test`
- `npm run build --prefix choir-app-frontend`


------
https://chatgpt.com/codex/tasks/task_e_688f3b45e04c8320b5a85b3de9d53a64