### PR TITLE
Avoid showing 401 error after session expiry

### DIFF
--- a/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/error-interceptor.ts
@@ -14,6 +14,11 @@ export class ErrorInterceptor implements HttpInterceptor {
         if (req.url.includes('/auth/signin')) {
           return throwError(() => error);
         }
+        if (error.status === 401) {
+          // Unauthorized errors are handled by AuthInterceptor (logout and redirect).
+          // Avoid showing them as global errors.
+          return throwError(() => error);
+        }
         if (error.status === 0 && (error as HttpErrorResponse).error === 'abort') {
           // The request was cancelled, e.g. due to logout. Avoid reporting an error.
           return throwError(() => error);


### PR DESCRIPTION
## Summary
- ignore 401 responses in the global `ErrorInterceptor` so expired sessions redirect to login without displaying a 401 error dialog

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_689308339b4c83209f377c4f7f0b7251