### PR TITLE
feat: support folk origins for pieces

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -133,7 +133,7 @@ exports.findLast = async (req, res) => {
             include: [{
                 model: Piece,
                 as: 'pieces',
-                attributes: ['id', 'title'],
+                attributes: ['id', 'title', 'origin'],
                 through: { attributes: [] },
                 include: [
                     { // Binde den Komponisten an jedes Stück
@@ -225,7 +225,7 @@ exports.findOne = async (req, res) => {
             include: [{
                 model: Piece,
                 as: 'pieces',
-                attributes: ['id', 'title'],
+                attributes: ['id', 'title', 'origin'],
                 through: { attributes: [] },
                 include: [
                     { model: Composer, as: 'composer', attributes: ['name'] },

--- a/choir-app-backend/src/controllers/search.controller.js
+++ b/choir-app-backend/src/controllers/search.controller.js
@@ -12,7 +12,8 @@ exports.search = async (req, res) => {
     where: {
       [Op.or]: [
         { title: like },
-        { lyrics: like }
+        { lyrics: like },
+        { origin: like }
       ]
     },
     include: [{ model: db.composer, as: 'composer', attributes: ['name'] }],

--- a/choir-app-backend/src/models/piece.model.js
+++ b/choir-app-backend/src/models/piece.model.js
@@ -43,6 +43,10 @@ module.exports = (sequelize, DataTypes) => {
         lyricsSource: { // Sonstige Quelle für den Text
             type: DataTypes.STRING,
             allowNull: true
+        },
+        origin: { // Alternativer Ursprung (z.B. Volksweise)
+            type: DataTypes.STRING,
+            allowNull: true
         }
     });
     return Piece;

--- a/choir-app-backend/src/validators/piece.validation.js
+++ b/choir-app-backend/src/validators/piece.validation.js
@@ -2,7 +2,14 @@ const { body } = require('express-validator');
 
 exports.createPieceValidation = [
   body('title').notEmpty().withMessage('Title is required.'),
-  body('composerId').isInt().withMessage('Valid composerId is required.'),
+  body('composerId').optional({ nullable: true }).isInt(),
+  body('origin').optional({ nullable: true }).isString(),
+  body().custom((value, { req }) => {
+    if (!req.body.composerId && !(req.body.composers && req.body.composers.length) && !req.body.origin) {
+      throw new Error('composerId or origin is required');
+    }
+    return true;
+  }),
   body('subtitle').optional({ nullable: true }).isString(),
   body('composerCollection').optional({ nullable: true }).isString(),
   body('arrangerIds').optional().isArray().withMessage('arrangerIds must be an array'),
@@ -19,7 +26,8 @@ exports.createPieceValidation = [
 
 exports.updatePieceValidation = [
   body('title').optional().notEmpty(),
-  body('composerId').optional().isInt(),
+  body('composerId').optional({ nullable: true }).isInt(),
+  body('origin').optional({ nullable: true }).isString(),
   body('subtitle').optional({ nullable: true }).isString(),
   body('composerCollection').optional({ nullable: true }).isString(),
   body('arrangerIds').optional().isArray(),

--- a/choir-app-backend/tests/piece.validation.test.js
+++ b/choir-app-backend/tests/piece.validation.test.js
@@ -9,6 +9,11 @@ const { createPieceValidation, updatePieceValidation } = require('../src/validat
     let res = validationResult(req1);
     assert.ok(!res.isEmpty(), 'create should fail without title');
 
+    const reqNoComposer = { body: { title: 'X' } };
+    for (const v of createPieceValidation) { await v.run(reqNoComposer); }
+    res = validationResult(reqNoComposer);
+    assert.ok(!res.isEmpty(), 'create should fail without composerId or origin');
+
     const req2 = { body: { title: 'X', arrangerIds: 'foo' } };
     for (const v of updatePieceValidation) { await v.run(req2); }
     res = validationResult(req2);

--- a/choir-app-backend/tests/search.controller.test.js
+++ b/choir-app-backend/tests/search.controller.test.js
@@ -12,6 +12,7 @@ const controller = require('../src/controllers/search.controller');
     const composer = await db.composer.create({ name: 'Handel' });
     await db.piece.create({ title: 'Hallelujah', composerId: composer.id });
     await db.piece.create({ title: 'Freedom', lyrics: 'Words of hope and love', composerId: composer.id });
+    await db.piece.create({ title: 'Folk', origin: 'Tradition' });
     await db.collection.create({ title: 'Advent', prefix: 'AD' });
     await db.event.create({ choirId: choir.id, date: new Date(), type: 'SERVICE', notes: 'Weekly service' });
 
@@ -21,6 +22,10 @@ const controller = require('../src/controllers/search.controller');
     assert.strictEqual(res.statusCode, 200);
     assert.ok(res.data.pieces.find(p => p.title === 'Freedom'));
     assert.strictEqual(res.data.collections.length, 0);
+
+    const reqOrigin = { query: { q: 'Trad' }, activeChoirId: choir.id };
+    await controller.search(reqOrigin, res);
+    assert.ok(res.data.pieces.find(p => p.title === 'Folk'));
 
     console.log('search.controller tests passed');
     await db.sequelize.close();

--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -14,6 +14,7 @@ export interface EventPiece {
    * compatible with both variations.
    */
   composer?: Composer & { id?: number };
+  origin?: string;
   /** Optional author data used when displaying the piece in event lists */
   author?: Author;
   /** Optional lyrics source text */

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -26,6 +26,7 @@ export interface Piece {
   subtitle?: string;
   composerCollection?: string;
   voicing?: string;
+  origin?: string;
   composer?: Composer;
   composers?: (Composer & { piece_composer: { type?: string } })[];
   category?: Category;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -167,7 +167,7 @@ export class ApiService {
    * Creates a new piece in the global master list.
    * @param pieceData - The core data for the new piece.
    */
-  createGlobalPiece(pieceData: { title: string, composerId: number, categoryId?: number, voicing?: string, composers?: { id: number; type?: string }[] }): Observable<Piece> {
+  createGlobalPiece(pieceData: { title: string; composerId?: number | null; origin?: string | null; categoryId?: number; voicing?: string; composers?: { id: number; type?: string }[] }): Observable<Piece> {
     return this.pieceService.createGlobalPiece(pieceData);
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -214,8 +214,8 @@
             </td>
           </ng-container>
           <ng-container matColumnDef="composer">
-            <th mat-header-cell *matHeaderCellDef> Komponist </th>
-            <td mat-cell *matCellDef="let piece">{{ piece.composer?.name }}</td>
+            <th mat-header-cell *matHeaderCellDef> Komponist/Ursprung </th>
+            <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</td>
           </ng-container>
           <tr mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></tr>

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -43,7 +43,7 @@
           <input matInput formControlName="prefix" placeholder="CB">
         </mat-form-field>
         <div *ngIf="collectionForm.value.singleEdition && selectedPieceLinks.length > 0" class="composer-display">
-          <strong>Komponist:</strong> {{ selectedPieceLinks[0].piece.composer?.name || '-' }}
+          <strong>Komponist/Ursprung:</strong> {{ selectedPieceLinks[0].piece.composer?.name || selectedPieceLinks[0].piece.origin || '-' }}
         </div>
 
         <mat-form-field appearance="outline">
@@ -107,7 +107,7 @@
                   <!-- This template will be shown for all regular pieces -->
                   <ng-template #regularOption>
                     {{ piece.title }}
-                    <small class="composer-hint"> - {{ piece.composer?.name }}</small>
+                    <small class="composer-hint"> - {{ piece.composer?.name || piece.origin }}</small>
                   </ng-template>
                 </mat-option>
               </mat-autocomplete>
@@ -162,8 +162,8 @@
                 <div class="piece-title">{{ link.piece.title }}</div>
                 <div
                   class="piece-composer"
-                  *ngIf="link.piece.composer?.name"
-                >{{ link.piece.composer.name }}</div>
+                  *ngIf="link.piece.composer?.name || link.piece.origin"
+                >{{ link.piece.composer?.name || link.piece.origin }}</div>
               </td>
             </ng-container>
 

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -137,7 +137,7 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
       }
       this.composerCache.set(collection.id, '');
       this.apiService.getCollectionById(collection.id).subscribe(col => {
-        const name = col.pieces?.[0]?.composer?.name ?? '';
+        const name = col.pieces?.[0]?.composer?.name || col.pieces?.[0]?.origin || '';
         this.composerCache.set(collection.id, name);
       });
     }

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -23,8 +23,8 @@
       </ng-container>
 
       <ng-container matColumnDef="composer">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist</th>
-        <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || '-' }}</td>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist/Ursprung</th>
+        <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin || '-' }}</td>
       </ng-container>
 
       <ng-container matColumnDef="author">

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
@@ -51,7 +51,7 @@ export class CollectionPieceListComponent implements OnInit, AfterViewInit {
       this.dataSource.sortingDataAccessor = (item, property) => {
         switch (property) {
           case 'composer':
-            return item.composer?.name || '';
+            return item.composer?.name || item.origin || '';
           case 'author':
             return item.author?.name || '';
           default:

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.ts
@@ -191,12 +191,12 @@ export class EventDialogComponent implements OnInit {
                     const lookup: LookupPiece = {
                         id: newPiece.id,
                         title: newPiece.title,
-                        composerName: newPiece.composer?.name || '',
+                        composerName: newPiece.composer?.name || newPiece.origin || '',
                         reference:
                             newPiece.collections &&
                             newPiece.collections.length > 0
                                 ? `${newPiece.collections[0].singleEdition
-                                      ? newPiece.composer?.name || ''
+                                      ? newPiece.composer?.name || newPiece.origin || ''
                                       : newPiece.collections[0].prefix || ''}${
                                       newPiece.collections[0].collection_piece
                                           .numberInCollection
@@ -226,11 +226,11 @@ export class EventDialogComponent implements OnInit {
         this.selectedPieces = event.pieces.map((p) => ({
             id: p.id,
             title: p.title,
-            composerName: p.composer?.name || '',
+            composerName: p.composer?.name || p.origin || '',
             reference:
                 p.collections && p.collections.length > 0
                     ? `${p.collections[0].singleEdition
-                          ? p.composer?.name || ''
+                          ? p.composer?.name || p.origin || ''
                           : p.collections[0].prefix || ''}${
                           (p as any).collections[0].collection_piece
                               .numberInCollection

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.ts
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.ts
@@ -31,7 +31,7 @@ export class EventCardComponent {
     if (!piece) {
       return '';
     }
-    const composer = piece.composer?.name || '';
+    const composer = piece.composer?.name || piece.origin || '';
     const author = piece.author?.name || piece.lyricsSource || '';
     return author ? `${composer} - ${author}` : composer;
   }
@@ -43,7 +43,7 @@ export class EventCardComponent {
       const num = (ref as any).collection_piece?.numberInCollection;
 
       if (num) {
-        const prefix = ref.singleEdition ? piece.composer?.name || '' : ref.prefix || '';
+        const prefix = ref.singleEdition ? piece.composer?.name || piece.origin || '' : ref.prefix || '';
         return `${prefix}${num}`;
       }
     }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -101,9 +101,9 @@
 
             <!-- Composer Column -->
             <ng-container matColumnDef="composer">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="composer"> Komponist </th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="composer"> Komponist/Ursprung </th>
               <td mat-cell *matCellDef="let piece">
-                {{piece.composer?.name}}
+                {{piece.composer?.name || piece.origin}}
               </td>
             </ng-container>
 

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -272,7 +272,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     if (piece.collections && piece.collections.length > 0) {
       const ref = piece.collections[0];
       const num = (ref as any).collection_piece.numberInCollection;
-      const prefix = ref.singleEdition ? piece.composer?.name || '' : ref.prefix || '';
+      const prefix = ref.singleEdition ? piece.composer?.name || piece.origin || '' : ref.prefix || '';
       return `${prefix}${num}`;
     }
     return '-';

--- a/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail-dialog/piece-detail-dialog.component.html
@@ -1,6 +1,6 @@
 <h1 mat-dialog-title>{{ piece?.title }}</h1>
 <div mat-dialog-content *ngIf="piece">
-  <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
+  <p><strong>Komponist/Ursprung:</strong> {{ piece.composer?.name || piece.origin }}</p>
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
   <p><strong>Status im Chor:</strong> {{ piece.choir_repertoire?.status | pieceStatusLabel }}</p>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -6,7 +6,7 @@
     </button>
   </h2>
   <p *ngIf="piece.subtitle"><em>{{ piece.subtitle }}</em></p>
-  <p><strong>Komponist:</strong> {{ piece.composer?.name }}</p>
+  <p><strong>Komponist/Ursprung:</strong> {{ piece.composer?.name || piece.origin }}</p>
   <p *ngIf="piece.composerCollection"><strong>Sammlung des Komponisten:</strong> {{ piece.composerCollection }}</p>
   <p><strong>Dichter/Quelle:</strong> {{ piece.author?.name || piece.lyricsSource || '-' }}</p>
   <p><strong>Kategorie:</strong> {{ piece.category?.name }}</p>
@@ -20,7 +20,7 @@
     <p><strong>Enthalten in:</strong></p>
     <ul>
       <li *ngFor="let c of piece.collections">
-        {{ c.title }} ({{ c.singleEdition ? piece.composer?.name : c.prefix }}{{ c.collection_piece.numberInCollection }})
+        {{ c.title }} ({{ c.singleEdition ? (piece.composer?.name || piece.origin) : c.prefix }}{{ c.collection_piece.numberInCollection }})
       </li>
     </ul>
   </div>

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -63,6 +63,11 @@
                 </mat-autocomplete>
               </mat-form-field>
 
+              <mat-form-field appearance="outline">
+                <mat-label>Ursprung</mat-label>
+                <input matInput formControlName="origin">
+              </mat-form-field>
+
             </div>
           </ng-container>
 

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -38,6 +38,14 @@ export function authorOrSourceValidator(): ValidatorFn {
     };
 }
 
+export function composerOrOriginValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+        const composerId = control.get('composerId')?.value;
+        const origin = control.get('origin')?.value;
+        return !composerId && !origin ? { composerOrOriginRequired: true } : null;
+    };
+}
+
 @Component({
     selector: 'app-piece-dialog',
     standalone: true,
@@ -99,10 +107,11 @@ export class PieceDialogComponent implements OnInit {
             key: [''],
             timeSignature: [''],
             license: [''],
-            composerId: [null, Validators.required],
+            composerId: [null],
+            origin: [''],
             authorId: [null],
             categoryId: [null],
-        }, { validators: authorOrSourceValidator() });
+        }, { validators: [authorOrSourceValidator(), composerOrOriginValidator()] });
 
         if (!this.isEditMode && data.initialTitle) {
             this.pieceForm.get('title')?.setValue(data.initialTitle);
@@ -358,7 +367,7 @@ export class PieceDialogComponent implements OnInit {
     isGeneralStepInvalid(): boolean {
         return (
             this.pieceForm.get('title')?.invalid ||
-            this.pieceForm.get('composerId')?.invalid ||
+            this.pieceForm.hasError('composerOrOriginRequired') ||
             false
         );
     }
@@ -378,6 +387,7 @@ export class PieceDialogComponent implements OnInit {
             timeSignature: piece.timeSignature,
             license: piece.license,
             composerId: piece.composer?.id,
+            origin: piece.origin,
             authorId: piece.author?.id,
             categoryId: piece.category?.id,
             arrangerIds: piece.arrangers?.map((a) => a.id) || [],


### PR DESCRIPTION
## Summary
- allow specifying an optional origin for pieces without a composer
- surface origin throughout controllers, search and repertoire lookups
- update frontend forms and tables to display composer or origin

## Testing
- `npm test --prefix choir-app-backend`
- `npm test` *(fails: ChromeHeadless missing libatk-bridge-2.0.so.0)*


------
https://chatgpt.com/codex/tasks/task_e_68910c4141f08320ae67a512bfc28574