### PR TITLE
feat: make page header sticky

### DIFF
--- a/choir-app-frontend/src/app/shared/components/page-header/page-header.component.scss
+++ b/choir-app-frontend/src/app/shared/components/page-header/page-header.component.scss
@@ -3,6 +3,10 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: var(--page-header-bg-color, #fff);
 }
 
 h1 {

--- a/choir-app-frontend/src/styles.scss
+++ b/choir-app-frontend/src/styles.scss
@@ -17,6 +17,10 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+:root {
+  --page-header-bg-color: #fff;
+}
+
 .container {
     padding: 2rem;
 }
@@ -63,6 +67,7 @@ mat-card-header {
 // Definieren Sie die Styles für das dunkle Theme unter einer spezifischen Klasse.
 // Diese Regeln werden nur aktiv, wenn der body-Tag die Klasse '.dark-theme' hat.
 .dark-theme {
+  --page-header-bg-color: #303030;
   // Only include the color styles for the dark theme to avoid duplicating
   // typography and density rules.
   @include mat.all-component-colors(nak.$nak-dark-theme);


### PR DESCRIPTION
## Summary
- keep page header fixed at top during scroll
- support theme-specific background colors for sticky header

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68944bbacad4832099a938c4927df52c