### PR TITLE
Allow editing collection piece numbers

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -140,7 +140,16 @@
             <!-- Number Column Definition -->
             <ng-container matColumnDef="number">
               <th mat-header-cell *matHeaderCellDef mat-sort-header="number"> Nr. </th>
-              <td mat-cell *matCellDef="let link"> {{link.numberInCollection}} </td>
+              <td mat-cell *matCellDef="let link" class="number-cell">
+                <mat-form-field appearance="outline">
+                  <input
+                    matInput
+                    [(ngModel)]="link.numberInCollection"
+                    (change)="onNumberChanged()"
+                    [ngModelOptions]="{standalone: true}"
+                  />
+                </mat-form-field>
+              </td>
             </ng-container>
 
             <!-- Title Column Definition -->

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -29,6 +29,10 @@ mat-form-field {
   font-size: 0.9em;
 }
 
+.piece-link-table .number-cell mat-form-field {
+  width: 4rem;
+}
+
 mat-chip-listbox {
     margin-top: 1rem;
     display: block;

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -8,6 +8,7 @@ import {
 import { CommonModule } from '@angular/common';
 import {
     ReactiveFormsModule,
+    FormsModule,
     FormBuilder,
     FormGroup,
     Validators,
@@ -46,6 +47,7 @@ interface SelectedPieceWithNumber {
     standalone: true,
     imports: [
         CommonModule,
+        FormsModule,
         ReactiveFormsModule,
         MaterialModule,
         MatAutocompleteModule,
@@ -443,7 +445,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
 
     private updateDataSource(goToLastPage = false): void {
         // Assign the new array to the .data property of the datasource
-        this.pieceLinkDataSource.data = this.selectedPieceLinks;
+        this.pieceLinkDataSource.data = [...this.selectedPieceLinks];
 
         // Move paginator to requested page after data change
         if (this.pieceLinkDataSource.paginator) {
@@ -521,5 +523,10 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
                     });
             }
         });
+    }
+
+    onNumberChanged(): void {
+        this.sortPieceLinksByNumber();
+        this.updateDataSource();
     }
 }


### PR DESCRIPTION
## Summary
- Enable editing of piece numbers directly in collection edit table
- Keep table order in sync by resorting and updating datasource on number changes
- Style number input field for compact display

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6890897d416c8320a134c7d372caf855