### PR TITLE
feat: improve table responsiveness for mobile

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -28,7 +28,7 @@
     <!-- Status Column -->
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef mat-sort-header="status"> Status </th>
-      <td mat-cell *matCellDef="let collection">
+      <td mat-cell *matCellDef="let collection" class="status-cell">
         <mat-icon
           class="status-icon"
           [color]="collection.isAdded ? 'primary' : 'disabled'"
@@ -41,7 +41,7 @@
     <!-- Title Column -->
     <ng-container matColumnDef="title">
       <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
-      <td mat-cell *matCellDef="let collection">
+      <td mat-cell *matCellDef="let collection" class="title-cell">
         <strong>{{ collection.title }}</strong>
         <div class="subtitle-hint" *ngIf="collection.subtitle">{{ collection.subtitle }}</div>
         <div class="prefix-hint" *ngIf="!collection.singleEdition && collection.prefix">{{ collection.prefix }}</div>
@@ -59,7 +59,7 @@
     <!-- Publisher Column -->
     <ng-container matColumnDef="publisher">
       <th mat-header-cell *matHeaderCellDef mat-sort-header="publisher"> Verlag </th>
-      <td mat-cell *matCellDef="let collection"> {{ collection.publisher || '-' }} </td>
+      <td mat-cell *matCellDef="let collection" class="publisher-cell"> {{ collection.publisher || '-' }} </td>
     </ng-container>
 
     <!-- Actions Column -->

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -91,11 +91,38 @@ mat-card-actions button mat-icon {
 
 @media (prefers-color-scheme: dark) {
     .table-wrapper .mat-row:hover {
-        background-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(255, 255, 255, 0.08);
     }
 }
 
 mat-paginator {
     flex-shrink: 0;
     border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+@media (max-width: 600px) {
+    .table-wrapper .mat-header-row {
+        display: none;
+    }
+
+    .table-wrapper .mat-row {
+        display: grid;
+        grid-template-columns: 64px 1fr auto;
+        align-items: center;
+        padding: 8px 0;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    }
+
+    .table-wrapper .mat-row .mat-cell {
+        border: none;
+        padding: 4px 8px;
+        display: block;
+    }
+
+    .table-wrapper .mat-row .cover-cell { grid-column: 1; }
+    .table-wrapper .mat-row .status-cell { grid-column: 2; order: 1; }
+    .table-wrapper .mat-row .title-cell { grid-column: 2; order: 2; }
+    .table-wrapper .mat-row .titles-cell { grid-column: 2; order: 3; }
+    .table-wrapper .mat-row .publisher-cell { grid-column: 2; order: 4; }
+    .table-wrapper .mat-row .actions-cell { grid-column: 3; order: 5; text-align: right; }
 }

--- a/choir-app-frontend/src/styles.scss
+++ b/choir-app-frontend/src/styles.scss
@@ -29,11 +29,23 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   .mat-mdc-table {
     display: block;
     width: 100%;
-    overflow-x: auto;
   }
 
-  .mat-mdc-table th,
-  .mat-mdc-table td {
+  .mat-mdc-header-row {
+    display: none;
+  }
+
+  .mat-mdc-row {
+    display: block;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    padding: 8px 0;
+  }
+
+  .mat-mdc-row .mat-mdc-cell {
+    display: block;
+    width: 100%;
+    padding: 4px 8px;
+    box-sizing: border-box;
     word-break: break-word;
   }
 }


### PR DESCRIPTION
## Summary
- make Material tables stack on small screens for better readability
- reorganize collection list layout for mobile with cover, details, and actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68930c7238c08320b5f131a5e1b2f303