### PR TITLE
Fix piece download links to retain filenames

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -140,7 +140,7 @@ export class PieceDetailComponent implements OnInit {
     if (/^https?:\/\//i.test(link.url)) {
       return link.url;
     }
-    const apiBase = environment.apiUrl.replace(/\/$/, '');
+    const apiBase = environment.apiUrl.replace(/\/api\/?$/, '');
     const path = link.url.startsWith('/') ? link.url : `/${link.url}`;
     return `${apiBase}${path}`;
   }

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -268,6 +268,7 @@ export class PieceDialogComponent implements OnInit {
         const linkGroup = this.linksFormArray.at(index) as FormGroup;
         this.pieceService.uploadPieceLinkFile(file).subscribe(res => {
             linkGroup.get('url')?.setValue(res.path);
+            linkGroup.get('description')?.setValue(file.name);
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure uploaded file links default to original filename
- correct piece link URL generation by stripping `/api`

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68942d5f3efc83208a54404b049bd058