### PR TITLE
Improve collection import error feedback

### DIFF
--- a/choir-app-backend/src/controllers/import.controller.js
+++ b/choir-app-backend/src/controllers/import.controller.js
@@ -163,7 +163,13 @@ exports.startImportCsvToCollection = async (req, res) => {
     const records = [];
     try {
         for await (const record of parser) { records.push(record); }
-    } catch (e) { return res.status(400).send({ message: 'Could not parse CSV file.' }); }
+    } catch (e) {
+        return res.status(400).send({
+            message: 'Could not parse CSV file.',
+            detail: e.message,
+            hint: "Check that the file uses ';' as separator and contains headers: nummer; titel; komponist; kategorie."
+        });
+    }
 
     // Vorschau-Modus bleibt synchron
     if (req.query.mode === 'preview') {

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
@@ -46,8 +46,8 @@
   </ng-container>
 
   <!-- Zeigen Sie das Log-Fenster an, sobald der Import gestartet wurde -->
-  <div *ngIf="isImporting" class="log-area">
-    <h3>Import läuft...</h3>
+  <div *ngIf="isImporting || importLogs.length > 0" class="log-area">
+    <h3>{{ isImporting ? 'Import läuft...' : 'Importprotokoll' }}</h3>
     <textarea readonly class="log-textarea">{{ importLogs.join('\n') }}</textarea>
   </div>
 </div>

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.ts
@@ -53,7 +53,12 @@ export class ImportDialogComponent implements OnDestroy {
         this.isLoading = false;
       },
       error: (err) => {
-        this.snackBar.open(`Fehler beim Laden der Vorschau: ${err.error?.message || 'Unbekannter Fehler'}`, 'Schließen');
+        const detail = err.error?.detail ? ` - ${err.error.detail}` : '';
+        const hint = err.error?.hint ? ` (${err.error.hint})` : '';
+        this.snackBar.open(
+          `Fehler beim Laden der Vorschau: ${err.error?.message || 'Unbekannter Fehler'}${detail}${hint}`,
+          'Schließen'
+        );
         this.isLoading = false;
       }
     });
@@ -72,7 +77,12 @@ export class ImportDialogComponent implements OnDestroy {
         this.pollStatus(response.jobId);
       },
       error: (err) => {
-        this.snackBar.open(`Import konnte nicht gestartet werden: ${err.error?.message || 'Unbekannter Fehler'}`, 'Schließen');
+        const detail = err.error?.detail ? ` - ${err.error.detail}` : '';
+        const hint = err.error?.hint ? ` (${err.error.hint})` : '';
+        this.snackBar.open(
+          `Import konnte nicht gestartet werden: ${err.error?.message || 'Unbekannter Fehler'}${detail}${hint}`,
+          'Schließen'
+        );
         this.isLoading = false;
         this.isImporting = false;
       }
@@ -114,6 +124,9 @@ export class ImportDialogComponent implements OnDestroy {
           this.snackBar.open(finalMessage, 'OK', { duration: 7000 });
           this.dialogRef.close(true); // Schließen und Erfolg signalisieren
         } else if (job.status === 'failed') {
+          if (job.error) {
+            this.importLogs = [...this.importLogs, `ERROR: ${job.error}`];
+          }
           this.snackBar.open(`Import fehlgeschlagen: ${job.error}`, 'Schließen');
           this.isImporting = false;
         }


### PR DESCRIPTION
## Summary
- return detailed parse errors with hints when importing pieces CSV
- surface backend error details in import dialog and keep logs visible after failures

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fc7e3eb9083208af2b3768de30a6f