### PR TITLE
fix: prevent sidenav overlay on desktop

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -65,11 +65,13 @@
 </mat-toolbar>
 
 <mat-sidenav-container class="site-container">
-  <mat-sidenav #appDrawer mode="over" [fixedInViewport]="false" [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
-    [mode]="(isHandset$ | async) ? 'over' : 'side'" [opened]="!(isHandset$ | async) && drawerOpenByWidth" class="appDrawer" [ngClass]="{'appdrawer-invisible' : !(isLoggedIn$ | async)}">
+  <mat-sidenav *ngIf="isLoggedIn$ | async" #appDrawer [fixedInViewport]="false"
+    [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
+    [mode]="(isHandset$ | async) ? 'over' : 'side'"
+    [opened]="!(isHandset$ | async) && drawerOpenByWidth" class="appDrawer">
 
     <mat-nav-list>
-      <app-choir-switcher *ngIf="isLoggedIn$ | async"></app-choir-switcher>
+      <app-choir-switcher></app-choir-switcher>
       <app-menu-list-item *ngFor="let item of navItems" [item]="item"></app-menu-list-item>
     </mat-nav-list>
   </mat-sidenav>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
@@ -83,10 +83,6 @@
   font-size: small;
 }
 
-.appdrawer-invisible {
-  display: none;
-}
-
 @media (max-width: 599px) {
   .appDrawer {
     width: 70vw;

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -54,8 +54,15 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
   showAdminSubmenu: boolean = true;
   isExpanded = true;
   isShowing = false;
-  @ViewChild('appDrawer') appDrawer: MatDrawer | undefined;
-   private isHandset: boolean = false;
+  private _appDrawer: MatDrawer | undefined;
+  @ViewChild('appDrawer')
+  set appDrawer(drawer: MatDrawer | undefined) {
+    this._appDrawer = drawer;
+    if (drawer) {
+      this.navService.appDrawer = drawer;
+    }
+  }
+  private isHandset: boolean = false;
 
   drawerOpenByWidth = true;
   private readonly drawerWidth = 220;
@@ -143,8 +150,8 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
 
   ngAfterViewInit(): void {
     this.evaluateDrawerWidth();
-    if (this.appDrawer) {
-      this.navService.appDrawer = this.appDrawer;
+    if (this._appDrawer) {
+      this.navService.appDrawer = this._appDrawer;
     }
   }
 
@@ -311,7 +318,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
 
   public closeSidenav() {
     if (this.isHandset) {
-      this.appDrawer?.close();
+      this._appDrawer?.close();
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure main layout sidenav only rendered when logged in
- remove css-based hiding and update ViewChild handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68930823ccc083209238d192ba65a302