### PR TITLE
feat: add piece reporting option

### DIFF
--- a/choir-app-backend/src/routes/piece.routes.js
+++ b/choir-app-backend/src/routes/piece.routes.js
@@ -20,6 +20,7 @@ router.get("/:id", wrap(controller.findOne));
 router.post("/", role.requireNonDemo, createPieceValidation, validate, wrap(controller.create));
 router.put("/:id", role.requireNonDemo, updatePieceValidation, validate, wrap(controller.update));
 router.delete("/:id", role.requireNonDemo, wrap(controller.delete));
+router.post("/:id/report", role.requireNonDemo, wrap(controller.report));
 router.post("/:id/image", role.requireNonDemo, imageUpload.single('image'), wrap(controller.uploadImage));
 router.post("/link-file", role.requireNonDemo, fileUpload.single('file'), wrap(controller.uploadLinkFile));
 

--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -232,3 +232,28 @@ exports.sendPostNotificationMail = async (recipients, title, text) => {
     throw err;
   }
 };
+
+exports.sendPieceReportMail = async (recipients, piece, reporter, category, reason, link) => {
+  if (emailDisabled() || !Array.isArray(recipients) || recipients.length === 0) return;
+  const settings = await db.mail_setting.findByPk(1);
+  const transporter = await createTransporter(settings);
+  try {
+    const subject = `Meldung zu Stück: ${piece}`;
+    const text = `${reporter} hat das Stück "${piece}" gemeldet.\nKategorie: ${category}\nBegründung: ${reason}\n${link}`;
+    const html = `<p>${reporter} hat das Stück "${piece}" gemeldet.</p>` +
+      `<p><strong>Kategorie:</strong> ${category}</p>` +
+      `<p><strong>Begründung:</strong><br>${reason.replace(/\n/g, '<br>')}</p>` +
+      `<p><a href="${link}">Stück ansehen</a></p>`;
+    await transporter.sendMail({
+      from: getFromAddress(settings),
+      to: recipients,
+      subject,
+      text,
+      html
+    });
+  } catch (err) {
+    logger.error(`Error sending piece report mail: ${err.message}`);
+    logger.error(err.stack);
+    throw err;
+  }
+};

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -152,7 +152,9 @@ export class ApiService {
   deletePieceNote(noteId: number) {
     return this.pieceService.deletePieceNote(noteId);
   }
-
+  reportPiece(pieceId: number, category: string, reason: string) {
+    return this.pieceService.reportPiece(pieceId, category, reason);
+  }
 
   // --- Global Piece Methods ---
 

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -147,4 +147,8 @@ export class PieceService {
     formData.append('file', file);
     return this.http.post<{ path: string }>(`${this.apiUrl}/pieces/link-file`, formData);
   }
+
+  reportPiece(pieceId: number, category: string, reason: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/pieces/${pieceId}/report`, { category, reason });
+  }
 }

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -5,6 +5,7 @@
       <mat-icon>edit</mat-icon>
     </button>
   </h2>
+  <button mat-button color="warn" (click)="openReportDialog()">Stück melden</button>
   <p *ngIf="piece.subtitle"><em>{{ piece.subtitle }}</em></p>
   <p><strong>Komponist/Ursprung:</strong> {{ piece.composer?.name || piece.origin }}</p>
   <p *ngIf="piece.composerCollection"><strong>Sammlung des Komponisten:</strong> {{ piece.composerCollection }}</p>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -12,6 +12,7 @@ import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { PieceDialogComponent } from '../piece-dialog/piece-dialog.component';
+import { PieceReportDialogComponent } from '../piece-report-dialog/piece-report-dialog.component';
 import { environment } from 'src/environments/environment';
 
 @Component({
@@ -132,6 +133,16 @@ export class PieceDetailComponent implements OnInit {
       if (wasUpdated) {
         this.snackBar.open('Stück aktualisiert.', 'OK', { duration: 3000 });
         this.loadPiece(this.piece!.id);
+      }
+    });
+  }
+
+  openReportDialog(): void {
+    if (!this.piece) return;
+    const dialogRef = this.dialog.open(PieceReportDialogComponent, { data: { pieceId: this.piece.id } });
+    dialogRef.afterClosed().subscribe(sent => {
+      if (sent) {
+        this.snackBar.open('Meldung gesendet.', 'OK', { duration: 3000 });
       }
     });
   }

--- a/choir-app-frontend/src/app/features/literature/piece-report-dialog/piece-report-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-report-dialog/piece-report-dialog.component.html
@@ -1,0 +1,18 @@
+<h1 mat-dialog-title>Stück melden</h1>
+<div mat-dialog-content>
+  <mat-form-field appearance="fill" class="full-width">
+    <mat-label>Kategorie</mat-label>
+    <mat-select [(value)]="category">
+      <mat-option *ngFor="let c of categories" [value]="c">{{ c }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+  <mat-form-field appearance="fill" class="full-width">
+    <mat-label>Begründung</mat-label>
+    <textarea matInput [(ngModel)]="reason" rows="4"></textarea>
+  </mat-form-field>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="dialogRef.close()">Abbrechen</button>
+  <button mat-flat-button color="primary" (click)="send()" [disabled]="!reason">Senden</button>
+</div>
+

--- a/choir-app-frontend/src/app/features/literature/piece-report-dialog/piece-report-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-report-dialog/piece-report-dialog.component.scss
@@ -1,0 +1,4 @@
+.full-width {
+  width: 100%;
+}
+

--- a/choir-app-frontend/src/app/features/literature/piece-report-dialog/piece-report-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-report-dialog/piece-report-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+
+@Component({
+  selector: 'app-piece-report-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MaterialModule],
+  templateUrl: './piece-report-dialog.component.html',
+  styleUrls: ['./piece-report-dialog.component.scss']
+})
+export class PieceReportDialogComponent {
+  category = 'Fehlerhafte Daten';
+  reason = '';
+  categories = ['Fehlerhafte Daten', 'Urheberrechtsverletzung', 'Defekte Verknüpfungen', 'Sonstiges'];
+
+  constructor(
+    private api: ApiService,
+    public dialogRef: MatDialogRef<PieceReportDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { pieceId: number }
+  ) {}
+
+  send(): void {
+    if (!this.reason) return;
+    this.api.reportPiece(this.data.pieceId, this.category, this.reason).subscribe(() => {
+      this.dialogRef.close(true);
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- allow users to report repertoire pieces
- notify admins via email with category and description

## Testing
- `npm test --prefix choir-app-frontend` *(fails: libatk-1.0.so.0 missing)*
- `npm run check --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68944e6e8c008320b4d12845c49d9244