### PR TITLE
feat(library): add dialog for adding items

### DIFF
--- a/choir-app-frontend/src/app/features/library/library-item-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-item-dialog.component.html
@@ -1,0 +1,26 @@
+<h1 mat-dialog-title>Stück hinzufügen</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" class="add-form">
+    <mat-form-field>
+      <mat-label>Sammlung</mat-label>
+      <mat-select formControlName="collectionId">
+        <mat-option *ngFor="let c of collections$ | async" [value]="c.id">
+          {{ c.title }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Stück ID</mat-label>
+      <input matInput type="number" formControlName="pieceId" />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Exemplare</mat-label>
+      <input matInput type="number" formControlName="copies" />
+    </mat-form-field>
+    <mat-checkbox formControlName="isBorrowed">Entliehen</mat-checkbox>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-raised-button color="primary" (click)="save()" [disabled]="form.invalid">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/library/library-item-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/library/library-item-dialog.component.ts
@@ -1,0 +1,42 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { Collection } from '@core/models/collection';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-library-item-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MaterialModule],
+  templateUrl: './library-item-dialog.component.html'
+})
+export class LibraryItemDialogComponent {
+  form: FormGroup;
+  collections$!: Observable<Collection[]>;
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<LibraryItemDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { collections$: Observable<Collection[]> }
+  ) {
+    this.collections$ = data.collections$;
+    this.form = this.fb.group({
+      pieceId: [null, Validators.required],
+      collectionId: [null, Validators.required],
+      copies: [1, [Validators.required, Validators.min(1)]],
+      isBorrowed: [false]
+    });
+  }
+
+  save(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -19,27 +19,7 @@
 <div *ngIf="isAdmin" class="import-section">
   <input type="file" (change)="onFileChange($event)" />
   <button mat-raised-button color="primary" (click)="upload()" [disabled]="!selectedFile">CSV importieren</button>
-
-  <form [formGroup]="form" class="add-form">
-    <mat-form-field>
-      <mat-label>Sammlung</mat-label>
-      <mat-select formControlName="collectionId">
-        <mat-option *ngFor="let c of collections$ | async" [value]="c.id">
-          {{ c.title }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>Stück ID</mat-label>
-      <input matInput type="number" formControlName="pieceId">
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>Exemplare</mat-label>
-      <input matInput type="number" formControlName="copies">
-    </mat-form-field>
-    <mat-checkbox formControlName="isBorrowed">Entliehen</mat-checkbox>
-    <button mat-raised-button color="primary" (click)="add()" [disabled]="form.invalid">Hinzufügen</button>
-  </form>
+  <button mat-raised-button color="accent" (click)="openAddDialog()">Stück hinzufügen</button>
 </div>
 
 <ng-container *ngIf="items$ | async as items">


### PR DESCRIPTION
## Summary
- replace inline library add form with modal dialog
- implement `LibraryItemDialogComponent` for library item input

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_688fc135e858832082ae9c22b920ae93