### PR TITLE
feat(admin): collapsible file sections with unassigned counts

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
@@ -1,77 +1,97 @@
-<h2>Cover</h2>
-<table mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
-  <ng-container matColumnDef="filename">
-    <th mat-header-cell *matHeaderCellDef>Datei</th>
-    <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
-  </ng-container>
-  <ng-container matColumnDef="linked">
-    <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
-    <td mat-cell *matCellDef="let f">
-      <a *ngIf="f.collectionId" [routerLink]="['/collections/edit', f.collectionId]">{{ f.collectionTitle }}</a>
-      <span *ngIf="!f.collectionId">–</span>
-    </td>
-  </ng-container>
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-    <td mat-cell *matCellDef="let f">
-      <button mat-icon-button color="warn" *ngIf="!f.collectionId" (click)="delete('covers', f.filename)" matTooltip="Löschen">
-        <mat-icon>delete</mat-icon>
-      </button>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-</table>
-<p *ngIf="covers.length === 0">Keine Dateien gefunden.</p>
+<mat-accordion>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        Cover ({{ unassignedCovers }} unzugewiesen)
+      </mat-panel-title>
+    </mat-expansion-panel-header>
+    <table mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
+      <ng-container matColumnDef="filename">
+        <th mat-header-cell *matHeaderCellDef>Datei</th>
+        <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+      </ng-container>
+      <ng-container matColumnDef="linked">
+        <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
+        <td mat-cell *matCellDef="let f">
+          <a *ngIf="f.collectionId" [routerLink]="['/collections/edit', f.collectionId]">{{ f.collectionTitle }}</a>
+          <span *ngIf="!f.collectionId">–</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+        <td mat-cell *matCellDef="let f">
+          <button mat-icon-button color="warn" *ngIf="!f.collectionId" (click)="delete('covers', f.filename)" matTooltip="Löschen">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <p *ngIf="covers.length === 0">Keine Dateien gefunden.</p>
+  </mat-expansion-panel>
 
-<h2>Notenbild</h2>
-<table mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
-  <ng-container matColumnDef="filename">
-    <th mat-header-cell *matHeaderCellDef>Datei</th>
-    <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
-  </ng-container>
-  <ng-container matColumnDef="linked">
-    <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
-    <td mat-cell *matCellDef="let f">
-      <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
-      <span *ngIf="!f.pieceId">–</span>
-    </td>
-  </ng-container>
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-    <td mat-cell *matCellDef="let f">
-      <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('images', f.filename)" matTooltip="Löschen">
-        <mat-icon>delete</mat-icon>
-      </button>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-</table>
-<p *ngIf="images.length === 0">Keine Dateien gefunden.</p>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        Notenbild ({{ unassignedImages }} unzugewiesen)
+      </mat-panel-title>
+    </mat-expansion-panel-header>
+    <table mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
+      <ng-container matColumnDef="filename">
+        <th mat-header-cell *matHeaderCellDef>Datei</th>
+        <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+      </ng-container>
+      <ng-container matColumnDef="linked">
+        <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
+        <td mat-cell *matCellDef="let f">
+          <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
+          <span *ngIf="!f.pieceId">–</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+        <td mat-cell *matCellDef="let f">
+          <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('images', f.filename)" matTooltip="Löschen">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <p *ngIf="images.length === 0">Keine Dateien gefunden.</p>
+  </mat-expansion-panel>
 
-<h2>Hochgeladene Dateien</h2>
-<table mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
-  <ng-container matColumnDef="filename">
-    <th mat-header-cell *matHeaderCellDef>Datei</th>
-    <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
-  </ng-container>
-  <ng-container matColumnDef="linked">
-    <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
-    <td mat-cell *matCellDef="let f">
-      <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
-      <span *ngIf="!f.pieceId">–</span>
-    </td>
-  </ng-container>
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-    <td mat-cell *matCellDef="let f">
-      <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('files', f.filename)" matTooltip="Löschen">
-        <mat-icon>delete</mat-icon>
-      </button>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-</table>
-<p *ngIf="files.length === 0">Keine Dateien gefunden.</p>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        Hochgeladene Dateien ({{ unassignedFiles }} unzugewiesen)
+      </mat-panel-title>
+    </mat-expansion-panel-header>
+    <table mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
+      <ng-container matColumnDef="filename">
+        <th mat-header-cell *matHeaderCellDef>Datei</th>
+        <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+      </ng-container>
+      <ng-container matColumnDef="linked">
+        <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
+        <td mat-cell *matCellDef="let f">
+          <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
+          <span *ngIf="!f.pieceId">–</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+        <td mat-cell *matCellDef="let f">
+          <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('files', f.filename)" matTooltip="Löschen">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <p *ngIf="files.length === 0">Keine Dateien gefunden.</p>
+  </mat-expansion-panel>
+</mat-accordion>

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
@@ -36,4 +36,16 @@ export class ManageFilesComponent implements OnInit {
     if (!confirm('Datei wirklich löschen?')) return;
     this.api.deleteUploadFile(category, filename).subscribe(() => this.load());
   }
+
+  get unassignedCovers(): number {
+    return this.covers.filter((c) => !c.collectionId).length;
+  }
+
+  get unassignedImages(): number {
+    return this.images.filter((i) => !i.pieceId).length;
+  }
+
+  get unassignedFiles(): number {
+    return this.files.filter((f) => !f.pieceId).length;
+  }
 }


### PR DESCRIPTION
## Summary
- Make admin file sections collapsible using Angular Material expansion panels
- Show how many files are unassigned in each section header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68944176ae2083208dfe2fd74a8cd712