### PR TITLE
Show event notes when no pieces present on dashboard

### DIFF
--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.html
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.html
@@ -9,18 +9,25 @@
         {{ event.date | date:'fullDate' }}
         <span class="event-creator" *ngIf="event.director">({{ event.director.name }})</span>
       </h3>
-      <mat-list>
-        <mat-list-item *ngFor="let piece of event.pieces">
-          <div matListItemTitle>
-            <a [routerLink]="['/pieces', piece.id]" class="piece-link">
-              {{getPieceReference(piece)}} {{ piece.title }}
-            </a>
-          </div>
-          <div matListItemLine>
-              <span>{{ getPieceSubtitle(piece) }}</span>
-          </div>
-        </mat-list-item>
-      </mat-list>
+      <ng-container *ngIf="event.pieces.length > 0; else noteBlock">
+        <mat-list>
+          <mat-list-item *ngFor="let piece of event.pieces">
+            <div matListItemTitle>
+              <a [routerLink]="['/pieces', piece.id]" class="piece-link">
+                {{getPieceReference(piece)}} {{ piece.title }}
+              </a>
+            </div>
+            <div matListItemLine>
+                <span>{{ getPieceSubtitle(piece) }}</span>
+            </div>
+          </mat-list-item>
+        </mat-list>
+      </ng-container>
+      <ng-template #noteBlock>
+        <div *ngIf="event.notes" class="event-note">
+          {{ event.notes }}
+        </div>
+      </ng-template>
     </ng-container>
 
     <!-- Diese Vorlage wird angezeigt, wenn das 'event'-Input null ist -->

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.scss
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.scss
@@ -7,6 +7,8 @@ mat-card {
 
 mat-card-content {
     flex-grow: 1; // Lässt den Inhalt wachsen, um den Platz zu füllen
+    display: flex;
+    flex-direction: column;
 }
 
 mat-card-content h3 {
@@ -28,6 +30,15 @@ mat-card-content h3 {
     align-items: center;
     height: 100px;
     color: #999;
+}
+
+.event-note {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 0 1rem;
 }
 
 // In dunklem Modus anpassen

--- a/choir-app-frontend/src/app/features/home/event-card/event-card.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/event-card/event-card.component.spec.ts
@@ -35,4 +35,19 @@ describe('EventCardComponent', () => {
     const h3 = fixture.nativeElement.querySelector('h3');
     expect(h3.textContent).toContain('(Alice)');
   });
+
+  it('should show notes when no pieces are present', () => {
+    component.event = {
+      id: 2,
+      date: '2023-01-02',
+      type: 'SERVICE',
+      createdAt: '2023-01-02',
+      updatedAt: '2023-01-02',
+      notes: 'General rehearsal',
+      pieces: []
+    } as any;
+    fixture.detectChanges();
+    const noteEl = fixture.nativeElement.querySelector('.event-note');
+    expect(noteEl.textContent).toContain('General rehearsal');
+  });
 });


### PR DESCRIPTION
## Summary
- show event notes when events have no pieces on dashboard event cards
- center displayed notes with new styling
- test that notes render without pieces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b8ee54488320869842f416ef40b0