### PR TITLE
Use dialog to edit pieces in collection view

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -394,10 +394,29 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     }
 
     openEditPieceDialog(pieceId: number): void {
-        const url = this.router.serializeUrl(
-            this.router.createUrlTree(['/pieces', pieceId], { queryParams: { edit: true } })
-        );
-        window.open(url, '_blank');
+        const dialogRef = this.dialog.open(PieceDialogComponent, {
+            width: '90vw',
+            maxWidth: '1000px',
+            data: { pieceId }
+        });
+
+        dialogRef.afterClosed().subscribe((wasUpdated) => {
+            if (wasUpdated) {
+                this.apiService.getPieceById(pieceId).subscribe((updatedPiece) => {
+                    const allIndex = this.allPieces.findIndex((p) => p.id === updatedPiece.id);
+                    if (allIndex !== -1) {
+                        this.allPieces[allIndex] = updatedPiece;
+                    }
+                    const linkIndex = this.selectedPieceLinks.findIndex(
+                        (l) => l.piece.id === updatedPiece.id
+                    );
+                    if (linkIndex !== -1) {
+                        this.selectedPieceLinks[linkIndex].piece = updatedPiece;
+                        this.updateDataSource();
+                    }
+                });
+            }
+        });
     }
 
     addPieceToCollection(): void {


### PR DESCRIPTION
## Summary
- Open `PieceDialogComponent` instead of new tab when editing a piece from the collection edit page
- Refresh updated piece in current collection after dialog closes

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6890d6a6da708320bf1a524136e5b7d1