### PR TITLE
feat(library): allow admin to add collection items

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js",
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js",
     "check": "node --check server.js",
     "init": "node scripts/init.js",
     "seed": "node scripts/seed.js"

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -143,6 +143,9 @@ db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
 // Library items referencing pieces
 db.piece.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'pieceId' });
 db.library_item.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
+// Library items referencing collections
+db.collection.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'collectionId' });
+db.library_item.belongsTo(db.collection, { foreignKey: 'collectionId', as: 'collection' });
 
 
 module.exports = db;

--- a/choir-app-backend/src/models/library_item.model.js
+++ b/choir-app-backend/src/models/library_item.model.js
@@ -4,6 +4,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: false
     },
+    collectionId: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
     copies: {
       type: DataTypes.INTEGER,
       defaultValue: 1

--- a/choir-app-backend/src/routes/library.routes.js
+++ b/choir-app-backend/src/routes/library.routes.js
@@ -5,10 +5,13 @@ const router = require("express").Router();
 const { handler: wrap } = require("../utils/async");
 const { memoryUpload } = require('../utils/upload');
 const upload = memoryUpload();
+const { createLibraryItemValidation } = require("../validators/library.validation");
+const validate = require("../validators/validate");
 
 router.use(authJwt.verifyToken);
 
 router.get('/', wrap(controller.findAll));
+router.post('/', role.requireAdmin, createLibraryItemValidation, validate, wrap(controller.create));
 router.post('/import', role.requireAdmin, upload.single('csvfile'), wrap(controller.importCsv));
 router.post('/:id/borrow', role.requireDirector, wrap(controller.borrow));
 router.post('/:id/return', role.requireDirector, wrap(controller.returnItem));

--- a/choir-app-backend/src/validators/library.validation.js
+++ b/choir-app-backend/src/validators/library.validation.js
@@ -1,0 +1,9 @@
+const { body } = require('express-validator');
+
+exports.createLibraryItemValidation = [
+  body('pieceId').isInt().withMessage('pieceId must be an integer'),
+  body('collectionId').isInt().withMessage('collectionId must be an integer'),
+  body('copies').isInt({ min: 1 }).withMessage('copies must be an integer'),
+  body('isBorrowed').optional().isBoolean().withMessage('isBorrowed must be a boolean')
+];
+

--- a/choir-app-backend/tests/library.controller.test.js
+++ b/choir-app-backend/tests/library.controller.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/library.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+
+    const piece = await db.piece.create({ title: 'Test Piece' });
+    const collection = await db.collection.create({ title: 'Test Collection' });
+    await collection.addPiece(piece, { through: { numberInCollection: '1' } });
+
+    const res = {
+      status(code) { this.statusCode = code; return this; },
+      send(data) { this.data = data; }
+    };
+
+    await controller.create({ body: { pieceId: piece.id, collectionId: collection.id, copies: 2, isBorrowed: true } }, res);
+    assert.strictEqual(res.statusCode, 201);
+    assert.strictEqual(res.data.collectionId, collection.id);
+    assert.strictEqual(res.data.copies, 2);
+    assert.strictEqual(res.data.status, 'borrowed');
+
+    const listRes = {
+      status(code) { this.statusCode = code; return this; },
+      send(data) { this.data = data; }
+    };
+    await controller.findAll({}, listRes);
+    assert.strictEqual(listRes.statusCode, 200);
+    assert.strictEqual(listRes.data.length, 1);
+    assert.strictEqual(listRes.data[0].collection.id, collection.id);
+
+    console.log('library.controller tests passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();
+

--- a/choir-app-frontend/src/app/core/models/library-item.ts
+++ b/choir-app-frontend/src/app/core/models/library-item.ts
@@ -1,8 +1,11 @@
 import { Piece } from './piece';
+import { Collection } from './collection';
 
 export interface LibraryItem {
   id: number;
   piece?: Piece;
+  collection?: Collection;
+  collectionId?: number;
   copies: number;
   status: 'available' | 'borrowed';
   availableAt?: string | null;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -491,6 +491,10 @@ export class ApiService {
     return this.libraryService.importCsv(file);
   }
 
+  addLibraryItem(data: { pieceId: number; collectionId: number; copies: number; isBorrowed?: boolean }): Observable<LibraryItem> {
+    return this.libraryService.addItem(data);
+  }
+
   borrowLibraryItem(id: number): Observable<any> {
     return this.libraryService.borrowItem(id);
   }

--- a/choir-app-frontend/src/app/core/services/library.service.ts
+++ b/choir-app-frontend/src/app/core/services/library.service.ts
@@ -20,6 +20,10 @@ export class LibraryService {
     return this.http.post(`${this.apiUrl}/import`, formData);
   }
 
+  addItem(data: { pieceId: number; collectionId: number; copies: number; isBorrowed?: boolean }): Observable<LibraryItem> {
+    return this.http.post<LibraryItem>(this.apiUrl, data);
+  }
+
   borrowItem(id: number): Observable<any> {
     return this.http.post(`${this.apiUrl}/${id}/borrow`, {});
   }

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -19,6 +19,23 @@
 <div *ngIf="isAdmin" class="import-section">
   <input type="file" (change)="onFileChange($event)" />
   <button mat-raised-button color="primary" (click)="upload()" [disabled]="!selectedFile">CSV importieren</button>
+
+  <form [formGroup]="form" class="add-form">
+    <mat-form-field>
+      <mat-label>Sammlung ID</mat-label>
+      <input matInput type="number" formControlName="collectionId">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Stück ID</mat-label>
+      <input matInput type="number" formControlName="pieceId">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Exemplare</mat-label>
+      <input matInput type="number" formControlName="copies">
+    </mat-form-field>
+    <mat-checkbox formControlName="isBorrowed">Entliehen</mat-checkbox>
+    <button mat-raised-button color="primary" (click)="add()" [disabled]="form.invalid">Hinzufügen</button>
+  </form>
 </div>
 
 <ng-container *ngIf="items$ | async as items">


### PR DESCRIPTION
## Summary
- extend library items with collection references
- allow admins to create library items with copy counts and borrow state
- add frontend form and services for adding collection pieces

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f57953f64832085c6391efe59a517