### PR TITLE
feat(stats): allow filtering inactive pieces

### DIFF
--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -108,13 +108,16 @@ export class AdminService {
     return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
   }
 
-  getStatistics(startDate?: Date | string, endDate?: Date | string): Observable<StatsSummary> {
+  getStatistics(startDate?: Date | string, endDate?: Date | string, activeMonths?: number): Observable<StatsSummary> {
     const params: any = {};
     if (startDate) {
       params.startDate = startDate instanceof Date ? startDate.toISOString() : startDate;
     }
     if (endDate) {
       params.endDate = endDate instanceof Date ? endDate.toISOString() : endDate;
+    }
+    if (activeMonths !== undefined) {
+      params.activeMonths = activeMonths;
     }
     return this.http.get<StatsSummary>(`${this.apiUrl}/stats`, { params });
   }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -686,8 +686,8 @@ export class ApiService {
     return this.adminService.checkChoirAdminStatus();
   }
 
-  getStatistics(startDate?: Date, endDate?: Date): Observable<StatsSummary> {
-    return this.adminService.getStatistics(startDate, endDate);
+  getStatistics(startDate?: Date, endDate?: Date, activeMonths?: number): Observable<StatsSummary> {
+    return this.adminService.getStatistics(startDate, endDate, activeMonths);
   }
 
   pingBackend(): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -15,6 +15,11 @@
       <mat-datepicker #endPicker></mat-datepicker>
     </mat-form-field>
 
+    <mat-form-field appearance="fill">
+      <mat-label>Aktive Monate</mat-label>
+      <input matInput type="number" [(ngModel)]="activeMonths" />
+    </mat-form-field>
+
     <button mat-raised-button color="primary" (click)="loadStats()">Statistik laden</button>
   </div>
 

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
@@ -20,6 +20,7 @@ export class StatisticsComponent implements OnInit {
 
   startDate?: Date;
   endDate?: Date;
+  activeMonths?: number;
 
 
   constructor(private apiService: ApiService) {}
@@ -29,7 +30,7 @@ export class StatisticsComponent implements OnInit {
   }
 
   loadStats(): void {
-    this.apiService.getStatistics(this.startDate, this.endDate)
+    this.apiService.getStatistics(this.startDate, this.endDate, this.activeMonths)
       .subscribe(s => {
       this.stats = s;
       this.leastUsedPieces = s.leastUsedPieces;


### PR DESCRIPTION
## Summary
- add `activeMonths` filter to stats endpoint
- expose active month filter on statistics page

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_689043474ab883208a8187ae79c087b6