### PR TITLE
Show composer name for single-edition collections

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -144,7 +144,7 @@ exports.findLast = async (req, res) => {
                     { // Binde die Sammlungsdaten an jedes Stück
                         model: Collection,
                         as: 'collections',
-                        attributes: ['prefix'], // Wir brauchen nur den Präfix
+                        attributes: ['prefix', 'singleEdition'], // Wir brauchen nur den Präfix
                         through: {
                             model: CollectionPiece,
                             as: 'collection_piece', // Stellen Sie sicher, dass dieser Alias korrekt ist
@@ -232,7 +232,7 @@ exports.findOne = async (req, res) => {
                     {
                         model: Collection,
                         as: 'collections',
-                        attributes: ['prefix'],
+                        attributes: ['prefix', 'singleEdition'],
                         through: {
                             model: CollectionPiece,
                             as: 'collection_piece',

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -14,6 +14,7 @@ export interface PieceNote {
 export interface CollectionReference {
   prefix: string;
   title?: string;
+  singleEdition?: boolean;
   collection_piece: { // The name of the through model in Sequelize
     numberInCollection: string;
   };

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -195,7 +195,9 @@ export class EventDialogComponent implements OnInit {
                         reference:
                             newPiece.collections &&
                             newPiece.collections.length > 0
-                                ? `${newPiece.collections[0].prefix || ''}${
+                                ? `${newPiece.collections[0].singleEdition
+                                      ? newPiece.composer?.name || ''
+                                      : newPiece.collections[0].prefix || ''}${
                                       newPiece.collections[0].collection_piece
                                           .numberInCollection
                                   }`
@@ -227,7 +229,9 @@ export class EventDialogComponent implements OnInit {
             composerName: p.composer?.name || '',
             reference:
                 p.collections && p.collections.length > 0
-                    ? `${p.collections[0].prefix || ''}${
+                    ? `${p.collections[0].singleEdition
+                          ? p.composer?.name || ''
+                          : p.collections[0].prefix || ''}${
                           (p as any).collections[0].collection_piece
                               .numberInCollection
                       }`

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -20,7 +20,7 @@
     <p><strong>Enthalten in:</strong></p>
     <ul>
       <li *ngFor="let c of piece.collections">
-        {{ c.title }} ({{ c.prefix }}{{ c.collection_piece.numberInCollection }})
+        {{ c.title }} ({{ c.singleEdition ? piece.composer?.name : c.prefix }}{{ c.collection_piece.numberInCollection }})
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- use composer name as collection prefix when a piece belongs to a single-edition collection
- expose collection `singleEdition` to clients and adjust displays to show the composer instead of the prefix

## Testing
- `npm test --prefix choir-app-backend`
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6890cce715848320931864d6c6987148