### PR TITLE
feat: filter statistics by date range

### DIFF
--- a/choir-app-backend/src/controllers/stats.controller.js
+++ b/choir-app-backend/src/controllers/stats.controller.js
@@ -1,8 +1,19 @@
 const db = require("../models");
-const { Sequelize } = require("sequelize");
+const { Sequelize, Op } = require("sequelize");
 
 exports.overview = async (req, res) => {
     const choirId = req.activeChoirId;
+    const { startDate, endDate } = req.query;
+    const dateWhere = {};
+    if (startDate || endDate) {
+        dateWhere.date = {};
+        if (startDate) {
+            dateWhere.date[Op.gte] = new Date(startDate);
+        }
+        if (endDate) {
+            dateWhere.date[Op.lte] = new Date(endDate);
+        }
+    }
     try {
         // Top pieces in services
         const topServicePieces = await db.piece.findAll({
@@ -14,7 +25,7 @@ exports.overview = async (req, res) => {
             include: [{
                 model: db.event,
                 attributes: [],
-                where: { choirId, type: 'SERVICE' },
+                where: { choirId, type: 'SERVICE', ...dateWhere },
                 through: { attributes: [] }
             }],
             group: ['piece.id'],
@@ -33,7 +44,7 @@ exports.overview = async (req, res) => {
             include: [{
                 model: db.event,
                 attributes: [],
-                where: { choirId, type: 'REHEARSAL' },
+                where: { choirId, type: 'REHEARSAL', ...dateWhere },
                 through: { attributes: [] }
             }],
             group: ['piece.id'],

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -108,8 +108,15 @@ export class AdminService {
     return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
   }
 
-  getStatistics(): Observable<StatsSummary> {
-    return this.http.get<StatsSummary>(`${this.apiUrl}/stats`);
+  getStatistics(startDate?: Date | string, endDate?: Date | string): Observable<StatsSummary> {
+    const params: any = {};
+    if (startDate) {
+      params.startDate = startDate instanceof Date ? startDate.toISOString() : startDate;
+    }
+    if (endDate) {
+      params.endDate = endDate instanceof Date ? endDate.toISOString() : endDate;
+    }
+    return this.http.get<StatsSummary>(`${this.apiUrl}/stats`, { params });
   }
 
   getMailSettings(): Observable<MailSettings> {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -681,8 +681,8 @@ export class ApiService {
     return this.adminService.checkChoirAdminStatus();
   }
 
-  getStatistics(): Observable<StatsSummary> {
-    return this.adminService.getStatistics();
+  getStatistics(startDate?: Date, endDate?: Date): Observable<StatsSummary> {
+    return this.adminService.getStatistics(startDate, endDate);
   }
 
   pingBackend(): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -1,27 +1,47 @@
-<div class="stats-page" *ngIf="stats">
+<div class="stats-page">
   <h2>Statistik</h2>
 
-  <mat-card>
-    <h3>Top 3 Gottesdienst-Stücke</h3>
-    <ol>
-      <li *ngFor="let item of stats.topServicePieces">
-        <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
-      </li>
-    </ol>
-  </mat-card>
+  <div class="date-controls">
+    <mat-form-field appearance="fill">
+      <mat-label>Von</mat-label>
+      <input matInput [matDatepicker]="startPicker" [(ngModel)]="startDate" />
+      <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+      <mat-datepicker #startPicker></mat-datepicker>
+    </mat-form-field>
 
-  <mat-card>
-    <h3>Meist geprobte Stücke</h3>
-    <ol>
-      <li *ngFor="let item of stats.topRehearsalPieces">
-        <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
-      </li>
-    </ol>
-  </mat-card>
+    <mat-form-field appearance="fill">
+      <mat-label>Bis</mat-label>
+      <input matInput [matDatepicker]="endPicker" [(ngModel)]="endDate" />
+      <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+      <mat-datepicker #endPicker></mat-datepicker>
+    </mat-form-field>
 
-  <mat-card>
-    <h3>Stücke im Repertoire</h3>
-    <p>Singfähig: {{stats.singableCount}}</p>
-    <p>Probe: {{stats.rehearsalCount}}</p>
-  </mat-card>
+    <button mat-raised-button color="primary" (click)="loadStats()">Statistik laden</button>
+  </div>
+
+  <ng-container *ngIf="stats">
+    <mat-card>
+      <h3>Top 3 Gottesdienst-Stücke</h3>
+      <ol>
+        <li *ngFor="let item of stats.topServicePieces">
+          <a [routerLink]="['/pieces', item.id]">{{ item.title }}</a> ({{ item.count }}x)
+        </li>
+      </ol>
+    </mat-card>
+
+    <mat-card>
+      <h3>Meist geprobte Stücke</h3>
+      <ol>
+        <li *ngFor="let item of stats.topRehearsalPieces">
+          <a [routerLink]="['/pieces', item.id]">{{ item.title }}</a> ({{ item.count }}x)
+        </li>
+      </ol>
+    </mat-card>
+
+    <mat-card>
+      <h3>Stücke im Repertoire</h3>
+      <p>Singfähig: {{ stats.singableCount }}</p>
+      <p>Probe: {{ stats.rehearsalCount }}</p>
+    </mat-card>
+  </ng-container>
 </div>

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
@@ -4,20 +4,28 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { StatsSummary } from '@core/models/stats-summary';
 import { RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-statistics',
   standalone: true,
   templateUrl: './statistics.component.html',
   styleUrls: ['./statistics.component.scss'],
-  imports: [CommonModule, MaterialModule, RouterModule]
+  imports: [CommonModule, FormsModule, MaterialModule, RouterModule]
 })
 export class StatisticsComponent implements OnInit {
   stats?: StatsSummary;
+  startDate?: Date;
+  endDate?: Date;
 
   constructor(private apiService: ApiService) {}
 
   ngOnInit(): void {
-    this.apiService.getStatistics().subscribe(s => this.stats = s);
+    this.loadStats();
+  }
+
+  loadStats(): void {
+    this.apiService.getStatistics(this.startDate, this.endDate)
+      .subscribe(s => this.stats = s);
   }
 }


### PR DESCRIPTION
## Summary
- allow optional `startDate`/`endDate` query params for statistics backend
- add date range parameters in admin and API services
- extend statistics component with date pickers and load button

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68903667e8c883209901c84160900df1