### PR TITLE
Fix failing PieceDetailComponent tests by supplying HttpClient

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
 import { PieceDetailComponent } from './piece-detail.component';
@@ -14,7 +15,7 @@ describe('PieceDetailComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PieceDetailComponent],
+      imports: [PieceDetailComponent, HttpClientTestingModule],
       providers: [
         {
           provide: ActivatedRoute,


### PR DESCRIPTION
## Summary
- add HttpClientTestingModule to `PieceDetailComponent` tests to satisfy HttpClient dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68945812cf4483208552529f7bc6facf