### PR TITLE
Fix piece search new item title

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -98,13 +98,10 @@
               <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayPiece" (optionSelected)="onPieceSelected($event)">
                 <!-- The #auto MUST match the [matAutocomplete] above -->
                 <mat-option *ngFor="let piece of filteredPieces$ | async" [value]="piece">
-                  <!-- Use *ngIf inside the mat-option to conditionally show content -->
-                  <div *ngIf="piece.id === addNewPieceOption.id; else regularOption" class="add-new-option">
+                  <div *ngIf="piece.isNew; else regularOption" class="add-new-option">
                     <mat-icon>add</mat-icon>
-                    <span>{{ piece.title }}</span>
+                    <span>Stück anlegen "{{ piece.title }}"</span>
                   </div>
-
-                  <!-- This template will be shown for all regular pieces -->
                   <ng-template #regularOption>
                     {{ piece.title }}
                     <small class="composer-hint"> - {{ piece.composer?.name }}</small>


### PR DESCRIPTION
## Summary
- preserve typed title when adding new pieces in collection editor
- align piece search autocomplete with composer/author creation flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689109dbc31c8320b036d86c85653716