### PR TITLE
Avoid opening piece links in new tab

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -33,7 +33,7 @@
       <h3>Dateien</h3>
       <ul>
         <li *ngFor="let link of fileLinks">
-          <a [href]="getLinkUrl(link)" target="_blank" rel="noopener">{{ link.description }}</a>
+          <a [href]="getLinkUrl(link)">{{ link.description }}</a>
         </li>
       </ul>
     </div>
@@ -41,7 +41,7 @@
       <h3>Links</h3>
       <ul>
         <li *ngFor="let link of externalLinks">
-          <a [href]="getLinkUrl(link)" target="_blank" rel="noopener">{{ link.description }}</a>
+          <a [href]="getLinkUrl(link)">{{ link.description }}</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Open piece-related file and external links in the current tab instead of a new window

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6890d686cd308320b51e0e0e1a8fa8ef