### PR TITLE
Add join-by-link option and restrict service settings

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.duplicate.test.js",
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.duplicate.test.js && node tests/join.controller.test.js",
     "check": "node --check server.js",
     "init": "node scripts/init.js",
     "seed": "node scripts/seed.js"

--- a/choir-app-backend/src/controllers/join.controller.js
+++ b/choir-app-backend/src/controllers/join.controller.js
@@ -4,7 +4,9 @@ const bcrypt = require('bcryptjs');
 exports.getJoinInfo = async (req, res) => {
   try {
     const choir = await db.choir.findOne({ where: { joinHash: req.params.token } });
-    if (!choir) return res.status(404).send({ message: 'Join link not found.' });
+    if (!choir || !choir.modules || !choir.modules.joinByLink) {
+      return res.status(404).send({ message: 'Join link not found.' });
+    }
     res.status(200).send({ choirName: choir.name });
   } catch (err) {
     res.status(500).send({ message: err.message });
@@ -18,7 +20,9 @@ exports.joinChoir = async (req, res) => {
   }
   try {
     const choir = await db.choir.findOne({ where: { joinHash: req.params.token } });
-    if (!choir) return res.status(404).send({ message: 'Join link not found.' });
+    if (!choir || !choir.modules || !choir.modules.joinByLink) {
+      return res.status(404).send({ message: 'Join link not found.' });
+    }
     const existing = await db.user.findOne({ where: { email } });
     if (existing) return res.status(409).send({ message: 'User already exists.' });
     const user = await db.user.create({ name, email, password: bcrypt.hashSync(password, 8), role: 'singer' });

--- a/choir-app-backend/tests/join.controller.test.js
+++ b/choir-app-backend/tests/join.controller.test.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/join.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+    const choir = await db.choir.create({ name: 'Join Test Choir', joinHash: 'token123', modules: {} });
+    const res = {
+      status(code) { this.statusCode = code; return this; },
+      send(data) { this.data = data; }
+    };
+
+    await controller.getJoinInfo({ params: { token: 'token123' } }, res);
+    assert.strictEqual(res.statusCode, 404, 'join should be disabled by default');
+
+    await choir.update({ modules: { joinByLink: true } });
+
+    await controller.getJoinInfo({ params: { token: 'token123' } }, res);
+    assert.strictEqual(res.statusCode, 200, 'join info should succeed when enabled');
+    assert.strictEqual(res.data.choirName, 'Join Test Choir');
+
+    await controller.joinChoir({ params: { token: 'token123' }, body: { name: 'User', email: 'u@example.com', password: 'pw' } }, res);
+    assert.strictEqual(res.statusCode, 201, 'join should succeed when enabled');
+
+    console.log('join.controller test passed');
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -8,6 +8,7 @@ export interface Choir {
     pieceCount?: number;
     modules?: {
         dienstplan?: boolean;
+        joinByLink?: boolean;
     };
     joinHash?: string;
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -30,7 +30,6 @@
           </button>
         </div>
       </form>
-      <p *ngIf="isChoirAdmin && joinLink">Beitrittslink: <a [href]="joinLink" target="_blank">{{joinLink}}</a></p>
     </mat-card-content>
   </mat-card>
 
@@ -40,11 +39,16 @@
       <mat-card-title>Einstellungen</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <mat-checkbox [(ngModel)]="dienstplanEnabled" (change)="onToggleDienstplan()">
+      <mat-checkbox [(ngModel)]="dienstplanEnabled" (change)="onModulesChange()">
         Dienstplan anzeigen
       </mat-checkbox>
 
-      <div class="service-settings">
+      <mat-checkbox [(ngModel)]="joinByLinkEnabled" (change)="onModulesChange()">
+        Beitritt als Sänger per Link erlauben
+      </mat-checkbox>
+      <p *ngIf="joinByLinkEnabled && joinLink">Beitrittslink: <a [href]="joinLink" target="_blank">{{joinLink}}</a></p>
+
+      <div class="service-settings" *ngIf="dienstplanEnabled">
         <h3>Gottesdienste</h3>
         <mat-form-field appearance="outline">
           <mat-label>Sonntags</mat-label>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -32,6 +32,7 @@ export class ManageChoirComponent implements OnInit {
 
   isChoirAdmin = false;
   dienstplanEnabled = false;
+  joinByLinkEnabled = false;
 
   /**
    * Holds the choirId from the query parameter when a global admin
@@ -87,6 +88,7 @@ export class ManageChoirComponent implements OnInit {
         this.choirForm.patchValue(pageData.choirDetails);
         this.isChoirAdmin = pageData.isChoirAdmin;
         this.dienstplanEnabled = !!pageData.choirDetails.modules?.dienstplan;
+        this.joinByLinkEnabled = !!pageData.choirDetails.modules?.joinByLink;
         const rules = pageData.planRules as any[] || [];
         const sundayRule = rules.find(r => r.dayOfWeek === 0);
         if (sundayRule) {
@@ -223,12 +225,12 @@ export class ManageChoirComponent implements OnInit {
   }
 
 
-  onToggleDienstplan(): void {
+  onModulesChange(): void {
     if (!this.isChoirAdmin) {
       return;
     }
 
-    const modules = { dienstplan: this.dienstplanEnabled };
+    const modules = { dienstplan: this.dienstplanEnabled, joinByLink: this.joinByLinkEnabled };
     const opts = this.adminChoirId ? { choirId: this.adminChoirId } : undefined;
     this.apiService.updateMyChoir({ modules }, opts).subscribe({
       next: () => {


### PR DESCRIPTION
## Summary
- add optional "Beitritt als Sänger per Link erlauben" checkbox to choir settings
- hide Gottesdienst settings unless Dienstplan is enabled
- disallow choir joining via link unless allowed, with tests

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file)*
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_689195f9b56c8320beedb1ebb8d888ca