### PR TITLE
Display composer names in collection pieces

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -141,7 +141,10 @@
             <!-- Title Column Definition -->
             <ng-container matColumnDef="title">
               <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
-              <td mat-cell *matCellDef="let link"> {{link.piece.title}} </td>
+              <td mat-cell *matCellDef="let link">
+                <div>{{ link.piece.title }}</div>
+                <div class="composer" *ngIf="link.piece.composer?.name">{{ link.piece.composer.name }}</div>
+              </td>
             </ng-container>
 
             <!-- Actions Column Definition -->

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -24,6 +24,11 @@ mat-form-field {
   font-style: italic;
 }
 
+.piece-link-table .composer {
+  color: #666;
+  font-size: 0.9em;
+}
+
 mat-chip-listbox {
     margin-top: 1rem;
     display: block;


### PR DESCRIPTION
## Summary
- Show each piece's composer in gray under the title within collection edit view
- Style composer text with smaller gray font

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f64cfbb78832096798880f22b6584