### PR TITLE
feat: show composer name for single edition collections

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -38,10 +38,13 @@
           </mat-autocomplete>
         </mat-form-field>
 
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" *ngIf="!collectionForm.value.singleEdition || selectedPieceLinks.length === 0">
           <mat-label>Präfix (z.B. GL, EG)</mat-label>
           <input matInput formControlName="prefix" placeholder="CB">
         </mat-form-field>
+        <div *ngIf="collectionForm.value.singleEdition && selectedPieceLinks.length > 0" class="composer-display">
+          <strong>Komponist:</strong> {{ selectedPieceLinks[0].piece.composer?.name || '-' }}
+        </div>
 
         <mat-form-field appearance="outline">
           <mat-label>Verlagsnummer</mat-label>

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.ts
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.ts
@@ -43,7 +43,8 @@ export class EventCardComponent {
       const num = (ref as any).collection_piece?.numberInCollection;
 
       if (num) {
-        return `${ref.prefix || ''}${num}`;
+        const prefix = ref.singleEdition ? piece.composer?.name || '' : ref.prefix || '';
+        return `${prefix}${num}`;
       }
     }
     // Fallback, wenn keine Referenz vorhanden ist

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -272,7 +272,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     if (piece.collections && piece.collections.length > 0) {
       const ref = piece.collections[0];
       const num = (ref as any).collection_piece.numberInCollection;
-      return `${ref.prefix || ''}${num}`;
+      const prefix = ref.singleEdition ? piece.composer?.name || '' : ref.prefix || '';
+      return `${prefix}${num}`;
     }
     return '-';
   }


### PR DESCRIPTION
## Summary
- display first piece's composer instead of prefix when editing single-edition collections
- show composer name for single-edition pieces in lists and event cards

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6890d4b1f79083208afbdaae56900988