### PR TITLE
Prefill title when adding new piece

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -67,6 +67,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     pieceCtrl = new FormControl<string | Piece>('');
     filteredPieces$!: Observable<Piece[]>;
     allPieces: Piece[] = [];
+    private lastPieceSearch = '';
     publisherCtrl = new FormControl<string>('');
     publishers: Publisher[] = [];
     filteredPublishers$!: Observable<string[]>;
@@ -221,6 +222,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
             map((value) => {
                 const searchString =
                     typeof value === 'string' ? value : value?.title || '';
+                this.lastPieceSearch = searchString;
                 const filteredPieces = this._filter(searchString);
                 return [this.addNewPieceOption, ...filteredPieces];
             })
@@ -361,20 +363,20 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     onPieceSelected(event: MatAutocompleteSelectedEvent): void {
         const selectedPiece = event.option.value as Piece;
         if (selectedPiece.id === this.addNewPieceOption.id) {
-            this.openAddPieceDialog();
+            this.openAddPieceDialog(this.lastPieceSearch);
         } else {
             this.addPieceForm.patchValue({ piece: selectedPiece });
             this.proposeNextNumber();
         }
     }
 
-    openAddPieceDialog(): void {
+    openAddPieceDialog(prefillTitle?: string): void {
         this.pieceCtrl.setValue('');
         const pieceDialogRef = this.dialog.open(PieceDialogComponent, {
             width: '90vw',
             maxWidth: '1000px',
             disableClose: true,
-            data: { pieceId: null },
+            data: { pieceId: null, initialTitle: prefillTitle },
         });
         pieceDialogRef
             .afterClosed()

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.spec.ts
@@ -18,7 +18,7 @@ describe('PieceDialogComponent', () => {
       providers: [
         { provide: AuthService, useValue: { isAdmin$: of(true) } },
         { provide: MatDialogRef, useValue: {} },
-        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: { pieceId: null, initialTitle: 'Test Title' } },
         { provide: MatDialog, useValue: {} },
         { provide: MatSnackBar, useValue: { open: () => {} } }
       ]
@@ -32,5 +32,9 @@ describe('PieceDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should prefill title when initialTitle is provided', () => {
+    expect(component.pieceForm.get('title')?.value).toBe('Test Title');
   });
 });

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -83,7 +83,7 @@ export class PieceDialogComponent implements OnInit {
         private snackBar: MatSnackBar,
         public dialog: MatDialog,
         public dialogRef: MatDialogRef<PieceDialogComponent>,
-        @Inject(MAT_DIALOG_DATA) public data: { pieceId: number | null }
+        @Inject(MAT_DIALOG_DATA) public data: { pieceId?: number | null; initialTitle?: string }
     ) {
         this.isEditMode = !!data.pieceId;
 
@@ -103,6 +103,10 @@ export class PieceDialogComponent implements OnInit {
             authorId: [null],
             categoryId: [null],
         }, { validators: authorOrSourceValidator() });
+
+        if (!this.isEditMode && data.initialTitle) {
+            this.pieceForm.get('title')?.setValue(data.initialTitle);
+        }
     }
 
     ngOnInit(): void {


### PR DESCRIPTION
## Summary
- preserve the typed search term when selecting "+ Neues Stück anlegen..." in collections
- pass the stored title into the piece dialog so the title field is prefilled
- cover the new dialog behavior with a unit test

## Testing
- `cd choir-app-frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_6890c48cdf608320ad7814bc8a0df671