### PR TITLE
Remove piece ID from library items

### DIFF
--- a/choir-app-backend/src/controllers/library.controller.js
+++ b/choir-app-backend/src/controllers/library.controller.js
@@ -4,12 +4,15 @@ const LibraryItem = db.library_item;
 const Piece = db.piece;
 const Collection = db.collection;
 
-// List all library items with piece details
+// List all library items with collection details
 exports.findAll = async (req, res) => {
   const items = await LibraryItem.findAll({
     include: [
-      { model: Piece, as: 'piece' },
-      { model: Collection, as: 'collection' }
+      {
+        model: Collection,
+        as: 'collection',
+        include: [{ model: Piece, through: { attributes: ['numberInCollection'] } }]
+      }
     ]
   });
   res.status(200).send(items);
@@ -17,19 +20,12 @@ exports.findAll = async (req, res) => {
 
 // Create a library item referencing a collection
 exports.create = async (req, res) => {
-  const { pieceId, collectionId, copies = 1, isBorrowed = false } = req.body;
-
-  const piece = await Piece.findByPk(pieceId);
-  if (!piece) return res.status(404).send({ message: 'Piece not found.' });
+  const { collectionId, copies = 1, isBorrowed = false } = req.body;
 
   const collection = await Collection.findByPk(collectionId);
   if (!collection) return res.status(404).send({ message: 'Collection not found.' });
 
-  const hasPiece = await collection.hasPiece(piece);
-  if (!hasPiece) return res.status(400).send({ message: 'Piece not part of collection.' });
-
   const item = await LibraryItem.create({
-    pieceId,
     collectionId,
     copies,
     status: isBorrowed ? 'borrowed' : 'available'
@@ -38,7 +34,7 @@ exports.create = async (req, res) => {
   res.status(201).send(item);
 };
 
-// Import library items from CSV (pieceId;copies)
+// Import library items from CSV (collectionId;copies)
 exports.importCsv = async (req, res) => {
   if (!req.file) return res.status(400).send({ message: 'No CSV file uploaded.' });
 
@@ -46,10 +42,10 @@ exports.importCsv = async (req, res) => {
   const parser = parse(fileContent, { delimiter: ';', columns: header => header.map(h => h.trim().toLowerCase()), skip_empty_lines: true, trim: true });
 
   for await (const record of parser) {
-    const pieceId = parseInt(record.pieceid || record.piece_id || record.id);
-    if (!pieceId) continue;
+    const collectionId = parseInt(record.collectionid || record.collection_id || record.id);
+    if (!collectionId) continue;
     const copies = record.exemplare ? parseInt(record.exemplare) : record.copies ? parseInt(record.copies) : 1;
-    await LibraryItem.create({ pieceId, copies });
+    await LibraryItem.create({ collectionId, copies });
   }
 
   res.status(200).send({ message: 'Import complete.' });

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -140,9 +140,6 @@ db.post.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 db.user.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
 
-// Library items referencing pieces
-db.piece.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'pieceId' });
-db.library_item.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
 // Library items referencing collections
 db.collection.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'collectionId' });
 db.library_item.belongsTo(db.collection, { foreignKey: 'collectionId', as: 'collection' });

--- a/choir-app-backend/src/models/library_item.model.js
+++ b/choir-app-backend/src/models/library_item.model.js
@@ -1,9 +1,5 @@
 module.exports = (sequelize, DataTypes) => {
   const LibraryItem = sequelize.define('library_item', {
-    pieceId: {
-      type: DataTypes.INTEGER,
-      allowNull: false
-    },
     collectionId: {
       type: DataTypes.INTEGER,
       allowNull: true

--- a/choir-app-backend/src/validators/library.validation.js
+++ b/choir-app-backend/src/validators/library.validation.js
@@ -1,7 +1,6 @@
 const { body } = require('express-validator');
 
 exports.createLibraryItemValidation = [
-  body('pieceId').isInt().withMessage('pieceId must be an integer'),
   body('collectionId').isInt().withMessage('collectionId must be an integer'),
   body('copies').isInt({ min: 1 }).withMessage('copies must be an integer'),
   body('isBorrowed').optional().isBoolean().withMessage('isBorrowed must be a boolean')

--- a/choir-app-backend/tests/library.controller.test.js
+++ b/choir-app-backend/tests/library.controller.test.js
@@ -19,7 +19,7 @@ const controller = require('../src/controllers/library.controller');
       send(data) { this.data = data; }
     };
 
-    await controller.create({ body: { pieceId: piece.id, collectionId: collection.id, copies: 2, isBorrowed: true } }, res);
+    await controller.create({ body: { collectionId: collection.id, copies: 2, isBorrowed: true } }, res);
     assert.strictEqual(res.statusCode, 201);
     assert.strictEqual(res.data.collectionId, collection.id);
     assert.strictEqual(res.data.copies, 2);
@@ -33,6 +33,8 @@ const controller = require('../src/controllers/library.controller');
     assert.strictEqual(listRes.statusCode, 200);
     assert.strictEqual(listRes.data.length, 1);
     assert.strictEqual(listRes.data[0].collection.id, collection.id);
+    assert.strictEqual(listRes.data[0].collection.pieces.length, 1);
+    assert.strictEqual(listRes.data[0].collection.pieces[0].id, piece.id);
 
     console.log('library.controller tests passed');
     await db.sequelize.close();

--- a/choir-app-frontend/src/app/core/models/library-item.ts
+++ b/choir-app-frontend/src/app/core/models/library-item.ts
@@ -1,9 +1,7 @@
-import { Piece } from './piece';
 import { Collection } from './collection';
 
 export interface LibraryItem {
   id: number;
-  piece?: Piece;
   collection?: Collection;
   collectionId?: number;
   copies: number;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -491,7 +491,7 @@ export class ApiService {
     return this.libraryService.importCsv(file);
   }
 
-  addLibraryItem(data: { pieceId: number; collectionId: number; copies: number; isBorrowed?: boolean }): Observable<LibraryItem> {
+  addLibraryItem(data: { collectionId: number; copies: number; isBorrowed?: boolean }): Observable<LibraryItem> {
     return this.libraryService.addItem(data);
   }
 

--- a/choir-app-frontend/src/app/core/services/library.service.ts
+++ b/choir-app-frontend/src/app/core/services/library.service.ts
@@ -20,7 +20,7 @@ export class LibraryService {
     return this.http.post(`${this.apiUrl}/import`, formData);
   }
 
-  addItem(data: { pieceId: number; collectionId: number; copies: number; isBorrowed?: boolean }): Observable<LibraryItem> {
+  addItem(data: { collectionId: number; copies: number; isBorrowed?: boolean }): Observable<LibraryItem> {
     return this.http.post<LibraryItem>(this.apiUrl, data);
   }
 

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -30,10 +30,6 @@
       </mat-select>
     </mat-form-field>
     <mat-form-field>
-      <mat-label>Stück ID</mat-label>
-      <input matInput type="number" formControlName="pieceId">
-    </mat-form-field>
-    <mat-form-field>
       <mat-label>Exemplare</mat-label>
       <input matInput type="number" formControlName="copies">
     </mat-form-field>
@@ -46,7 +42,7 @@
   <table mat-table [dataSource]="items" class="mat-elevation-z8">
     <ng-container matColumnDef="title">
       <th mat-header-cell *matHeaderCellDef>Titel</th>
-      <td mat-cell *matCellDef="let element">{{element.piece?.title}}</td>
+      <td mat-cell *matCellDef="let element">{{element.collection?.title}}</td>
     </ng-container>
 
     <ng-container matColumnDef="copies">

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -30,7 +30,6 @@ export class LibraryComponent implements OnInit {
     this.collections$ = this.api.getCollections();
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
     this.form = this.fb.group({
-      pieceId: [null, Validators.required],
       collectionId: [null, Validators.required],
       copies: [1, [Validators.required, Validators.min(1)]],
       isBorrowed: [false]


### PR DESCRIPTION
## Summary
- remove `pieceId` from library items and link them solely to collections
- adjust controllers, validation, and CSV import accordingly
- update Angular services and components to work without `pieceId`

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc0e1c0e4832088fb9b9bfbbc1b5d