### PR TITLE
Add collapsible lyrics to piece details

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -10,6 +10,12 @@
   <p *ngIf="piece.composerCollection"><strong>Sammlung des Komponisten:</strong> {{ piece.composerCollection }}</p>
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
+  <mat-expansion-panel *ngIf="piece.lyrics">
+    <mat-expansion-panel-header>
+      <mat-panel-title>Liedtext</mat-panel-title>
+    </mat-expansion-panel-header>
+    <div class="lyrics">{{ piece.lyrics }}</div>
+  </mat-expansion-panel>
   <div *ngIf="piece.collections?.length">
     <p><strong>Enthalten in:</strong></p>
     <ul>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
@@ -12,3 +12,7 @@
   max-width: 100%;
   margin-bottom: 1rem;
 }
+
+.lyrics {
+  white-space: pre-line;
+}

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -44,4 +44,11 @@ describe('PieceDetailComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should show lyrics when provided', () => {
+    component.piece = { id: 1, title: 'Test', lyrics: 'Line1\nLine2' } as any;
+    fixture.detectChanges();
+    const lyricsEl: HTMLElement | null = fixture.nativeElement.querySelector('.lyrics');
+    expect(lyricsEl?.textContent).toContain('Line1');
+  });
 });


### PR DESCRIPTION
## Summary
- show lyrics with preserved line breaks on the piece details page
- hide lyrics behind expandable panel to save space
- cover lyrics rendering with a simple unit test

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68905c1c936c83209c9adde70ad712ea