### PR TITLE
feat(admin): allow opening composer piece links in new tab

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
@@ -51,7 +51,7 @@
         <div *ngIf="expandedPieces.length; else none">
           <ul>
             <li *ngFor="let p of expandedPieces">
-              <a [routerLink]="['/pieces', p.id]" (click)="openEditPieceDialog(p.id, $event)">{{ p.title }}</a>
+              <a [routerLink]="['/pieces', p.id]" (click)="openEditPieceDialog($event, p.id)">{{ p.title }}</a>
             </li>
           </ul>
         </div>

--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.ts
@@ -184,9 +184,12 @@ export class ManageCreatorsComponent implements OnInit, AfterViewInit {
   isExpansionDetailRow = (_: number, row: Composer | Author) =>
     this.expandedPerson?.id === row.id;
 
-  openEditPieceDialog(pieceId: number, event?: Event): void {
-    event?.preventDefault();
-    event?.stopPropagation();
+  openEditPieceDialog(event: MouseEvent, pieceId: number): void {
+    if (event.ctrlKey || event.metaKey || event.button !== 0) {
+      return; // allow default navigation for new tab or new window
+    }
+    event.preventDefault();
+    event.stopPropagation();
     const expandedId = this.expandedPerson?.id;
     const dialogRef = this.dialog.open(PieceDialogComponent, {
       width: '90vw',


### PR DESCRIPTION
## Summary
- enable opening composer piece links in new tab by ignoring Ctrl/Meta/middle clicks
- keep inline edit dialog on regular clicks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c23858e08320aa1a07de4f14f546