### PR TITLE
Add subtitle and composer collection fields to pieces

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -17,10 +17,22 @@ const { getFrontendUrl } = require('../utils/frontend-url');
  * will link this piece to a choir.
  */
 exports.create = async (req, res) => {
-     const {
-        title, composerId, categoryId, voicing,
-        key, timeSignature, lyrics, imageIdentifier, license, opus, lyricsSource,
-        authorName, authorId,
+    const {
+        title,
+        subtitle,
+        composerCollection,
+        composerId,
+        categoryId,
+        voicing,
+        key,
+        timeSignature,
+        lyrics,
+        imageIdentifier,
+        license,
+        opus,
+        lyricsSource,
+        authorName,
+        authorId,
         arrangerIds, // e.g., [12, 15]
         links        // e.g., [{ description: 'YouTube', url: '...' }]
     } = req.body;
@@ -36,8 +48,18 @@ exports.create = async (req, res) => {
         }
 
         const newPiece = await base.service.create({
-            title, composerId, categoryId, voicing, key, timeSignature,
-            lyrics, imageIdentifier, license, opus,
+            title,
+            subtitle,
+            composerCollection,
+            composerId,
+            categoryId,
+            voicing,
+            key,
+            timeSignature,
+            lyrics,
+            imageIdentifier,
+            license,
+            opus,
             lyricsSource,
             authorId: resolvedAuthorId
         });

--- a/choir-app-backend/src/models/piece.model.js
+++ b/choir-app-backend/src/models/piece.model.js
@@ -4,6 +4,14 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.STRING,
             allowNull: false
         },
+        subtitle: { // Untertitel
+            type: DataTypes.STRING,
+            allowNull: true
+        },
+        composerCollection: { // Sammlung des Komponisten
+            type: DataTypes.STRING,
+            allowNull: true
+        },
         voicing: {
             type: DataTypes.STRING,
             allowNull: true

--- a/choir-app-backend/src/validators/piece.validation.js
+++ b/choir-app-backend/src/validators/piece.validation.js
@@ -3,6 +3,8 @@ const { body } = require('express-validator');
 exports.createPieceValidation = [
   body('title').notEmpty().withMessage('Title is required.'),
   body('composerId').isInt().withMessage('Valid composerId is required.'),
+  body('subtitle').optional({ nullable: true }).isString(),
+  body('composerCollection').optional({ nullable: true }).isString(),
   body('arrangerIds').optional().isArray().withMessage('arrangerIds must be an array'),
   body('arrangerIds.*').optional().isInt().withMessage('arrangerIds must contain integers'),
   body('links').optional().isArray().withMessage('links must be an array'),
@@ -15,6 +17,8 @@ exports.createPieceValidation = [
 exports.updatePieceValidation = [
   body('title').optional().notEmpty(),
   body('composerId').optional().isInt(),
+  body('subtitle').optional({ nullable: true }).isString(),
+  body('composerCollection').optional({ nullable: true }).isString(),
   body('arrangerIds').optional().isArray(),
   body('arrangerIds.*').optional().isInt(),
   body('links').optional().isArray(),

--- a/choir-app-backend/tests/piece.controller.test.js
+++ b/choir-app-backend/tests/piece.controller.test.js
@@ -21,6 +21,8 @@ const controller = require('../src/controllers/piece.controller');
     const req = {
       body: {
         title: 'Test Piece',
+        subtitle: 'Subtitle',
+        composerCollection: 'Deutsche Messe',
         composerId: composer.id,
         authorId: author.id,
       },
@@ -38,6 +40,8 @@ const controller = require('../src/controllers/piece.controller');
   const created = await db.piece.findByPk(res.data.id);
   assert.strictEqual(created.composerId, composer.id);
   assert.strictEqual(created.authorId, author.id);
+  assert.strictEqual(created.subtitle, 'Subtitle');
+  assert.strictEqual(created.composerCollection, 'Deutsche Messe');
 
   // non-admin update should create change request
   await controller.update({

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -22,6 +22,8 @@ export interface CollectionReference {
 export interface Piece {
   id: number;
   title: string;
+  subtitle?: string;
+  composerCollection?: string;
   voicing?: string;
   composer?: Composer;
   category?: Category;

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -5,7 +5,9 @@
       <mat-icon>edit</mat-icon>
     </button>
   </h2>
+  <p *ngIf="piece.subtitle"><em>{{ piece.subtitle }}</em></p>
   <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
+  <p *ngIf="piece.composerCollection"><strong>Sammlung des Komponisten:</strong> {{ piece.composerCollection }}</p>
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
   <div *ngIf="piece.collections?.length">

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -20,6 +20,11 @@
                 <input matInput formControlName="title" cdkFocusInitial>
               </mat-form-field>
 
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Untertitel</mat-label>
+                <input matInput formControlName="subtitle">
+              </mat-form-field>
+
               <mat-form-field appearance="outline">
                 <mat-label>Besetzung (z.B. SATB)</mat-label>
                 <input matInput formControlName="voicing">
@@ -64,6 +69,11 @@
                     </ng-template>
                   </mat-option>
                 </mat-autocomplete>
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Sammlung des Komponisten</mat-label>
+                <input matInput formControlName="composerCollection">
               </mat-form-field>
 
               <mat-form-field appearance="outline">

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -89,6 +89,8 @@ export class PieceDialogComponent implements OnInit {
 
         this.pieceForm = this.fb.group({
             title: ['', Validators.required],
+            subtitle: [''],
+            composerCollection: [''],
             voicing: [''],
             lyrics: [''],
             lyricsSource: [''],
@@ -364,6 +366,8 @@ export class PieceDialogComponent implements OnInit {
     populateForm(piece: Piece): void {
         this.pieceForm.patchValue({
             title: piece.title,
+            subtitle: piece.subtitle,
+            composerCollection: piece.composerCollection,
             opus: piece.opus,
             voicing: piece.voicing,
             key: piece.key,


### PR DESCRIPTION
## Summary
- allow storing optional subtitles and composer collections for pieces
- expose new fields through create/update APIs with validation and tests
- support subtitle and composer collection in front-end forms and detail views

## Testing
- `npm test` (backend)
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68903c9db6388320afc98537b79fb185