### PR TITLE
Fix piece file download links

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -15,7 +15,7 @@ app.use(helmet());
 app.use(compression());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
+app.use(['/uploads', '/api/uploads'], express.static(path.join(__dirname, '..', 'uploads')));
 
 if (process.env.NODE_ENV != "production") {
     app.use((req, res, next) => {

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -142,6 +142,7 @@ export class PieceDetailComponent implements OnInit {
     }
     const apiBase = environment.apiUrl.replace(/\/api\/?$/, '');
     const path = link.url.startsWith('/') ? link.url : `/${link.url}`;
-    return `${apiBase}${path}`;
+    const fullPath = path.startsWith('/api/') ? path : `/api${path}`;
+    return `${apiBase}${fullPath}`;
   }
 }


### PR DESCRIPTION
## Summary
- Serve uploaded files under both `/uploads` and `/api/uploads` paths
- Ensure piece links point to `/api/uploads` so downloads work behind proxy

## Testing
- `npm test` *(fails: segmentation fault during Angular build)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_689441bf2858832095d62e65739784ec