### PR TITLE
fix: add collections to library via dialog

### DIFF
--- a/choir-app-frontend/src/app/features/library/library-item-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-item-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>Stück hinzufügen</h1>
+<h1 mat-dialog-title>Sammlung hinzufügen</h1>
 <div mat-dialog-content>
   <form [formGroup]="form" class="add-form">
     <mat-form-field>
@@ -8,10 +8,6 @@
           {{ c.title }}
         </mat-option>
       </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>Stück ID</mat-label>
-      <input matInput type="number" formControlName="pieceId" />
     </mat-form-field>
     <mat-form-field>
       <mat-label>Exemplare</mat-label>

--- a/choir-app-frontend/src/app/features/library/library-item-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/library/library-item-dialog.component.ts
@@ -23,7 +23,6 @@ export class LibraryItemDialogComponent {
   ) {
     this.collections$ = data.collections$;
     this.form = this.fb.group({
-      pieceId: [null, Validators.required],
       collectionId: [null, Validators.required],
       copies: [1, [Validators.required, Validators.min(1)]],
       isBorrowed: [false]


### PR DESCRIPTION
## Summary
- remove piece ID field from library add dialog so collections can be added directly
- update library dialog text to reflect collection additions

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_688fca5755bc83208c9cff7e3cacd637