### PR TITLE
Show file and external links on piece detail page

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -16,16 +16,24 @@
       </li>
     </ul>
   </div>
-  <div *ngIf="pieceImage || piece.links?.length">
+  <div *ngIf="pieceImage || fileLinks.length || externalLinks.length">
     <div *ngIf="pieceImage" class="sheet-image">
       <h3>Notenbild</h3>
       <img [src]="pieceImage" alt="Notenbild" />
     </div>
-    <div *ngIf="piece.links?.length">
+    <div *ngIf="fileLinks.length">
+      <h3>Dateien</h3>
+      <ul>
+        <li *ngFor="let link of fileLinks">
+          <a [href]="getLinkUrl(link)" target="_blank" rel="noopener">{{ link.description }}</a>
+        </li>
+      </ul>
+    </div>
+    <div *ngIf="externalLinks.length">
       <h3>Links</h3>
       <ul>
-        <li *ngFor="let link of piece.links">
-          <a [href]="link.url" target="_blank" rel="noopener">{{ link.description }}</a>
+        <li *ngFor="let link of externalLinks">
+          <a [href]="getLinkUrl(link)" target="_blank" rel="noopener">{{ link.description }}</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Display file downloads and external sources separately on piece detail view
- Build absolute URLs for relative link paths

## Testing
- `npm test --prefix choir-app-frontend`
- `npm run check --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_688f512a96b88320bd15561ac2116d14