### PR TITLE
feat: delete file when removing piece link

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -5,6 +5,7 @@ const Category = db.category;
 const Author = db.author;
 const path = require('path');
 const fs = require('fs/promises');
+const fileService = require('../services/file.service');
 const BaseCrudController = require('./baseCrud.controller');
 const base = new BaseCrudController(Piece);
 const emailService = require('../services/email.service');
@@ -278,6 +279,17 @@ exports.uploadImage = async (req, res, next) => {
 exports.uploadLinkFile = async (req, res, next) => {
     if (!req.file) return res.status(400).send({ message: 'No file uploaded.' });
     res.status(200).send({ path: `/uploads/piece-files/${req.file.filename}` });
+};
+
+exports.deleteLinkFile = async (req, res, next) => {
+    const { path: filePath } = req.body || {};
+    if (!filePath) return res.status(400).send({ message: 'No file path provided.' });
+
+    const filename = path.basename(filePath);
+    const result = await fileService.deleteFile('files', filename);
+    if (result.notFound) return res.status(404).send({ message: 'File not found.' });
+    if (result.inUse) return res.status(400).send({ message: 'File in use.' });
+    return res.status(200).send({ message: 'File deleted.' });
 };
 
 exports.getImage = async (req, res, next) => {

--- a/choir-app-backend/src/routes/piece.routes.js
+++ b/choir-app-backend/src/routes/piece.routes.js
@@ -23,5 +23,6 @@ router.delete("/:id", role.requireNonDemo, wrap(controller.delete));
 router.post("/:id/report", role.requireNonDemo, wrap(controller.report));
 router.post("/:id/image", role.requireNonDemo, imageUpload.single('image'), wrap(controller.uploadImage));
 router.post("/link-file", role.requireNonDemo, fileUpload.single('file'), wrap(controller.uploadLinkFile));
+router.delete("/link-file", role.requireNonDemo, wrap(controller.deleteLinkFile));
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -148,6 +148,10 @@ export class PieceService {
     return this.http.post<{ path: string }>(`${this.apiUrl}/pieces/link-file`, formData);
   }
 
+  deletePieceLinkFile(path: string): Observable<any> {
+    return this.http.request('delete', `${this.apiUrl}/pieces/link-file`, { body: { path } });
+  }
+
   reportPiece(pieceId: number, category: string, reason: string): Observable<any> {
     return this.http.post(`${this.apiUrl}/pieces/${pieceId}/report`, { category, reason });
   }

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -143,7 +143,7 @@
                   </mat-form-field>
                   <div *ngIf="link.get('type')?.value === 'FILE_DOWNLOAD'" class="file-upload">
                     <input type="file" (change)="onLinkFileSelected($event, i)" accept="application/pdf,image/*,audio/*" />
-                    <span *ngIf="link.get('url')?.value">Datei hochgeladen</span>
+                    <span *ngIf="link.get('url')?.value">{{ link.get('downloadName')?.value || 'Datei hochgeladen' }}</span>
                   </div>
                   <mat-form-field appearance="outline">
                     <mat-label>Typ</mat-label>


### PR DESCRIPTION
## Summary
- delete backend file when removing piece link
- show filename for piece link and track removed files
- cleanup unused link files on save

## Testing
- `npm test` (backend)
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6894540676bc8320ba942edc61f2ab16