### PR TITLE
feat(admin): add file overview

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -375,6 +375,7 @@ exports.updateChoirMember = async (req, res) => {
 };
 
 const logService = require('../services/log.service');
+const fileService = require('../services/file.service');
 
 exports.listLogs = async (req, res) => {
     try {
@@ -403,6 +404,27 @@ exports.deleteLog = async (req, res) => {
     try {
         const deleted = await logService.deleteLogFile(filename);
         if (!deleted) return res.status(404).send({ message: 'Log file not found' });
+        res.status(200).send({ message: 'Deleted' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.listUploads = async (req, res) => {
+    try {
+        const data = await fileService.listFiles();
+        res.status(200).send(data);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.deleteUpload = async (req, res) => {
+    const { category, filename } = req.params;
+    try {
+        const result = await fileService.deleteFile(category, filename);
+        if (result.inUse) return res.status(409).send({ message: 'File in use' });
+        if (result.notFound) return res.status(404).send({ message: 'File not found' });
         res.status(200).send({ message: 'Deleted' });
     } catch (err) {
         res.status(500).send({ message: err.message });

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -38,6 +38,8 @@ router.get("/login-attempts", wrap(controller.getLoginAttempts));
 router.get('/logs', wrap(controller.listLogs));
 router.get('/logs/:filename', wrap(controller.getLog));
 router.delete('/logs/:filename', wrap(controller.deleteLog));
+router.get('/uploads', wrap(controller.listUploads));
+router.delete('/uploads/:category/:filename', wrap(controller.deleteUpload));
 router.get('/mail-settings', wrap(controller.getMailSettings));
 router.put('/mail-settings', wrap(controller.updateMailSettings));
 router.post('/mail-settings/test', wrap(controller.sendTestMail));

--- a/choir-app-backend/src/services/file.service.js
+++ b/choir-app-backend/src/services/file.service.js
@@ -1,0 +1,100 @@
+const fs = require('fs/promises');
+const path = require('path');
+const db = require('../models');
+const { Op } = require('sequelize');
+
+const BASE_DIR = path.join(__dirname, '..', '..', 'uploads');
+const DIRS = {
+  covers: 'collection-covers',
+  images: 'piece-images',
+  files: 'piece-files',
+};
+
+async function safeReaddir(sub) {
+  try {
+    return await fs.readdir(path.join(BASE_DIR, sub));
+  } catch {
+    return [];
+  }
+}
+
+async function listFiles() {
+  const [coverNames, imageNames, fileNames, collections, pieces, links] = await Promise.all([
+    safeReaddir(DIRS.covers),
+    safeReaddir(DIRS.images),
+    safeReaddir(DIRS.files),
+    db.collection.findAll({ attributes: ['id', 'title', 'coverImage'], where: { coverImage: { [Op.not]: null } } }),
+    db.piece.findAll({ attributes: ['id', 'title', 'imageIdentifier'], where: { imageIdentifier: { [Op.not]: null } } }),
+    db.piece_link.findAll({
+      where: { type: 'FILE_DOWNLOAD' },
+      attributes: ['url', 'pieceId'],
+      include: [{ model: db.piece, attributes: ['id', 'title'] }],
+    }),
+  ]);
+
+  const coverMap = new Map();
+  collections.forEach(c => {
+    if (c.coverImage) coverMap.set(c.coverImage, { id: c.id, title: c.title });
+  });
+
+  const imageMap = new Map();
+  pieces.forEach(p => {
+    if (p.imageIdentifier) imageMap.set(p.imageIdentifier, { id: p.id, title: p.title });
+  });
+
+  const fileMap = new Map();
+  links.forEach(l => {
+    const file = path.basename(l.url || '');
+    if (file) fileMap.set(file, { id: l.piece?.id, title: l.piece?.title });
+  });
+
+  return {
+    covers: coverNames.map(name => ({
+      filename: name,
+      collectionId: coverMap.get(name)?.id || null,
+      collectionTitle: coverMap.get(name)?.title || null,
+    })),
+    images: imageNames.map(name => ({
+      filename: name,
+      pieceId: imageMap.get(name)?.id || null,
+      pieceTitle: imageMap.get(name)?.title || null,
+    })),
+    files: fileNames.map(name => ({
+      filename: name,
+      pieceId: fileMap.get(name)?.id || null,
+      pieceTitle: fileMap.get(name)?.title || null,
+    })),
+  };
+}
+
+async function deleteFile(category, filename) {
+  const sub = DIRS[category];
+  if (!sub) return { notFound: true };
+  const safe = path.basename(filename);
+  const filePath = path.join(BASE_DIR, sub, safe);
+
+  let inUse = false;
+  if (category === 'covers') {
+    const count = await db.collection.count({ where: { coverImage: safe } });
+    inUse = count > 0;
+  } else if (category === 'images') {
+    const count = await db.piece.count({ where: { imageIdentifier: safe } });
+    inUse = count > 0;
+  } else if (category === 'files') {
+    const url = `/uploads/${DIRS.files}/${safe}`;
+    const count = await db.piece_link.count({ where: { type: 'FILE_DOWNLOAD', url } });
+    inUse = count > 0;
+  }
+
+  if (inUse) return { inUse: true };
+
+  try {
+    await fs.unlink(filePath);
+    return { success: true };
+  } catch (err) {
+    if (err.code === 'ENOENT') return { notFound: true };
+    throw err;
+  }
+}
+
+module.exports = { listFiles, deleteFile };

--- a/choir-app-frontend/src/app/core/models/backend-file.ts
+++ b/choir-app-frontend/src/app/core/models/backend-file.ts
@@ -1,0 +1,13 @@
+export interface BackendFile {
+  filename: string;
+  pieceId?: number | null;
+  pieceTitle?: string | null;
+  collectionId?: number | null;
+  collectionTitle?: string | null;
+}
+
+export interface UploadOverview {
+  covers: BackendFile[];
+  images: BackendFile[];
+  files: BackendFile[];
+}

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -9,6 +9,7 @@ import { StatsSummary } from '../models/stats-summary';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
+import { UploadOverview } from '../models/backend-file';
 
 @Injectable({ providedIn: 'root' })
 export class AdminService {
@@ -92,6 +93,14 @@ export class AdminService {
 
   deleteLog(filename: string): Observable<any> {
     return this.http.delete(`${this.apiUrl}/admin/logs/${encodeURIComponent(filename)}`);
+  }
+
+  listUploadFiles(): Observable<UploadOverview> {
+    return this.http.get<UploadOverview>(`${this.apiUrl}/admin/uploads`);
+  }
+
+  deleteUploadFile(category: string, filename: string): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/admin/uploads/${encodeURIComponent(category)}/${encodeURIComponent(filename)}`);
   }
 
   downloadBackup(): Observable<Blob> {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -39,6 +39,7 @@ import { RepertoireFilter } from '../models/repertoire-filter';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
+import { UploadOverview } from '../models/backend-file';
 import { FilterPresetService } from './filter-preset.service';
 import { UserAvailability } from '../models/user-availability';
 import { MemberAvailability } from '../models/member-availability';
@@ -640,6 +641,14 @@ export class ApiService {
 
   deleteLog(filename: string): Observable<any> {
     return this.adminService.deleteLog(filename);
+  }
+
+  listUploadFiles(): Observable<UploadOverview> {
+    return this.adminService.listUploadFiles();
+  }
+
+  deleteUploadFile(category: string, filename: string): Observable<any> {
+    return this.adminService.deleteUploadFile(category, filename);
   }
 
   downloadBackup(): Observable<Blob> {

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -21,6 +21,7 @@ export const adminRoutes: Routes = [
       { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent), data: { title: 'Admin – Änderungen' } },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent), data: { title: 'Admin – Protokolle' } },
       { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent), data: { title: 'Admin – Develop' } },
+      { path: 'files', loadComponent: () => import('./manage-files/manage-files.component').then(m => m.ManageFilesComponent), data: { title: 'Admin – Dateien' } },
     ],
   },
 ];

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
@@ -1,0 +1,77 @@
+<h2>Cover</h2>
+<table mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
+  <ng-container matColumnDef="filename">
+    <th mat-header-cell *matHeaderCellDef>Datei</th>
+    <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+  </ng-container>
+  <ng-container matColumnDef="linked">
+    <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
+    <td mat-cell *matCellDef="let f">
+      <a *ngIf="f.collectionId" [routerLink]="['/collections/edit', f.collectionId]">{{ f.collectionTitle }}</a>
+      <span *ngIf="!f.collectionId">–</span>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+    <td mat-cell *matCellDef="let f">
+      <button mat-icon-button color="warn" *ngIf="!f.collectionId" (click)="delete('covers', f.filename)" matTooltip="Löschen">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+</table>
+<p *ngIf="covers.length === 0">Keine Dateien gefunden.</p>
+
+<h2>Notenbild</h2>
+<table mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
+  <ng-container matColumnDef="filename">
+    <th mat-header-cell *matHeaderCellDef>Datei</th>
+    <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+  </ng-container>
+  <ng-container matColumnDef="linked">
+    <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
+    <td mat-cell *matCellDef="let f">
+      <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
+      <span *ngIf="!f.pieceId">–</span>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+    <td mat-cell *matCellDef="let f">
+      <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('images', f.filename)" matTooltip="Löschen">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+</table>
+<p *ngIf="images.length === 0">Keine Dateien gefunden.</p>
+
+<h2>Hochgeladene Dateien</h2>
+<table mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
+  <ng-container matColumnDef="filename">
+    <th mat-header-cell *matHeaderCellDef>Datei</th>
+    <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+  </ng-container>
+  <ng-container matColumnDef="linked">
+    <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
+    <td mat-cell *matCellDef="let f">
+      <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
+      <span *ngIf="!f.pieceId">–</span>
+    </td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+    <td mat-cell *matCellDef="let f">
+      <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('files', f.filename)" matTooltip="Löschen">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+</table>
+<p *ngIf="files.length === 0">Keine Dateien gefunden.</p>

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.scss
@@ -1,0 +1,7 @@
+h2 {
+  margin-top: 1rem;
+}
+
+.table {
+  width: 100%;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { RouterModule } from '@angular/router';
+import { ApiService } from 'src/app/core/services/api.service';
+import { BackendFile, UploadOverview } from 'src/app/core/models/backend-file';
+
+@Component({
+  selector: 'app-manage-files',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, RouterModule],
+  templateUrl: './manage-files.component.html',
+  styleUrls: ['./manage-files.component.scss']
+})
+export class ManageFilesComponent implements OnInit {
+  covers: BackendFile[] = [];
+  images: BackendFile[] = [];
+  files: BackendFile[] = [];
+  displayedColumns = ['filename', 'linked', 'actions'];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.api.listUploadFiles().subscribe((data: UploadOverview) => {
+      this.covers = data.covers;
+      this.images = data.images;
+      this.files = data.files;
+    });
+  }
+
+  delete(category: string, filename: string): void {
+    if (!confirm('Datei wirklich löschen?')) return;
+    this.api.deleteUploadFile(category, filename).subscribe(() => this.load());
+  }
+}


### PR DESCRIPTION
## Summary
- add service to inspect and delete uploaded files
- expose new admin endpoints and Angular view to review files and navigate to linked pieces/collections

## Testing
- `cd choir-app-backend && npm test`
- `cd choir-app-frontend && npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68942edb9890832091963567c19a2542