### PR TITLE
fix: safely toggle drawer

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar color="primary" class="main-toolbar">
-  <button type="button" aria-label="Menü umschalten" mat-icon-button (click)="appDrawer.toggle()">
+  <button type="button" aria-label="Menü umschalten" mat-icon-button (click)="appDrawer?.toggle()">
     <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
   </button>
 


### PR DESCRIPTION
## Summary
- safely toggle `appDrawer` using optional chaining to avoid undefined errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68933887c894832080028beea7e5279f