### PR TITLE
Allow alphanumeric collection numbering

### DIFF
--- a/choir-app-backend/src/validators/collection.validation.js
+++ b/choir-app-backend/src/validators/collection.validation.js
@@ -5,7 +5,10 @@ exports.createCollectionValidation = [
   body('subtitle').optional().isString(),
   body('pieces').optional().isArray().withMessage('pieces must be an array'),
   body('pieces.*.pieceId').optional().isInt().withMessage('pieceId must be an integer'),
-  body('pieces.*.numberInCollection').optional().isInt().withMessage('numberInCollection must be an integer'),
+  body('pieces.*.numberInCollection')
+    .optional()
+    .matches(/^\d+[a-zA-Z]*$/)
+    .withMessage('numberInCollection must be numeric with optional letters'),
   body('singleEdition').optional().isBoolean()
 ];
 
@@ -14,6 +17,8 @@ exports.updateCollectionValidation = [
   body('subtitle').optional().isString(),
   body('pieces').optional().isArray(),
   body('pieces.*.pieceId').optional().isInt(),
-  body('pieces.*.numberInCollection').optional().isInt(),
+  body('pieces.*.numberInCollection')
+    .optional()
+    .matches(/^\d+[a-zA-Z]*$/),
   body('singleEdition').optional().isBoolean()
 ];

--- a/choir-app-backend/tests/collection.validation.test.js
+++ b/choir-app-backend/tests/collection.validation.test.js
@@ -19,6 +19,16 @@ const { createCollectionValidation, updateCollectionValidation } = require('../s
     res = validationResult(req3);
     assert.ok(!res.isEmpty(), 'create should fail when subtitle is not string');
 
+    const req4 = { body: { title: 'A', pieces: [{ pieceId: 1, numberInCollection: '11a' }] } };
+    for (const v of createCollectionValidation) { await v.run(req4); }
+    res = validationResult(req4);
+    assert.ok(res.isEmpty(), 'create should allow alphanumeric numberInCollection');
+
+    const req5 = { body: { title: 'A', pieces: [{ pieceId: 1, numberInCollection: '11!' }] } };
+    for (const v of createCollectionValidation) { await v.run(req5); }
+    res = validationResult(req5);
+    assert.ok(!res.isEmpty(), 'create should fail for invalid numberInCollection');
+
     console.log('collection.validation tests passed');
   } catch (err) {
     console.error(err);

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -193,9 +193,14 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
                 case 'title':
                     return link.piece.title.toLowerCase();
                 case 'number':
-                    // Wir versuchen, die Nummer als Zahl zu parsen, um eine korrekte numerische Sortierung zu ermöglichen.
-                    const num = parseInt(link.numberInCollection, 10);
-                    return isNaN(num) ? link.numberInCollection : num; // Fallback auf String-Sortierung, falls es keine Zahl ist
+                    // Versuche die numerische und alphanumerische Komponente zu trennen
+                    const match = link.numberInCollection.match(/^(\d+)([a-zA-Z]*)$/);
+                    if (match) {
+                        const base = parseInt(match[1], 10);
+                        const suffix = match[2] ? match[2].toLowerCase().charCodeAt(0) / 100 : 0;
+                        return base + suffix;
+                    }
+                    return link.numberInCollection;
                 default:
                     return (link as any)[property];
             }
@@ -414,13 +419,17 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
 
     private sortPieceLinksByNumber(): void {
         this.selectedPieceLinks.sort((a, b) => {
-            const numA = parseInt(a.numberInCollection, 10);
-            const numB = parseInt(b.numberInCollection, 10);
-            // Wenn beide Zahlen sind, vergleiche sie numerisch
-            if (!isNaN(numA) && !isNaN(numB)) {
-                return numA - numB;
+            const pattern = /^(\d+)([a-zA-Z]*)$/;
+            const matchA = a.numberInCollection.match(pattern);
+            const matchB = b.numberInCollection.match(pattern);
+            if (matchA && matchB) {
+                const baseA = parseInt(matchA[1], 10);
+                const baseB = parseInt(matchB[1], 10);
+                if (baseA !== baseB) {
+                    return baseA - baseB;
+                }
+                return matchA[2].localeCompare(matchB[2]);
             }
-            // Ansonsten, vergleiche als Text (Fallback)
             return a.numberInCollection.localeCompare(b.numberInCollection);
         });
     }


### PR DESCRIPTION
## Summary
- allow numbers with optional letters when linking pieces to collections
- handle alphanumeric collection numbers in UI sorting
- test validation for alphanumeric collection numbers

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689047324ca883209e2f6de054eaef12