### PR TITLE
style: display posts like blog and allow admin edits

### DIFF
--- a/choir-app-backend/src/controllers/auth.controller.js
+++ b/choir-app-backend/src/controllers/auth.controller.js
@@ -160,6 +160,9 @@ exports.switchChoir = async (req, res) => {
 
 exports.checkChoirAdminStatus = async (req, res) => {
     try {
+        if (req.userRole === 'admin') {
+            return res.status(200).send({ isChoirAdmin: true });
+        }
         const association = await db.user_choir.findOne({
             where: {
                 userId: req.userId,

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -3,19 +3,21 @@
 </div>
 
 <ng-container *ngIf="posts.length; else noPosts">
-  <mat-list class="post-list">
-    <mat-list-item *ngFor="let p of posts">
-      <div class="full-width">
-        <h3>{{ p.title }}</h3>
+  <div class="post-list">
+    <mat-card *ngFor="let p of posts" class="post">
+      <mat-card-header>
+        <mat-card-title>{{ p.title }}</mat-card-title>
+        <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }}</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
         <p>{{ p.text }}</p>
-        <small>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }}</small>
-      </div>
-      <div *ngIf="canEdit(p)" class="actions">
+      </mat-card-content>
+      <mat-card-actions *ngIf="canEdit(p)" class="actions">
         <button mat-icon-button (click)="editPost(p)" matTooltip="Bearbeiten"><mat-icon>edit</mat-icon></button>
         <button mat-icon-button (click)="deletePost(p)" matTooltip="Löschen"><mat-icon>delete</mat-icon></button>
-      </div>
-    </mat-list-item>
-  </mat-list>
+      </mat-card-actions>
+    </mat-card>
+  </div>
 </ng-container>
 
 <ng-template #noPosts>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.scss
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.scss
@@ -9,13 +9,13 @@
   gap: 8px;
 }
 
-.full-width {
-  flex: 1;
-}
-
 .post-list {
   flex: 1 1 auto;
   overflow: auto;
+}
+
+.post {
+  margin-bottom: 1rem;
 }
 
 .no-posts {


### PR DESCRIPTION
## Summary
- treat global admins as choir admins when checking edit permissions
- render posts in a blog-like card layout
- add margin styling for post cards

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689194247e208320b1e8bc09e794505b