### PR TITLE
feat: responsive tables on mobile

### DIFF
--- a/choir-app-frontend/src/styles.scss
+++ b/choir-app-frontend/src/styles.scss
@@ -25,6 +25,17 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   .container {
     padding: 1rem;
   }
+
+  .mat-mdc-table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .mat-mdc-table th,
+  .mat-mdc-table td {
+    word-break: break-word;
+  }
 }
 
 // Add space below all Material card headers


### PR DESCRIPTION
## Summary
- prevent table overflow on small screens by making `mat-mdc-table` elements scrollable and breaking long words

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6890b4b356388320ae3d505d0e84b237