### PR TITLE
Increase file upload limit to 10MB

### DIFF
--- a/choir-app-backend/src/utils/upload.js
+++ b/choir-app-backend/src/utils/upload.js
@@ -1,7 +1,7 @@
 const multer = require('multer');
 const path = require('path');
 
-const DEFAULT_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const DEFAULT_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 function memoryUpload(options = {}) {
   const limits = { fileSize: DEFAULT_FILE_SIZE, ...options.limits };


### PR DESCRIPTION
## Summary
- raise server-side upload limit to 10 MB for memory and disk uploads

## Testing
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68944d1aad1c83209430b3cae20cda05