### PR TITLE
Ensure composer displayed in collection editor

### DIFF
--- a/choir-app-backend/src/controllers/collection.controller.js
+++ b/choir-app-backend/src/controllers/collection.controller.js
@@ -2,6 +2,7 @@ const db = require("../models");
 const Collection = db.collection;
 const Choir = db.choir;
 const Piece = db.piece;
+const Composer = db.composer;
 const logger = require("../config/logger");
 const path = require('path');
 const fs = require('fs').promises;
@@ -100,6 +101,7 @@ exports.findOne = async (req, res, next) => {
         const collection = await base.service.findById(req.params.id, {
             include: [{
                 model: Piece,
+                include: [{ model: Composer, as: 'composer', attributes: ['id', 'name'] }],
                 through: { attributes: ['numberInCollection'] }
             }]
         });


### PR DESCRIPTION
## Summary
- Include composer relation when fetching a collection by ID so composers appear in collection editor

## Testing
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68903aa5002483209f0c4773dbf25f8b