### PR TITLE
Add duplicate detection and migration for creators

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js",
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.duplicate.test.js",
     "check": "node --check server.js",
     "init": "node scripts/init.js",
     "seed": "node scripts/seed.js"

--- a/choir-app-backend/src/controllers/author.controller.js
+++ b/choir-app-backend/src/controllers/author.controller.js
@@ -2,5 +2,6 @@ const db = require("../models");
 const createCreatorController = require("./creator.controller");
 
 module.exports = createCreatorController(db.author, {
-  entityName: 'Author'
+  entityName: 'Author',
+  pieceField: 'authorId'
 });

--- a/choir-app-backend/src/controllers/composer.controller.js
+++ b/choir-app-backend/src/controllers/composer.controller.js
@@ -3,5 +3,6 @@ const createCreatorController = require("./creator.controller");
 
 module.exports = createCreatorController(db.composer, {
   entityName: 'Composer',
-  arranged: true
+  arranged: true,
+  pieceField: 'composerId'
 });

--- a/choir-app-backend/src/routes/author.routes.js
+++ b/choir-app-backend/src/routes/author.routes.js
@@ -7,6 +7,8 @@ router.use(authJwt.verifyToken);
 
 router.post("/", wrap(controller.create));
 router.get("/", wrap(controller.findAll));
+router.get("/duplicates", wrap(controller.findDuplicates));
+router.post("/migrate", wrap(controller.migrate));
 router.put("/:id", wrap(controller.update));
 router.delete("/:id", wrap(controller.delete));
 router.post("/:id/enrich", wrap(controller.enrich));

--- a/choir-app-backend/src/routes/composer.routes.js
+++ b/choir-app-backend/src/routes/composer.routes.js
@@ -7,6 +7,8 @@ router.use(authJwt.verifyToken);
 
 router.post("/", wrap(controller.create));
 router.get("/", wrap(controller.findAll));
+router.get("/duplicates", wrap(controller.findDuplicates));
+router.post("/migrate", wrap(controller.migrate));
 router.put("/:id", wrap(controller.update));
 router.delete("/:id", wrap(controller.delete));
 router.post("/:id/enrich", wrap(controller.enrich));

--- a/choir-app-backend/tests/creator.duplicate.test.js
+++ b/choir-app-backend/tests/creator.duplicate.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+process.env.DISABLE_EMAIL = 'true';
+
+const db = require('../src/models');
+const composerController = require('../src/controllers/composer.controller');
+const authorController = require('../src/controllers/author.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+
+    const c1 = await db.composer.create({ name: 'J. Bach' });
+    const c2 = await db.composer.create({ name: 'Johann Sebastian Bach' });
+    await db.composer.create({ name: 'Ludwig van Beethoven' });
+
+    const req = {};
+    let status;
+    const res = {
+      status(code) { status = code; return this; },
+      send(data) { this.data = data; if (!status) status = 200; }
+    };
+
+    await composerController.findDuplicates(req, res);
+    assert.strictEqual(status, 200);
+    assert.strictEqual(res.data.length, 1, 'one duplicate group');
+    const names = res.data[0].map(r => r.name);
+    assert(names.includes('J. Bach') && names.includes('Johann Sebastian Bach'));
+
+    const piece = await db.piece.create({ title: 'Toccata', composerId: c1.id });
+    await db.piece_arranger.create({ pieceId: piece.id, composerId: c1.id });
+    await composerController.migrate({ body: { sourceId: c1.id, targetId: c2.id } }, res);
+    assert.strictEqual(res.data.message.includes('Migration'), true);
+    const migratedPiece = await db.piece.findByPk(piece.id);
+    assert.strictEqual(migratedPiece.composerId, c2.id);
+    const migratedArranger = await db.piece_arranger.findOne({ where: { pieceId: piece.id } });
+    assert.strictEqual(migratedArranger.composerId, c2.id);
+    const deletedComposer = await db.composer.findByPk(c1.id);
+    assert.strictEqual(deletedComposer, null);
+
+    const a1 = await db.author.create({ name: 'F. Schiller' });
+    const a2 = await db.author.create({ name: 'Friedrich Schiller' });
+    const p2 = await db.piece.create({ title: 'Ode', composerId: c2.id, authorId: a1.id });
+    await authorController.findDuplicates(req, res);
+    assert.strictEqual(res.data.length, 1, 'author duplicate group');
+    await authorController.migrate({ body: { sourceId: a1.id, targetId: a2.id } }, res);
+    const migratedPiece2 = await db.piece.findByPk(p2.id);
+    assert.strictEqual(migratedPiece2.authorId, a2.id);
+    const deletedAuthor = await db.author.findByPk(a1.id);
+    assert.strictEqual(deletedAuthor, null);
+
+    console.log('creator duplicate tests passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add duplicate detection and migration utilities for authors and composers
- expose `/duplicates` and `/migrate` endpoints for creator resources
- test creator duplicate search and migration

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_6890a3d9539c8320b2dec0f1a857d74a