### PR TITLE
Preserve original filenames for piece downloads

### DIFF
--- a/choir-app-backend/src/models/piece_link.model.js
+++ b/choir-app-backend/src/models/piece_link.model.js
@@ -9,6 +9,10 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.STRING,
             allowNull: false
         },
+        downloadName: {
+            type: DataTypes.STRING,
+            allowNull: true
+        },
         type: {
             type: DataTypes.ENUM('EXTERNAL', 'FILE_DOWNLOAD'),
             defaultValue: 'EXTERNAL'

--- a/choir-app-backend/src/services/file.service.js
+++ b/choir-app-backend/src/services/file.service.js
@@ -27,7 +27,7 @@ async function listFiles() {
     db.piece.findAll({ attributes: ['id', 'title', 'imageIdentifier'], where: { imageIdentifier: { [Op.not]: null } } }),
     db.piece_link.findAll({
       where: { type: 'FILE_DOWNLOAD' },
-      attributes: ['url', 'pieceId'],
+      attributes: ['url', 'pieceId', 'downloadName'],
       include: [{ model: db.piece, attributes: ['id', 'title'] }],
     }),
   ]);
@@ -45,7 +45,7 @@ async function listFiles() {
   const fileMap = new Map();
   links.forEach(l => {
     const file = path.basename(l.url || '');
-    if (file) fileMap.set(file, { id: l.piece?.id, title: l.piece?.title });
+    if (file) fileMap.set(file, { id: l.piece?.id, title: l.piece?.title, downloadName: l.downloadName });
   });
 
   return {
@@ -63,6 +63,7 @@ async function listFiles() {
       filename: name,
       pieceId: fileMap.get(name)?.id || null,
       pieceTitle: fileMap.get(name)?.title || null,
+      downloadName: fileMap.get(name)?.downloadName || null,
     })),
   };
 }

--- a/choir-app-backend/src/validators/piece.validation.js
+++ b/choir-app-backend/src/validators/piece.validation.js
@@ -20,6 +20,7 @@ exports.createPieceValidation = [
   body('links').optional().isArray().withMessage('links must be an array'),
   body('links.*.description').optional().isString(),
   body('links.*.url').optional().isString(),
+  body('links.*.downloadName').optional().isString(),
   body('authorId').optional({ nullable: true }).isInt(),
   body('categoryId').optional({ nullable: true }).isInt()
 ];
@@ -38,6 +39,7 @@ exports.updatePieceValidation = [
   body('links').optional().isArray(),
   body('links.*.description').optional().isString(),
   body('links.*.url').optional().isString(),
+  body('links.*.downloadName').optional().isString(),
   body('authorId').optional({ nullable: true }).isInt(),
   body('categoryId').optional({ nullable: true }).isInt()
 ];

--- a/choir-app-frontend/src/app/core/models/backend-file.ts
+++ b/choir-app-frontend/src/app/core/models/backend-file.ts
@@ -4,6 +4,7 @@ export interface BackendFile {
   pieceTitle?: string | null;
   collectionId?: number | null;
   collectionTitle?: string | null;
+  downloadName?: string | null;
 }
 
 export interface UploadOverview {

--- a/choir-app-frontend/src/app/core/models/piece-link.ts
+++ b/choir-app-frontend/src/app/core/models/piece-link.ts
@@ -3,4 +3,5 @@ export interface PieceLink {
     url: string;
     description: string;
     type: 'EXTERNAL' | 'FILE_DOWNLOAD';
+    downloadName?: string;
 }

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
@@ -74,6 +74,10 @@
         <th mat-header-cell *matHeaderCellDef>Datei</th>
         <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
       </ng-container>
+      <ng-container matColumnDef="downloadName">
+        <th mat-header-cell *matHeaderCellDef>Downloadname</th>
+        <td mat-cell *matCellDef="let f">{{ f.downloadName || '–' }}</td>
+      </ng-container>
       <ng-container matColumnDef="linked">
         <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
         <td mat-cell *matCellDef="let f">
@@ -89,8 +93,8 @@
           </button>
         </td>
       </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-header-row *matHeaderRowDef="displayedFileColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedFileColumns"></tr>
     </table>
     <p *ngIf="files.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
@@ -17,6 +17,7 @@ export class ManageFilesComponent implements OnInit {
   images: BackendFile[] = [];
   files: BackendFile[] = [];
   displayedColumns = ['filename', 'linked', 'actions'];
+  displayedFileColumns = ['filename', 'downloadName', 'linked', 'actions'];
 
   constructor(private api: ApiService) {}
 

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -33,7 +33,7 @@
       <h3>Dateien</h3>
       <ul>
         <li *ngFor="let link of fileLinks">
-          <a [href]="getLinkUrl(link)" [attr.download]="link.description">{{ link.description }}</a>
+          <a [href]="getLinkUrl(link)" [attr.download]="link.downloadName || link.description">{{ link.description }}</a>
         </li>
       </ul>
     </div>

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -254,6 +254,7 @@ export class PieceDialogComponent implements OnInit {
             description: ['', Validators.required],
             url: ['', Validators.required],
             type: ['EXTERNAL', Validators.required],
+            downloadName: [''],
         });
         this.linksFormArray.push(linkFormGroup);
     }
@@ -269,12 +270,14 @@ export class PieceDialogComponent implements OnInit {
         this.pieceService.uploadPieceLinkFile(file).subscribe(res => {
             linkGroup.get('url')?.setValue(res.path);
             linkGroup.get('description')?.setValue(file.name);
+            linkGroup.get('downloadName')?.setValue(file.name);
         });
     }
 
     onLinkTypeChange(index: number): void {
         const linkGroup = this.linksFormArray.at(index) as FormGroup;
         linkGroup.get('url')?.setValue('');
+        linkGroup.get('downloadName')?.setValue('');
     }
 
     private initializeComposerAutocomplete(): void {
@@ -431,6 +434,7 @@ export class PieceDialogComponent implements OnInit {
                     description: [link.description, Validators.required],
                     url: [link.url, Validators.required],
                     type: [link.type, Validators.required],
+                    downloadName: [link.downloadName || ''],
                 })
             );
         });


### PR DESCRIPTION
## Summary
- Track the original filename for uploaded piece files via new `downloadName` field
- Expose and display both internal and download names in the admin file list
- Use stored download name when offering piece file downloads

## Testing
- `npm test --prefix choir-app-backend`
- `npm run check-backend`
- `npm test --prefix choir-app-frontend` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68944ca2319c8320905e2969e893a978