### PR TITLE
feat: confirm before replacing collection cover image

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -23,6 +23,7 @@ import {
 } from '@angular/material/autocomplete';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
+import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { AuthService } from '@core/services/auth.service';
 import { ImportDialogComponent } from '../import-dialog/import-dialog.component';
 
@@ -510,10 +511,27 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     }
 
     private handleFile(file: File): void {
-        this.coverFile = file;
-        const reader = new FileReader();
-        reader.onload = () => (this.coverPreview = reader.result as string);
-        reader.readAsDataURL(file);
+        const proceed = () => {
+            this.coverFile = file;
+            const reader = new FileReader();
+            reader.onload = () => (this.coverPreview = reader.result as string);
+            reader.readAsDataURL(file);
+        };
+
+        if (this.coverPreview) {
+            const dialogData: ConfirmDialogData = {
+                title: 'Cover überschreiben?',
+                message: 'Es existiert bereits ein Coverbild. Möchten Sie es überschreiben?',
+            };
+            const ref = this.dialog.open(ConfirmDialogComponent, { data: dialogData });
+            ref.afterClosed().subscribe(confirmed => {
+                if (confirmed) {
+                    proceed();
+                }
+            });
+        } else {
+            proceed();
+        }
     }
 
     // Fügen Sie diese Methode hinzu


### PR DESCRIPTION
## Summary
- prompt before overwriting an existing collection cover image

## Testing
- `cd choir-app-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b8633c088320933736dc8e3b5a97