### PR TITLE
Hide loan cart when empty

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -17,7 +17,7 @@
   </ng-container>
 
   <ng-container *ngIf="isLoggedIn$ | async">
-    <button mat-icon-button routerLink="/library/request" [matBadge]="cartCount$ | async" matBadgeColor="accent" [matBadgeHidden]="(cartCount$ | async) === 0" matTooltip="Entleihkorb">
+    <button *ngIf="(cartCount$ | async) > 0" mat-icon-button routerLink="/library/request" [matBadge]="cartCount$ | async" matBadgeColor="accent" matTooltip="Entleihkorb">
       <mat-icon>shopping_cart</mat-icon>
     </button>
     <span class="user-name" [ngClass]="{'hide-on-handset': (isHandset$ | async)}">{{ userName$ | async }}</span>


### PR DESCRIPTION
## Summary
- only render loan cart icon in header when there are items in the cart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890424878c48320987331b08fa80e2f