### PR TITLE
Fix PDF download on piece page with correct filenames

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -33,7 +33,7 @@
       <h3>Dateien</h3>
       <ul>
         <li *ngFor="let link of fileLinks">
-          <a [href]="getLinkUrl(link)">{{ link.description }}</a>
+          <a [href]="getLinkUrl(link)" [attr.download]="link.description">{{ link.description }}</a>
         </li>
       </ul>
     </div>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -140,8 +140,8 @@ export class PieceDetailComponent implements OnInit {
     if (/^https?:\/\//i.test(link.url)) {
       return link.url;
     }
-    const base = environment.baseUrl.replace(/\/$/, '');
+    const apiBase = environment.apiUrl.replace(/\/$/, '');
     const path = link.url.startsWith('/') ? link.url : `/${link.url}`;
-    return `${base}${path}`;
+    return `${apiBase}${path}`;
   }
 }


### PR DESCRIPTION
## Summary
- ensure piece file links go through API base so downloads are served by backend
- force browser downloads with original file names on piece detail page

## Testing
- `npm test --prefix choir-app-frontend`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6893b833489883209fe72005a4dc4093