### PR TITLE
feat: keep collection open when editing pieces

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -373,25 +373,10 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     }
 
     openEditPieceDialog(pieceId: number): void {
-        const dialogRef = this.dialog.open(PieceDialogComponent, {
-            width: '90vw',
-            maxWidth: '1000px',
-            disableClose: true,
-            data: { pieceId }
-        });
-
-        dialogRef.afterClosed().subscribe(wasUpdated => {
-            if (wasUpdated) {
-                this.apiService.getPieceById(pieceId).subscribe(updatedPiece => {
-                    const idx = this.allPieces.findIndex(p => p.id === pieceId);
-                    if (idx !== -1) this.allPieces[idx] = updatedPiece;
-                    this.selectedPieceLinks = this.selectedPieceLinks.map(link =>
-                        link.piece.id === pieceId ? { ...link, piece: updatedPiece } : link
-                    );
-                    this.updateDataSource();
-                });
-            }
-        });
+        const url = this.router.serializeUrl(
+            this.router.createUrlTree(['/pieces', pieceId], { queryParams: { edit: true } })
+        );
+        window.open(url, '_blank');
     }
 
     addPieceToCollection(): void {

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -16,7 +16,15 @@ describe('PieceDetailComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PieceDetailComponent],
       providers: [
-        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: { get: () => '1' },
+              queryParamMap: { get: () => null }
+            }
+          }
+        },
         { provide: ApiService, useValue: { getRepertoirePiece: () => of(null) } },
         {
           provide: AuthService,

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -47,12 +47,15 @@ export class PieceDetailComponent implements OnInit {
 
   ngOnInit(): void {
     const id = Number(this.route.snapshot.paramMap.get('id'));
-    this.loadPiece(id);
+    const openEdit = this.route.snapshot.queryParamMap.get('edit') === 'true';
+    this.loadPiece(id, () => {
+      if (openEdit) this.openEditPieceDialog();
+    });
     this.auth.currentUser$.subscribe(u => this.userId = u?.id || null);
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
   }
 
-  private loadPiece(id: number): void {
+  private loadPiece(id: number, afterLoad?: () => void): void {
     this.apiService.getRepertoirePiece(id).subscribe(p => {
       if (!p) return;
       this.piece = p;
@@ -63,6 +66,7 @@ export class PieceDetailComponent implements OnInit {
       }
       this.fileLinks = p.links?.filter(l => l.type === 'FILE_DOWNLOAD') || [];
       this.externalLinks = p.links?.filter(l => l.type === 'EXTERNAL') || [];
+      if (afterLoad) afterLoad();
     });
   }
 


### PR DESCRIPTION
## Summary
- open piece editing in a new tab so the collection edit screen remains
- automatically open edit dialog in piece detail when `?edit=true`

## Testing
- `npm test --prefix choir-app-frontend`
- `npm run check --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_68903b6a985883209abf6f31613976a4