### PR TITLE
feat: show collection contents in library

### DIFF
--- a/choir-app-frontend/src/app/features/library/library-collection-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-collection-dialog.component.html
@@ -1,0 +1,11 @@
+<h1 mat-dialog-title>{{ collection.title }}</h1>
+<div mat-dialog-content>
+  <mat-nav-list>
+    <a mat-list-item *ngFor="let piece of collection.pieces" [routerLink]="['/pieces', piece.id]" (click)="dialogRef.close()">
+      {{ piece.title }}
+    </a>
+  </mat-nav-list>
+</div>
+<div mat-dialog-actions>
+  <button mat-button mat-dialog-close>Schließen</button>
+</div>

--- a/choir-app-frontend/src/app/features/library/library-collection-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/library/library-collection-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { Collection } from '@core/models/collection';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-library-collection-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, MatDialogModule, RouterLink],
+  templateUrl: './library-collection-dialog.component.html'
+})
+export class LibraryCollectionDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public collection: Collection, public dialogRef: MatDialogRef<LibraryCollectionDialogComponent>) {}
+}
+

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -45,6 +45,6 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" class="clickable-row"></tr>
   </table>
 </ng-container>

--- a/choir-app-frontend/src/app/features/library/library.component.scss
+++ b/choir-app-frontend/src/app/features/library/library.component.scss
@@ -5,3 +5,7 @@
 .import-section {
   margin: 1rem 0;
 }
+
+.clickable-row {
+  cursor: pointer;
+}

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -7,7 +7,9 @@ import { Collection } from '@core/models/collection';
 import { Observable } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
 import { LibraryItemDialogComponent } from './library-item-dialog.component';
+import { LibraryCollectionDialogComponent } from './library-collection-dialog.component';
 
 @Component({
   selector: 'app-library',
@@ -23,7 +25,7 @@ export class LibraryComponent implements OnInit {
   isAdmin = false;
   displayedColumns: string[] = ['title', 'copies', 'status', 'availableAt'];
   
-  constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog) {}
+  constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private router: Router) {}
 
   ngOnInit(): void {
     this.load();
@@ -53,6 +55,19 @@ export class LibraryComponent implements OnInit {
     ref.afterClosed().subscribe(result => {
       if (result) {
         this.api.addLibraryItem(result).subscribe(() => this.load());
+      }
+    });
+  }
+
+  openCollection(item: LibraryItem): void {
+    const colId = item.collection?.id;
+    if (!colId) return;
+
+    this.api.getCollectionById(colId).subscribe(col => {
+      if ((col.singleEdition || (col.pieces && col.pieces.length === 1)) && col.pieces && col.pieces.length === 1) {
+        this.router.navigate(['/pieces', col.pieces[0].id]);
+      } else if (col.pieces && col.pieces.length > 0) {
+        this.dialog.open(LibraryCollectionDialogComponent, { data: col });
       }
     });
   }


### PR DESCRIPTION
## Summary
- make library table rows clickable and show collection pieces
- show piece details directly when collection contains only one piece
- add dialog component to list pieces of a collection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689031ca296083208c4a482c7385d1d2