### PR TITLE
Add pieces list view to collections module

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -95,9 +95,15 @@ exports.findAll = async (req, res) => {
 
     const pieces = await base.service.findAll({
             where,
+            attributes: {
+                include: [
+                    [db.sequelize.literal(`(SELECT COUNT(*) FROM "collection_pieces" AS "cp" WHERE "cp"."pieceId" = "piece"."id")`), 'collectionCount']
+                ]
+            },
             include: [
                 { model: Composer, as: 'composer', attributes: ['id', 'name'] },
                 { model: Category, as: 'category', attributes: ['id', 'name'] },
+                { model: Author, as: 'author', attributes: ['id', 'name'] },
                 { model: db.piece_link, as: 'links' }
             ],
             order: [['title', 'ASC']]

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { DashboardComponent } from './features/home/dashboard/dashboard.componen
 import { LiteratureListComponent } from './features/literature/literature-list/literature-list.component';
 import { CollectionListComponent } from './features/collections/collection-list/collection-list.component';
 import { CollectionEditComponent } from './features/collections/collection-edit/collection-edit.component';
+import { CollectionPieceListComponent } from './features/collections/piece-list/collection-piece-list.component';
 import { ProfileComponent } from './features/user/profile/profile.component';
 import { AuthGuard } from './core/guards/auth-guard'; // Stellen Sie sicher, dass der Pfad korrekt ist
 import { ImprintComponent } from '@features/legal/imprint/imprint.component';
@@ -80,6 +81,12 @@ export const routes: Routes = [
                 component: LiteratureListComponent,
                 canActivate: [AuthGuard],
                 data: { title: 'Repertoire' },
+            },
+            {
+                path: 'collections/pieces',
+                component: CollectionPieceListComponent,
+                canActivate: [AuthGuard],
+                data: { title: 'Stücke' },
             },
             {
                 path: 'collections',

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -34,6 +34,7 @@ export interface Piece {
   collections?: CollectionReference[];
   collectionPrefix?: string | null;
   collectionNumber?: string | null;
+  collectionCount?: number;
 
   key?: string;
   timeSignature?: string;

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -1,5 +1,9 @@
 
 <div class="header-actions">
+  <button mat-stroked-button routerLink="/collections/pieces">
+          <mat-icon>library_music</mat-icon>
+          <span>Alle Stücke</span>
+  </button>
   <button mat-flat-button color="accent" routerLink="/collections/new"
           [disabled]="!isChoirAdmin && !isAdmin"
           matTooltip="{{ !isChoirAdmin && !isAdmin ? 'Zum Hinzufügen müssen Sie als Chor-Administrator eingeloggt sein.' : '' }}">

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -1,0 +1,41 @@
+<div class="letter-filter">
+  <button mat-button *ngFor="let l of letters" (click)="onLetterSelect(l)" [color]="selectedLetter === l ? 'primary' : undefined">
+    {{ l }}
+  </button>
+</div>
+
+<div class="table-wrapper mat-elevation-z8">
+  <div class="table-scroll-container">
+    <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="title">Titel</th>
+        <td mat-cell *matCellDef="let piece" class="title-cell">
+          <strong>{{ piece.title }}</strong>
+          <div class="subtitle-hint" *ngIf="piece.subtitle">{{ piece.subtitle }}</div>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="composer">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist</th>
+        <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="author">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="author">Dichter</th>
+        <td mat-cell *matCellDef="let piece">{{ piece.author?.name || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="collections">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="collectionCount">Anzahl in Sammlungen</th>
+        <td mat-cell *matCellDef="let piece" class="count-cell">{{ piece.collectionCount || 0 }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openPiece(row)"></tr>
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</td>
+      </tr>
+    </table>
+  </div>
+  <mat-paginator [length]="totalPieces" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>
+</div>

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.scss
@@ -1,0 +1,23 @@
+.table-wrapper {
+  width: 100%;
+}
+
+.table-scroll-container {
+  max-height: 70vh;
+  overflow: auto;
+}
+
+.title-cell {
+  cursor: pointer;
+}
+
+.letter-filter {
+  margin-bottom: 1rem;
+  button {
+    min-width: 32px;
+  }
+}
+
+.count-cell {
+  text-align: center;
+}

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { PieceService } from '@core/services/piece.service';
+import { PaginatorService } from '@core/services/paginator.service';
+import { CollectionPieceListComponent } from './collection-piece-list.component';
+
+class MockPaginatorService {
+  getPageSize() { return 10; }
+  setPageSize() {}
+}
+
+describe('CollectionPieceListComponent', () => {
+  let component: CollectionPieceListComponent;
+  let fixture: ComponentFixture<CollectionPieceListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CollectionPieceListComponent, RouterTestingModule],
+      providers: [
+        { provide: PieceService, useValue: { getGlobalPieces: () => of([]) } },
+        { provide: PaginatorService, useClass: MockPaginatorService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CollectionPieceListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
@@ -1,0 +1,92 @@
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { PieceService } from '@core/services/piece.service';
+import { Piece } from '@core/models/piece';
+import { Router } from '@angular/router';
+import { PaginatorService } from '@core/services/paginator.service';
+
+@Component({
+  selector: 'app-collection-piece-list',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './collection-piece-list.component.html',
+  styleUrls: ['./collection-piece-list.component.scss']
+})
+export class CollectionPieceListComponent implements OnInit, AfterViewInit {
+  pieces: Piece[] = [];
+  dataSource = new MatTableDataSource<Piece>();
+  displayedColumns = ['title', 'composer', 'author', 'collections'];
+  letters: string[] = ['Alle','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z'];
+  selectedLetter = 'Alle';
+  totalPieces = 0;
+  pageSizeOptions: number[] = [10, 25, 50];
+  pageSize = 10;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(private pieceService: PieceService,
+              private router: Router,
+              private paginatorService: PaginatorService) {
+    this.pageSize = this.paginatorService.getPageSize('collection-piece-list', this.pageSizeOptions[0]);
+  }
+
+  ngOnInit(): void {
+    this.loadPieces();
+  }
+
+  ngAfterViewInit(): void {
+    if (this.paginator) {
+      this.paginator.pageSize = this.pageSize;
+      this.dataSource.paginator = this.paginator;
+      this.paginator.page.subscribe(e => this.paginatorService.setPageSize('collection-piece-list', e.pageSize));
+    }
+    if (this.sort) {
+      this.dataSource.sort = this.sort;
+      this.dataSource.sortingDataAccessor = (item, property) => {
+        switch (property) {
+          case 'composer':
+            return item.composer?.name || '';
+          case 'author':
+            return item.author?.name || '';
+          default:
+            return (item as any)[property];
+        }
+      };
+    }
+  }
+
+  loadPieces(): void {
+    this.pieceService.getGlobalPieces().subscribe(pieces => {
+      this.pieces = pieces;
+      this.applyFilter();
+    });
+  }
+
+  applyFilter(): void {
+    let filtered = this.pieces;
+    if (this.selectedLetter !== 'Alle') {
+      const letter = this.selectedLetter.toUpperCase();
+      filtered = filtered.filter(p => p.title.toUpperCase().startsWith(letter));
+    }
+    this.dataSource.data = filtered;
+    this.totalPieces = filtered.length;
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+      this.paginator.firstPage();
+    }
+  }
+
+  onLetterSelect(letter: string): void {
+    this.selectedLetter = letter;
+    this.applyFilter();
+  }
+
+  openPiece(piece: Piece): void {
+    this.router.navigate(['/pieces', piece.id]);
+  }
+}


### PR DESCRIPTION
## Summary
- expose collection link count in pieces API
- add global pieces list with filtering, sorting and pagination
- link pieces list into collections area and route

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890b2517dac8320b741e0fa271c65a8