### PR TITLE
Add toggle switch between collections and pieces lists

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -1,9 +1,9 @@
 
 <div class="header-actions">
-  <button mat-stroked-button routerLink="/collections/pieces">
-          <mat-icon>library_music</mat-icon>
-          <span>Alle Stücke</span>
-  </button>
+  <mat-button-toggle-group [value]="viewMode" (change)="onViewChange($event.value)">
+    <mat-button-toggle value="collections">Sammlungen</mat-button-toggle>
+    <mat-button-toggle value="pieces">Stücke</mat-button-toggle>
+  </mat-button-toggle-group>
   <button mat-flat-button color="accent" routerLink="/collections/new"
           [disabled]="!isChoirAdmin && !isAdmin"
           matTooltip="{{ !isChoirAdmin && !isAdmin ? 'Zum Hinzufügen müssen Sie als Chor-Administrator eingeloggt sein.' : '' }}">

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -12,7 +12,8 @@
 
 .header-actions {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 1rem;
 }
 

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -29,6 +29,7 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
   public isLoading = true;
   public isChoirAdmin = false;
   public isAdmin = false;
+  public viewMode: 'collections' | 'pieces' = 'collections';
   public pageSizeOptions: number[] = [10, 25, 50];
   public pageSize = 10;
   private _sort!: MatSort;
@@ -114,5 +115,11 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
 
   openCollection(collection: Collection): void {
     this.router.navigate(['/collections/edit', collection.id]);
+  }
+
+  onViewChange(value: 'collections' | 'pieces'): void {
+    if (value === 'pieces') {
+      this.router.navigate(['/collections/pieces']);
+    }
   }
 }

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -1,3 +1,10 @@
+<div class="header-actions">
+  <mat-button-toggle-group [value]="viewMode" (change)="onViewChange($event.value)">
+    <mat-button-toggle value="collections">Sammlungen</mat-button-toggle>
+    <mat-button-toggle value="pieces">Stücke</mat-button-toggle>
+  </mat-button-toggle-group>
+</div>
+
 <div class="letter-filter">
   <button mat-button *ngFor="let l of letters" (click)="onLetterSelect(l)" [color]="selectedLetter === l ? 'primary' : undefined">
     {{ l }}

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.scss
@@ -18,6 +18,12 @@
   }
 }
 
+.header-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 1rem;
+}
+
 .count-cell {
   text-align: center;
 }

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
@@ -25,6 +25,7 @@ export class CollectionPieceListComponent implements OnInit, AfterViewInit {
   totalPieces = 0;
   pageSizeOptions: number[] = [10, 25, 50];
   pageSize = 10;
+  viewMode: 'collections' | 'pieces' = 'pieces';
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
@@ -88,5 +89,11 @@ export class CollectionPieceListComponent implements OnInit, AfterViewInit {
 
   openPiece(piece: Piece): void {
     this.router.navigate(['/pieces', piece.id]);
+  }
+
+  onViewChange(value: 'collections' | 'pieces'): void {
+    if (value === 'collections') {
+      this.router.navigate(['/collections']);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace "Alle Stücke" button with a toggle group to switch between Sammlungen and Stücke views
- add corresponding toggle on the piece list for navigating back to collections
- style header actions for layout and maintain navigation state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c61310f0832088bb63481f245399