### PR TITLE
feat: show pdf icon and file size for downloads

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -33,7 +33,11 @@
       <h3>Dateien</h3>
       <ul>
         <li *ngFor="let link of fileLinks">
-          <a [href]="getLinkUrl(link)" [attr.download]="link.description">{{ link.description }}</a>
+          <a [href]="getLinkUrl(link)" [attr.download]="link.description">
+            <mat-icon *ngIf="link.isPdf" class="file-icon">picture_as_pdf</mat-icon>
+            {{ link.description }}
+          </a>
+          <span *ngIf="link.size">({{ formatFileSize(link.size) }})</span>
         </li>
       </ul>
     </div>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
@@ -16,3 +16,8 @@
 .lyrics {
   white-space: pre-line;
 }
+
+.file-icon {
+  vertical-align: middle;
+  margin-right: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- show a PDF icon for downloadable PDF files
- display file size next to each download link

## Testing
- `npm test` *(fails: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68944ce91f4483209de5c6dbdca117dd