### PR TITLE
fix: handle empty library data for mat-table

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -21,27 +21,29 @@
   <button mat-raised-button color="primary" (click)="upload()" [disabled]="!selectedFile">CSV importieren</button>
 </div>
 
-<table mat-table [dataSource]="items$ | async" class="mat-elevation-z8" *ngIf="items$ | async">
-  <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef>Titel</th>
-    <td mat-cell *matCellDef="let element">{{element.piece?.title}}</td>
-  </ng-container>
+<ng-container *ngIf="items$ | async as items">
+  <table mat-table [dataSource]="items" class="mat-elevation-z8">
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef>Titel</th>
+      <td mat-cell *matCellDef="let element">{{element.piece?.title}}</td>
+    </ng-container>
 
-  <ng-container matColumnDef="copies">
-    <th mat-header-cell *matHeaderCellDef>Exemplare</th>
-    <td mat-cell *matCellDef="let element">{{element.copies}}</td>
-  </ng-container>
+    <ng-container matColumnDef="copies">
+      <th mat-header-cell *matHeaderCellDef>Exemplare</th>
+      <td mat-cell *matCellDef="let element">{{element.copies}}</td>
+    </ng-container>
 
-  <ng-container matColumnDef="status">
-    <th mat-header-cell *matHeaderCellDef>Status</th>
-    <td mat-cell *matCellDef="let element">{{element.status}}</td>
-  </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let element">{{element.status}}</td>
+    </ng-container>
 
-  <ng-container matColumnDef="availableAt">
-    <th mat-header-cell *matHeaderCellDef>Verfügbar ab</th>
-    <td mat-cell *matCellDef="let element">{{element.availableAt | date}}</td>
-  </ng-container>
+    <ng-container matColumnDef="availableAt">
+      <th mat-header-cell *matHeaderCellDef>Verfügbar ab</th>
+      <td mat-cell *matCellDef="let element">{{element.availableAt | date}}</td>
+    </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</ng-container>


### PR DESCRIPTION
## Summary
- guard against null library items in table by using ng-container and binding to resolved items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f523b0770832084eae0acc6ea57fa