### PR TITLE
Collapse mobile sidenav after menu selection

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -143,6 +143,9 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
 
   ngAfterViewInit(): void {
     this.evaluateDrawerWidth();
+    if (this.appDrawer) {
+      this.navService.appDrawer = this.appDrawer;
+    }
   }
 
   @HostListener('window:resize')

--- a/choir-app-frontend/src/app/shared/components/menu-list-item/menu-list-item.component.ts
+++ b/choir-app-frontend/src/app/shared/components/menu-list-item/menu-list-item.component.ts
@@ -94,7 +94,9 @@ export class MenuListItemComponent implements OnInit, OnDestroy {
     onItemSelected(item: NavItem) {
         if (!item.children || !item.children.length) {
             if (item.route) {
-                this.router.navigate([item.route]);
+                this.router.navigate([item.route]).then(() => {
+                    this.navService.closeNav();
+                });
             }
         }
         if (item.children && item.children.length) {

--- a/choir-app-frontend/src/app/shared/components/menu-list-item/nav-service.ts
+++ b/choir-app-frontend/src/app/shared/components/menu-list-item/nav-service.ts
@@ -16,7 +16,9 @@ export class NavService {
   }
 
   public closeNav() {
-    this.appDrawer.close();
+    if (this.appDrawer && this.appDrawer.mode === 'over') {
+      this.appDrawer.close();
+    }
   }
 
   public openNav() {


### PR DESCRIPTION
## Summary
- close navigation drawer on mobile after selecting a menu item
- wire drawer to NavService for global control
- close drawer only when in over mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890723a58888320bb1915c66dc41e2b