### PR TITLE
Add library management feature

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -70,6 +70,7 @@ const planEntryRoutes = require("./routes/planEntry.routes");
 const availabilityRoutes = require("./routes/availability.routes");
 const clientErrorRoutes = require("./routes/client-error.routes");
 const postRoutes = require("./routes/post.routes");
+const libraryRoutes = require("./routes/library.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -98,6 +99,7 @@ app.use("/api/plan-entries", planEntryRoutes);
 app.use("/api/availabilities", availabilityRoutes);
 app.use("/api/client-errors", clientErrorRoutes);
 app.use("/api/posts", postRoutes);
+app.use("/api/library", libraryRoutes);
 
 app.use((err, req, res, next) => {
     logger.error(

--- a/choir-app-backend/src/controllers/library.controller.js
+++ b/choir-app-backend/src/controllers/library.controller.js
@@ -1,0 +1,51 @@
+const { parse } = require('csv-parse');
+const db = require('../models');
+const LibraryItem = db.library_item;
+const Piece = db.piece;
+
+// List all library items with piece details
+exports.findAll = async (req, res) => {
+  const items = await LibraryItem.findAll({
+    include: [{ model: Piece, as: 'piece' }]
+  });
+  res.status(200).send(items);
+};
+
+// Import library items from CSV (pieceId;copies)
+exports.importCsv = async (req, res) => {
+  if (!req.file) return res.status(400).send({ message: 'No CSV file uploaded.' });
+
+  const fileContent = req.file.buffer.toString('utf-8');
+  const parser = parse(fileContent, { delimiter: ';', columns: header => header.map(h => h.trim().toLowerCase()), skip_empty_lines: true, trim: true });
+
+  for await (const record of parser) {
+    const pieceId = parseInt(record.pieceid || record.piece_id || record.id);
+    if (!pieceId) continue;
+    const copies = record.exemplare ? parseInt(record.exemplare) : record.copies ? parseInt(record.copies) : 1;
+    await LibraryItem.create({ pieceId, copies });
+  }
+
+  res.status(200).send({ message: 'Import complete.' });
+};
+
+// Borrow an item - only directors may borrow
+exports.borrow = async (req, res) => {
+  const id = req.params.id;
+  const item = await LibraryItem.findByPk(id);
+  if (!item) return res.status(404).send({ message: 'Library item not found.' });
+
+  const returnDate = new Date();
+  returnDate.setMonth(returnDate.getMonth() + 3);
+
+  await item.update({ status: 'borrowed', availableAt: returnDate });
+  res.status(200).send(item);
+};
+
+// Return an item
+exports.returnItem = async (req, res) => {
+  const id = req.params.id;
+  const item = await LibraryItem.findByPk(id);
+  if (!item) return res.status(404).send({ message: 'Library item not found.' });
+  await item.update({ status: 'available', availableAt: null });
+  res.status(200).send(item);
+};

--- a/choir-app-backend/src/middleware/role.middleware.js
+++ b/choir-app-backend/src/middleware/role.middleware.js
@@ -40,4 +40,11 @@ async function requireChoirAdmin(req, res, next) {
     }
 }
 
-module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin };
+function requireDirector(req, res, next) {
+    if (['director', 'choir_admin', 'admin'].includes(req.userRole)) {
+        return next();
+    }
+    return res.status(403).send({ message: 'Require Director Role!' });
+}
+
+module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector };

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -40,6 +40,7 @@ db.mail_setting = require("./mail_setting.model.js")(sequelize, Sequelize);
 db.mail_template = require("./mail_template.model.js")(sequelize, Sequelize);
 db.system_setting = require("./system_setting.model.js")(sequelize, Sequelize);
 db.post = require("./post.model.js")(sequelize, Sequelize);
+db.library_item = require("./library_item.model.js")(sequelize, Sequelize);
 
 // --- Define Associations ---
 // A Choir has many Users
@@ -138,6 +139,10 @@ db.choir.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 db.user.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
+
+// Library items referencing pieces
+db.piece.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'pieceId' });
+db.library_item.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
 
 
 module.exports = db;

--- a/choir-app-backend/src/models/library_item.model.js
+++ b/choir-app-backend/src/models/library_item.model.js
@@ -1,0 +1,21 @@
+module.exports = (sequelize, DataTypes) => {
+  const LibraryItem = sequelize.define('library_item', {
+    pieceId: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    copies: {
+      type: DataTypes.INTEGER,
+      defaultValue: 1
+    },
+    status: {
+      type: DataTypes.ENUM('available', 'borrowed'),
+      defaultValue: 'available'
+    },
+    availableAt: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  });
+  return LibraryItem;
+};

