### PR TITLE
fix(collection): avoid unintended submit when editing pieces

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -168,10 +168,10 @@
             <ng-container matColumnDef="actions">
               <th mat-header-cell *matHeaderCellDef></th>
               <td mat-cell *matCellDef="let link" class="actions-cell">
-                <button mat-icon-button (click)="openEditPieceDialog(link.piece.id)" matTooltip="Stück bearbeiten">
+                <button type="button" mat-icon-button (click)="openEditPieceDialog(link.piece.id)" matTooltip="Stück bearbeiten">
                   <mat-icon>edit</mat-icon>
                 </button>
-                <button mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Stück aus Sammlung entfernen">
+                <button type="button" mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Stück aus Sammlung entfernen">
                   <mat-icon>delete</mat-icon>
                 </button>
               </td>


### PR DESCRIPTION
## Summary
- prevent collection form submission when opening the piece edit dialog by changing action buttons to type="button"

## Testing
- `cd choir-app-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891153218d8832089c8703e11dbf8df