### PR TITLE
feat: show borrowed library collections on dashboard

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -41,6 +41,18 @@
   </mat-list>
 </div>
 
+<ng-container *ngIf="borrowedItems$ | async as borrowed">
+  <div class="borrowed-section" *ngIf="borrowed.length > 0">
+    <h2>Entliehene Sammlungen</h2>
+    <mat-list>
+      <mat-list-item *ngFor="let item of borrowed">
+        {{ item.collection?.title || ('Sammlung ' + item.collectionId) }}
+        (Ablauf: {{ item.availableAt | date:'shortDate' }})
+      </mat-list-item>
+    </mat-list>
+  </div>
+</ng-container>
+
 <div *ngIf="isAdmin$ | async">
   <ng-container *ngIf="pieceChanges$ | async as changes">
     <div *ngIf="changes.length > 0">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -21,6 +21,7 @@ import { HelpService } from '@core/services/help.service';
 import { HelpWizardComponent } from '@shared/components/help-wizard/help-wizard.component';
 import { UserPreferencesService } from '@core/services/user-preferences.service';
 import { UserPreferences } from '@core/models/user-preferences';
+import { LibraryItem } from '@core/models/library-item';
 
 @Component({
   selector: 'app-dashboard',
@@ -45,6 +46,7 @@ export class DashboardComponent implements OnInit {
   pieceChanges$!: Observable<PieceChange[]>;
   nextEvents$!: Observable<Event[]>;
   latestPost$!: Observable<import('@core/models/post').Post | null>;
+  borrowedItems$!: Observable<LibraryItem[]>;
   showOnlyMine = false;
   isAdmin$: Observable<boolean | false>;
 
@@ -76,6 +78,11 @@ export class DashboardComponent implements OnInit {
 
     this.latestPost$ = this.refresh$.pipe(
       switchMap(() => this.apiService.getLatestPost())
+    );
+
+    this.borrowedItems$ = this.refresh$.pipe(
+      switchMap(() => this.apiService.getLibraryItems()),
+      map(items => items.filter(i => i.status === 'borrowed'))
     );
 
     this.pieceChanges$ = this.authService.isAdmin$.pipe(


### PR DESCRIPTION
## Summary
- display borrowed library collections with their return dates on the dashboard
- hide library section if there are no borrowed items

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_689072c997c88320b517a090e9d3cf18