--- a/choir-app-backend/src/routes/library.routes.js
+++ b/choir-app-backend/src/routes/library.routes.js
@@ -1,0 +1,16 @@
+const authJwt = require("../middleware/auth.middleware");
+const role = require("../middleware/role.middleware");
+const controller = require("../controllers/library.controller");
+const router = require("express").Router();
+const { handler: wrap } = require("../utils/async");
+const { memoryUpload } = require('../utils/upload');
+const upload = memoryUpload();
+
+router.use(authJwt.verifyToken);
+
+router.get('/', wrap(controller.findAll));
+router.post('/import', role.requireAdmin, upload.single('csvfile'), wrap(controller.importCsv));
+router.post('/:id/borrow', role.requireDirector, wrap(controller.borrow));
+router.post('/:id/return', role.requireDirector, wrap(controller.returnItem));
+
+module.exports = router;

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -130,6 +130,12 @@ export const routes: Routes = [
                 data: { title: 'Statistik' }
             },
             {
+                path: 'library',
+                loadComponent: () => import('./features/library/library.component').then(m => m.LibraryComponent),
+                canActivate: [AuthGuard],
+                data: { title: 'Bibliothek' }
+            },
+            {
                 path: 'pieces/:id',
                 component: PieceDetailComponent,
                 canActivate: [AuthGuard],

--- a/choir-app-frontend/src/app/core/models/library-item.ts
+++ b/choir-app-frontend/src/app/core/models/library-item.ts
@@ -1,0 +1,9 @@
+import { Piece } from './piece';
+
+export interface LibraryItem {
+  id: number;
+  piece?: Piece;
+  copies: number;
+  status: 'available' | 'borrowed';
+  availableAt?: string | null;
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -18,6 +18,7 @@ import { Choir } from '@core/models/choir';
 import { PlanRule } from '@core/models/plan-rule';
 import { PieceChange } from '../models/piece-change';
 import { Post } from '../models/post';
+import { LibraryItem } from '../models/library-item';
 import { PieceService } from './piece.service';
 import { ComposerService } from './composer.service';
 import { AuthorService } from './author.service';
@@ -44,6 +45,7 @@ import { AvailabilityService } from './availability.service';
 import { SearchService } from './search.service';
 import { MonthlyPlanService } from './monthly-plan.service';
 import { PostService } from './post.service';
+import { LibraryService } from './library.service';
 
 @Injectable({
   providedIn: 'root'
@@ -69,7 +71,8 @@ export class ApiService {
               private availabilityService: AvailabilityService,
               private searchService: SearchService,
               private monthlyPlanService: MonthlyPlanService,
-              private postService: PostService) {
+              private postService: PostService,
+              private libraryService: LibraryService) {
 
   }
 
@@ -477,6 +480,19 @@ export class ApiService {
 
   getRepertoirePiece(id: number): Observable<Piece> {
     return this.pieceService.getRepertoirePiece(id);
+  }
+
+  // --- Library ---
+  getLibraryItems(): Observable<LibraryItem[]> {
+    return this.libraryService.getLibraryItems();
+  }
+
+  importLibraryCsv(file: File): Observable<any> {
+    return this.libraryService.importCsv(file);
+  }
+
+  borrowLibraryItem(id: number): Observable<any> {
+    return this.libraryService.borrowItem(id);
   }
 
   getMyChoirDetails(options?: { choirId?: number }): Observable<Choir> {

--- a/choir-app-frontend/src/app/core/services/library.service.ts
+++ b/choir-app-frontend/src/app/core/services/library.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { LibraryItem } from '../models/library-item';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class LibraryService {
+  private apiUrl = `${environment.apiUrl}/library`;
+
+  constructor(private http: HttpClient) {}
+
+  getLibraryItems(): Observable<LibraryItem[]> {
+    return this.http.get<LibraryItem[]>(this.apiUrl);
+  }
+
+  importCsv(file: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('csvfile', file);
+    return this.http.post(`${this.apiUrl}/import`, formData);
+  }
+
+  borrowItem(id: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/${id}/borrow`, {});
+  }
+}

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -1,0 +1,47 @@
+<section class="library-text">
+  <p>ChorleiterInnen der NAK Nord- und Ostdeutschland können Originale der in der Inventarliste aufgeführten (Einzel-)Kompositionen ausleihen. Sammelbände/Bücher sind nur nach Absprache ausleihbar.</p>
+  <p>Ausleihe und Zusendung der Noten sind für den Entleiher kostenlos.</p>
+  <p>Der Zeitraum der Ausleihe beträgt 3 Monate und kann einmal verlängert werden. Der Entleiher verpflichtet sich zur vollständigen Rückgabe der entliehenen Exemplare bzw. sorgt bei Verlust für Ersatz.</p>
+  <p>Die Nutzer dürfen im probenüblichen Umfang Notizen mit Bleistift in die Noten eintragen.</p>
+  <p>Die Anfrage zur Ausleihe erfolgt per E-Mail an chorbibliothek@nak-nordost.de und enthält mindestens folgende Angaben:</p>
+  <ul>
+    <li>Name des Entleihers</li>
+    <li>Telefonnummer</li>
+    <li>Gemeinde/Bezirk</li>
+    <li>gewünschte/r Titel</li>
+    <li>Anzahl benötigter Exemplare</li>
+    <li>Lieferadresse</li>
+    <li>Grund der Ausleihe (z.B. Konzert, Jugendfreizeit)</li>
+  </ul>
+  <p>Hinweis: Dadurch, dass eine Komposition in unserer Notenbibliothek ausleihbar ist, ist keine Ableitung zur "automatischen Eignung" für spezielle Anlässe (Gottesdienst, Konzert, Freizeiten…) möglich. Die Verwendung dieser Literatur erfolgt genauso wie bei allen anderen Notenmaterialien, die nicht von der NAK herausgegeben wurden.</p>
+</section>
+
+<div *ngIf="isAdmin" class="import-section">
+  <input type="file" (change)="onFileChange($event)" />
+  <button mat-raised-button color="primary" (click)="upload()" [disabled]="!selectedFile">CSV importieren</button>
+</div>
+
+<table mat-table [dataSource]="items$ | async" class="mat-elevation-z8" *ngIf="items$ | async">
+  <ng-container matColumnDef="title">
+    <th mat-header-cell *matHeaderCellDef>Titel</th>
+    <td mat-cell *matCellDef="let element">{{element.piece?.title}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="copies">
+    <th mat-header-cell *matHeaderCellDef>Exemplare</th>
+    <td mat-cell *matCellDef="let element">{{element.copies}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="status">
+    <th mat-header-cell *matHeaderCellDef>Status</th>
+    <td mat-cell *matCellDef="let element">{{element.status}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="availableAt">
+    <th mat-header-cell *matHeaderCellDef>Verfügbar ab</th>
+    <td mat-cell *matCellDef="let element">{{element.availableAt | date}}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/library/library.component.scss
+++ b/choir-app-frontend/src/app/features/library/library.component.scss
@@ -1,0 +1,7 @@
+.library-text {
+  margin-bottom: 1rem;
+}
+
+.import-section {
+  margin: 1rem 0;
+}

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { LibraryItem } from '@core/models/library-item';
+import { Observable } from 'rxjs';
+import { AuthService } from '@core/services/auth.service';
+
+@Component({
+  selector: 'app-library',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './library.component.html',
+  styleUrls: ['./library.component.scss']
+})
+export class LibraryComponent implements OnInit {
+  items$!: Observable<LibraryItem[]>;
+  selectedFile: File | null = null;
+  isAdmin = false;
+  displayedColumns: string[] = ['title', 'copies', 'status', 'availableAt'];
+
+  constructor(private api: ApiService, private auth: AuthService) {}
+
+  ngOnInit(): void {
+    this.load();
+    this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
+  }
+
+  load(): void {
+    this.items$ = this.api.getLibraryItems();
+  }
+
+  onFileChange(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      this.selectedFile = file;
+    }
+  }
+
+  upload(): void {
+    if (this.selectedFile) {
+      this.api.importLibraryCsv(this.selectedFile).subscribe(() => this.load());
+    }
+  }
+}

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -246,6 +246,11 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
         visibleSubject: this.isLoggedIn$,
       },
       {
+        displayName: 'Bibliothek',
+        route: '/library',
+        visibleSubject: this.isLoggedIn$,
+      },
+      {
         displayName: 'Administration',
         //svgIconName: 's-settings',
         visibleSubject: this.isAdmin$,


### PR DESCRIPTION
## Summary
- add API and database model for library items with CSV import and borrow endpoints
- create Bibliothek page with required borrowing information and CSV upload
- integrate library page into routing and navigation

## Testing
- `cd choir-app-backend && npm test`
- `cd choir-app-frontend && npm test` *(fails: cannot start ChromeHeadless due to missing libXcomposite.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_688f453d6aec8320aa0541e55f8fdf3a