### PR TITLE
Hide border for collection number inputs

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -31,6 +31,16 @@ mat-form-field {
 
 .piece-link-table .number-cell mat-form-field {
   width: 4rem;
+
+  // Hide outline by default and only show on hover or focus
+  .mat-form-field-outline {
+    display: none;
+  }
+
+  &:hover .mat-form-field-outline,
+  &.mat-focused .mat-form-field-outline {
+    display: block;
+  }
 }
 
 mat-chip-listbox {


### PR DESCRIPTION
## Summary
- remove default border from number inputs in collection editor and only show on hover or focus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890a3087d8883209750898d1d1e3238