### PR TITLE
feat: extend statistics features

### DIFF
--- a/choir-app-backend/src/controllers/stats.controller.js
+++ b/choir-app-backend/src/controllers/stats.controller.js
@@ -1,24 +1,35 @@
 const db = require("../models");
-const { Sequelize } = require("sequelize");
+const { Sequelize, Op } = require("sequelize");
 
 exports.overview = async (req, res) => {
     const choirId = req.activeChoirId;
+    const { startDate, endDate } = req.query;
+
+    const dateClause = {};
+    if (startDate) {
+        dateClause[Op.gte] = new Date(startDate);
+    }
+    if (endDate) {
+        dateClause[Op.lte] = new Date(endDate);
+    }
+    const eventDateFilter = Object.keys(dateClause).length ? { date: dateClause } : {};
+
     try {
         // Top pieces in services
         const topServicePieces = await db.piece.findAll({
             attributes: [
-                'id',
-                'title',
-                [Sequelize.fn('COUNT', Sequelize.col('events.id')), 'count']
+                "id",
+                "title",
+                [Sequelize.fn("COUNT", Sequelize.col("events.id")), "count"],
             ],
             include: [{
                 model: db.event,
                 attributes: [],
-                where: { choirId, type: 'SERVICE' },
+                where: { choirId, type: "SERVICE", ...eventDateFilter },
                 through: { attributes: [] }
             }],
-            group: ['piece.id'],
-            order: [[Sequelize.literal('count'), 'DESC']],
+            group: ["piece.id"],
+            order: [[Sequelize.literal("count"), "DESC"]],
             limit: 3,
             subQuery: false
         });
@@ -26,39 +37,90 @@ exports.overview = async (req, res) => {
         // Top pieces rehearsed
         const topRehearsalPieces = await db.piece.findAll({
             attributes: [
-                'id',
-                'title',
-                [Sequelize.fn('COUNT', Sequelize.col('events.id')), 'count']
+                "id",
+                "title",
+                [Sequelize.fn("COUNT", Sequelize.col("events.id")), "count"],
             ],
             include: [{
                 model: db.event,
                 attributes: [],
-                where: { choirId, type: 'REHEARSAL' },
+                where: { choirId, type: "REHEARSAL", ...eventDateFilter },
                 through: { attributes: [] }
             }],
-            group: ['piece.id'],
-            order: [[Sequelize.literal('count'), 'DESC']],
+            group: ["piece.id"],
+            order: [[Sequelize.literal("count"), "DESC"]],
             limit: 3,
             subQuery: false
         });
 
         // Count singable pieces
         const singableCount = await db.choir_repertoire.count({
-            where: { choirId, status: 'CAN_BE_SUNG' }
+            where: { choirId, status: "CAN_BE_SUNG" }
         });
 
         // Count pieces currently in rehearsal
         const rehearsalCount = await db.choir_repertoire.count({
-            where: { choirId, status: 'IN_REHEARSAL' }
+            where: { choirId, status: "IN_REHEARSAL" }
+        });
+
+        // Pieces not sung for a long time
+        const cutoff = new Date();
+        cutoff.setMonth(cutoff.getMonth() - 12);
+
+        const leastUsedPieces = await db.piece.findAll({
+            attributes: [
+                "id",
+                "title",
+                [Sequelize.fn("COUNT", Sequelize.col("events.id")), "count"],
+                [Sequelize.fn("MAX", Sequelize.col("events.date")), "lastUsed"]
+            ],
+            include: [
+                {
+                    model: db.event,
+                    attributes: [],
+                    required: false,
+                    where: { choirId },
+                    through: { attributes: [] }
+                },
+                {
+                    model: db.choir,
+                    attributes: [],
+                    through: { attributes: [] },
+                    where: { id: choirId }
+                }
+            ],
+            group: ["piece.id"],
+            having: Sequelize.literal(`MAX("events"."date") IS NULL OR MAX("events"."date") < '${cutoff.toISOString()}'`),
+            order: [[Sequelize.literal("lastUsed"), "ASC"]],
+            limit: 3,
+            subQuery: false
+        });
+
+        // Distribution by voicing
+        const voicingDistribution = await db.piece.findAll({
+            attributes: [
+                "voicing",
+                [Sequelize.fn("COUNT", Sequelize.col("piece.id")), "count"]
+            ],
+            include: [{
+                model: db.choir,
+                attributes: [],
+                through: { attributes: [] },
+                where: { id: choirId }
+            }],
+            group: ["piece.voicing"]
         });
 
         res.status(200).send({
             topServicePieces,
             topRehearsalPieces,
             singableCount,
-            rehearsalCount
+            rehearsalCount,
+            leastUsedPieces,
+            voicingDistribution
         });
     } catch (err) {
-        res.status(500).send({ message: err.message || 'Error generating statistics.' });
+        res.status(500).send({ message: err.message || "Error generating statistics." });
     }
 };
+

--- a/choir-app-frontend/package-lock.json
+++ b/choir-app-frontend/package-lock.json
@@ -17,6 +17,8 @@
         "@angular/material": "^20.0.3",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
+        "chart.js": "^4.4.1",
+        "ng2-charts": "^4.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3600,6 +3602,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -6596,6 +6604,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -10185,6 +10205,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -10920,6 +10946,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/ng2-charts": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-4.1.1.tgz",
+      "integrity": "sha512-iHwXDbmX86lfeH8VRcsaW2tJATsuAZo4kvvC/Yk2l35zOHjevja1qBvO6BAibiDazi9r9aS6ZRJOqWPsz1pP2w==",
+      "license": "ISC",
+      "dependencies": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": ">=14.0.0",
+        "@angular/common": ">=14.0.0",
+        "@angular/core": ">=14.0.0",
+        "chart.js": "^3.4.0 || ^4.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -27,7 +27,9 @@
     "@angular/router": "^20.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "chart.js": "^4.4.1",
+    "ng2-charts": "^4.0.0"
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^20.0.0",

--- a/choir-app-frontend/src/app/core/models/stats-summary.ts
+++ b/choir-app-frontend/src/app/core/models/stats-summary.ts
@@ -9,4 +9,6 @@ export interface StatsSummary {
   topRehearsalPieces: PieceStat[];
   singableCount: number;
   rehearsalCount: number;
+  leastUsedPieces: PieceStat[];
+  voicingDistribution: { voicing: string; count: number }[];
 }

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -108,8 +108,15 @@ export class AdminService {
     return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
   }
 
-  getStatistics(): Observable<StatsSummary> {
-    return this.http.get<StatsSummary>(`${this.apiUrl}/stats`);
+  getStatistics(startDate?: string, endDate?: string): Observable<StatsSummary> {
+    const params: any = {};
+    if (startDate) {
+      params.startDate = startDate;
+    }
+    if (endDate) {
+      params.endDate = endDate;
+    }
+    return this.http.get<StatsSummary>(`${this.apiUrl}/stats`, { params });
   }
 
   getMailSettings(): Observable<MailSettings> {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -681,8 +681,8 @@ export class ApiService {
     return this.adminService.checkChoirAdminStatus();
   }
 
-  getStatistics(): Observable<StatsSummary> {
-    return this.adminService.getStatistics();
+  getStatistics(startDate?: string, endDate?: string): Observable<StatsSummary> {
+    return this.adminService.getStatistics(startDate, endDate);
   }
 
   pingBackend(): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -1,27 +1,63 @@
-<div class="stats-page" *ngIf="stats">
+<div class="stats-page">
   <h2>Statistik</h2>
 
-  <mat-card>
-    <h3>Top 3 Gottesdienst-Stücke</h3>
-    <ol>
-      <li *ngFor="let item of stats.topServicePieces">
-        <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
-      </li>
-    </ol>
-  </mat-card>
+  <div class="filter">
+    <mat-form-field appearance="fill">
+      <mat-label>Startdatum</mat-label>
+      <input matInput [matDatepicker]="startPicker" [(ngModel)]="startDate" />
+      <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+      <mat-datepicker #startPicker></mat-datepicker>
+    </mat-form-field>
 
-  <mat-card>
-    <h3>Meist geprobte Stücke</h3>
-    <ol>
-      <li *ngFor="let item of stats.topRehearsalPieces">
-        <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
-      </li>
-    </ol>
-  </mat-card>
+    <mat-form-field appearance="fill">
+      <mat-label>Enddatum</mat-label>
+      <input matInput [matDatepicker]="endPicker" [(ngModel)]="endDate" />
+      <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+      <mat-datepicker #endPicker></mat-datepicker>
+    </mat-form-field>
 
-  <mat-card>
-    <h3>Stücke im Repertoire</h3>
-    <p>Singfähig: {{stats.singableCount}}</p>
-    <p>Probe: {{stats.rehearsalCount}}</p>
-  </mat-card>
+    <button mat-raised-button color="primary" (click)="load()">Statistik laden</button>
+  </div>
+
+  <ng-container *ngIf="stats">
+    <mat-card>
+      <h3>Top 3 Gottesdienst-Stücke</h3>
+      <div class="chart-container">
+        <canvas baseChart [data]="serviceChartData" [type]="'bar'"></canvas>
+      </div>
+    </mat-card>
+
+    <mat-card>
+      <h3>Meist geprobte Stücke</h3>
+      <div class="chart-container">
+        <canvas baseChart [data]="rehearsalChartData" [type]="'bar'"></canvas>
+      </div>
+    </mat-card>
+
+    <mat-card>
+      <h3>Stücke im Repertoire</h3>
+      <p>Singfähig: {{stats.singableCount}}</p>
+      <p>Probe: {{stats.rehearsalCount}}</p>
+    </mat-card>
+
+    <mat-card *ngIf="stats.leastUsedPieces?.length">
+      <h3>Lange nicht gesungen</h3>
+      <ol>
+        <li *ngFor="let item of stats.leastUsedPieces">
+          <a [routerLink]="['/pieces', item.id]">{{item.title}}</a> ({{item.count}}x)
+        </li>
+      </ol>
+    </mat-card>
+
+    <mat-card *ngIf="stats.voicingDistribution?.length">
+      <h3>Verteilung nach Stimmenlage</h3>
+      <table>
+        <tr><th>Stimmenlage</th><th>Anzahl</th></tr>
+        <tr *ngFor="let v of stats.voicingDistribution">
+          <td>{{v.voicing || 'Unbekannt'}}</td>
+          <td>{{v.count}}</td>
+        </tr>
+      </table>
+    </mat-card>
+  </ng-container>
 </div>

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.scss
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.scss
@@ -2,4 +2,17 @@
   mat-card {
     margin-bottom: 1rem;
   }
+
+  .filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    align-items: center;
+  }
+
+  .chart-container {
+    display: block;
+    width: 100%;
+  }
 }

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
@@ -4,20 +4,43 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { StatsSummary } from '@core/models/stats-summary';
 import { RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { NgChartsModule } from 'ng2-charts';
+import { ChartData } from 'chart.js';
 
 @Component({
   selector: 'app-statistics',
   standalone: true,
   templateUrl: './statistics.component.html',
   styleUrls: ['./statistics.component.scss'],
-  imports: [CommonModule, MaterialModule, RouterModule]
+  imports: [CommonModule, MaterialModule, RouterModule, FormsModule, NgChartsModule]
 })
 export class StatisticsComponent implements OnInit {
   stats?: StatsSummary;
+  startDate?: Date;
+  endDate?: Date;
+  serviceChartData: ChartData<'bar'> = { labels: [], datasets: [{ data: [], label: 'Gottesdienst-Stücke' }] };
+  rehearsalChartData: ChartData<'bar'> = { labels: [], datasets: [{ data: [], label: 'Proben-Stücke' }] };
 
   constructor(private apiService: ApiService) {}
 
   ngOnInit(): void {
-    this.apiService.getStatistics().subscribe(s => this.stats = s);
+    this.load();
+  }
+
+  load(): void {
+    const start = this.startDate ? this.startDate.toISOString() : undefined;
+    const end = this.endDate ? this.endDate.toISOString() : undefined;
+    this.apiService.getStatistics(start, end).subscribe(s => {
+      this.stats = s;
+      this.serviceChartData = {
+        labels: s.topServicePieces.map(p => p.title),
+        datasets: [{ data: s.topServicePieces.map(p => p.count), label: 'Gottesdienst-Stücke' }]
+      };
+      this.rehearsalChartData = {
+        labels: s.topRehearsalPieces.map(p => p.title),
+        datasets: [{ data: s.topRehearsalPieces.map(p => p.count), label: 'Proben-Stücke' }]
+      };
+    });
   }
 }


### PR DESCRIPTION
## Summary
- enable optional start and end dates for statistics queries
- show statistics in frontend charts with date range filters
- include least-used pieces and voicing distribution in reports

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68903379eec0832089fa7b828cbab2d2