### PR TITLE
Improve collection save error handling

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -309,7 +309,11 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
                 });
             },
             error: (err) => {
-                this.snackBar.open(`Fehler: ${err.message}`, 'Schließen', {
+                let message = err.error?.message || err.message || 'Unbekannter Fehler beim Speichern.';
+                if (err.status === 400 && !err.error?.message) {
+                    message = 'Ungültige Eingaben. Bitte prüfen Sie die Angaben.';
+                }
+                this.snackBar.open(`Fehler: ${message}`, 'Schließen', {
                     duration: 5000,
                     verticalPosition: 'top',
                 });


### PR DESCRIPTION
## Summary
- validate piece IDs and duplicates when creating or updating collections
- handle invalid piece references with detailed error messages and surface backend messages to the user

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6890470590108320913e1fb0f5e69811