### PR TITLE
fix: handle null cart count

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -17,7 +17,7 @@
   </ng-container>
 
   <ng-container *ngIf="isLoggedIn$ | async">
-    <button *ngIf="(cartCount$ | async) > 0" mat-icon-button routerLink="/library/request" [matBadge]="cartCount$ | async" matBadgeColor="accent" matTooltip="Entleihkorb">
+    <button *ngIf="((cartCount$ | async) ?? 0) > 0" mat-icon-button routerLink="/library/request" [matBadge]="(cartCount$ | async) ?? 0" matBadgeColor="accent" matTooltip="Entleihkorb">
       <mat-icon>shopping_cart</mat-icon>
     </button>
     <span class="user-name" [ngClass]="{'hide-on-handset': (isHandset$ | async)}">{{ userName$ | async }}</span>


### PR DESCRIPTION
## Summary
- guard against `null` cart counts in main layout badge and visibility check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68904d7e5e4c8320890e55649367cac8