### PR TITLE
feat: add collection subtitle

### DIFF
--- a/choir-app-backend/src/controllers/collection.controller.js
+++ b/choir-app-backend/src/controllers/collection.controller.js
@@ -9,12 +9,12 @@ const BaseCrudController = require('./baseCrud.controller');
 const base = new BaseCrudController(Collection);
 
 exports.create = async (req, res, next) => {
-    const { title, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
+    const { title, subtitle, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
     try {
         if (singleEdition && pieces && pieces.length > 1) {
             return res.status(400).send({ message: 'Einzelausgabe kann nur ein Stück enthalten.' });
         }
-        const collection = await base.service.create({ title, publisher, prefix, description, publisherNumber, singleEdition });
+        const collection = await base.service.create({ title, subtitle, publisher, prefix, description, publisherNumber, singleEdition });
         if (pieces && pieces.length > 0) {
             for (const pieceInfo of pieces) {
                 await collection.addPiece(pieceInfo.pieceId, {
@@ -28,7 +28,7 @@ exports.create = async (req, res, next) => {
 
 exports.update = async (req, res, next) => {
     const id = req.params.id;
-    const { title, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
+    const { title, subtitle, publisher, prefix, description, publisherNumber, singleEdition, pieces } = req.body;
     try {
         const collection = await db.collection.findByPk(id);
 
@@ -37,7 +37,7 @@ exports.update = async (req, res, next) => {
         if (singleEdition && pieces && pieces.length > 1) {
             return res.status(400).send({ message: 'Einzelausgabe kann nur ein Stück enthalten.' });
         }
-        await base.service.update(id, { title, publisher, prefix, description, publisherNumber, singleEdition });
+        await base.service.update(id, { title, subtitle, publisher, prefix, description, publisherNumber, singleEdition });
         await collection.setPieces([]);
         if (pieces && pieces.length > 0) {
             for (const pieceLink of pieces) {

--- a/choir-app-backend/src/controllers/search.controller.js
+++ b/choir-app-backend/src/controllers/search.controller.js
@@ -35,6 +35,7 @@ exports.search = async (req, res) => {
     where: {
       [Op.or]: [
         { title: like },
+        { subtitle: like },
         { prefix: like }
       ]
     },

--- a/choir-app-backend/src/models/collection.model.js
+++ b/choir-app-backend/src/models/collection.model.js
@@ -1,6 +1,7 @@
 module.exports = (sequelize, DataTypes) => {
     const Collection = sequelize.define("collection", {
         title: { type: DataTypes.STRING, allowNull: false, unique: true },
+        subtitle: { type: DataTypes.STRING },
         publisher: { type: DataTypes.STRING },
         prefix: { type: DataTypes.STRING }, // e.g., "GL", "EG"
         description: { type: DataTypes.TEXT },

--- a/choir-app-backend/src/validators/collection.validation.js
+++ b/choir-app-backend/src/validators/collection.validation.js
@@ -2,6 +2,7 @@ const { body } = require('express-validator');
 
 exports.createCollectionValidation = [
   body('title').notEmpty().withMessage('Title is required.'),
+  body('subtitle').optional().isString(),
   body('pieces').optional().isArray().withMessage('pieces must be an array'),
   body('pieces.*.pieceId').optional().isInt().withMessage('pieceId must be an integer'),
   body('pieces.*.numberInCollection').optional().isInt().withMessage('numberInCollection must be an integer'),
@@ -10,6 +11,7 @@ exports.createCollectionValidation = [
 
 exports.updateCollectionValidation = [
   body('title').optional().notEmpty(),
+  body('subtitle').optional().isString(),
   body('pieces').optional().isArray(),
   body('pieces.*.pieceId').optional().isInt(),
   body('pieces.*.numberInCollection').optional().isInt(),

--- a/choir-app-backend/tests/collection.validation.test.js
+++ b/choir-app-backend/tests/collection.validation.test.js
@@ -14,6 +14,11 @@ const { createCollectionValidation, updateCollectionValidation } = require('../s
     res = validationResult(req2);
     assert.ok(!res.isEmpty(), 'update should fail when pieces is not array');
 
+    const req3 = { body: { title: 'A', subtitle: 123 } };
+    for (const v of createCollectionValidation) { await v.run(req3); }
+    res = validationResult(req3);
+    assert.ok(!res.isEmpty(), 'create should fail when subtitle is not string');
+
     console.log('collection.validation tests passed');
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -25,7 +25,7 @@ const db = require('../src/models');
     checkFields(db.composer, ['name']);
     checkFields(db.publisher, ['name']);
     checkFields(db.category, ['name']);
-    checkFields(db.collection, ['singleEdition']);
+    checkFields(db.collection, ['singleEdition', 'subtitle']);
     checkFields(db.collection_piece, ['numberInCollection']);
     checkFields(db.user_choir, ['rolesInChoir', 'registrationStatus']);
     checkFields(db.piece_change, ['data']);

--- a/choir-app-frontend/src/app/core/models/collection.ts
+++ b/choir-app-frontend/src/app/core/models/collection.ts
@@ -16,6 +16,11 @@ export interface Collection {
   title: string;
 
   /**
+   * Optional subtitle providing additional context.
+   */
+  subtitle?: string;
+
+  /**
    * The publisher of the collection (e.g., "Carus-Verlag", "Oxford University Press").
    * This is optional.
    */

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -26,6 +26,11 @@
         </mat-form-field>
 
         <mat-form-field appearance="outline">
+          <mat-label>Untertitel</mat-label>
+          <input matInput formControlName="subtitle">
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
           <mat-label>Verlag</mat-label>
           <input matInput [formControl]="publisherCtrl" [matAutocomplete]="pubAuto">
           <mat-autocomplete #pubAuto="matAutocomplete" (optionSelected)="onPublisherSelected($event)">

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -114,6 +114,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     ) {
         this.collectionForm = this.fb.group({
             title: ['', Validators.required],
+            subtitle: [''],
             publisher: [''],
             prefix: [''],
             publisherNumber: [''],
@@ -319,6 +320,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     populateForm(collection: Collection): void {
         this.collectionForm.patchValue({
             title: collection.title,
+            subtitle: collection.subtitle,
             publisher: collection.publisher,
             prefix: collection.prefix,
             publisherNumber: collection.publisherNumber,

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -39,6 +39,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
       <td mat-cell *matCellDef="let collection">
         <strong>{{ collection.title }}</strong>
+        <div class="subtitle-hint" *ngIf="collection.subtitle">{{ collection.subtitle }}</div>
         <div class="prefix-hint" *ngIf="collection.prefix">Präfix: {{ collection.prefix }}</div>
       </td>
     </ng-container>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -5,6 +5,11 @@
     margin-bottom: 2rem;
 }
 
+.subtitle-hint {
+    font-size: 0.9rem;
+    color: #555;
+}
+
 .header-actions {
     display: flex;
     justify-content: flex-end;

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.html
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.html
@@ -19,6 +19,6 @@
 <section *ngIf="results.collections.length">
   <h3>Collections</h3>
   <ul>
-    <li *ngFor="let c of results.collections">{{ c.title }}</li>
+    <li *ngFor="let c of results.collections">{{ c.title }}<span *ngIf="c.subtitle"> – {{ c.subtitle }}</span></li>
   </ul>
 </section>


### PR DESCRIPTION
## Summary
- allow collections to store an optional subtitle
- surface subtitle across collection forms, lists, search and API validation

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68903cb2c934832084223a6d365482cf