### PR TITLE
Enable piece links and Markdown in posts

### DIFF
--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -146,6 +146,8 @@ db.choir.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 db.user.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
+db.piece.hasMany(db.post, { as: 'posts' });
+db.post.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
 
 // Library items referencing collections
 db.collection.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'collectionId' });

--- a/choir-app-backend/src/models/post.model.js
+++ b/choir-app-backend/src/models/post.model.js
@@ -7,6 +7,10 @@ module.exports = (sequelize, DataTypes) => {
     text: {
       type: DataTypes.TEXT,
       allowNull: false
+    },
+    pieceId: {
+      type: DataTypes.INTEGER,
+      allowNull: true
     }
   });
   return Post;

--- a/choir-app-backend/src/validators/post.validation.js
+++ b/choir-app-backend/src/validators/post.validation.js
@@ -6,5 +6,6 @@ function noHtml(value) {
 
 exports.postValidation = [
   body('title').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
-  body('text').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed')
+  body('text').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
+  body('pieceId').optional().isInt()
 ];

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -32,7 +32,7 @@ const db = require('../src/models');
     checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
-    checkFields(db.post, ['title', 'text']);
+    checkFields(db.post, ['title', 'text', 'pieceId']);
 
     // Basic association checks
     assert(db.user.associations.choirs, 'User should have choirs association');

--- a/choir-app-frontend/package-lock.json
+++ b/choir-app-frontend/package-lock.json
@@ -17,6 +17,8 @@
         "@angular/material": "^20.0.3",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
+        "dompurify": "^3.1.6",
+        "marked": "^12.0.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -5491,6 +5493,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -7465,6 +7474,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -10390,6 +10408,18 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -25,6 +25,8 @@
     "@angular/material": "^20.0.3",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
+    "dompurify": "^3.1.6",
+    "marked": "^12.0.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/choir-app-frontend/src/app/core/models/post.ts
+++ b/choir-app-frontend/src/app/core/models/post.ts
@@ -7,4 +7,5 @@ export interface Post {
   createdAt: string;
   updatedAt: string;
   author?: { id: number; name: string };
+  piece?: { id: number; title: string };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -718,11 +718,11 @@ export class ApiService {
     return this.postService.getLatestPost();
   }
 
-  createPost(data: { title: string; text: string }): Observable<Post> {
+  createPost(data: { title: string; text: string; pieceId?: number | null }): Observable<Post> {
     return this.postService.createPost(data);
   }
 
-  updatePost(id: number, data: { title: string; text: string }): Observable<Post> {
+  updatePost(id: number, data: { title: string; text: string; pieceId?: number | null }): Observable<Post> {
     return this.postService.updatePost(id, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/post.service.ts
+++ b/choir-app-frontend/src/app/core/services/post.service.ts
@@ -17,11 +17,11 @@ export class PostService {
     return this.http.get<Post | null>(`${this.apiUrl}/posts/latest`);
   }
 
-  createPost(data: { title: string; text: string }): Observable<Post> {
+  createPost(data: { title: string; text: string; pieceId?: number | null }): Observable<Post> {
     return this.http.post<Post>(`${this.apiUrl}/posts`, data);
   }
 
-  updatePost(id: number, data: { title: string; text: string }): Observable<Post> {
+  updatePost(id: number, data: { title: string; text: string; pieceId?: number | null }): Observable<Post> {
     return this.http.put<Post>(`${this.apiUrl}/posts/${id}`, data);
   }
 

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.html
@@ -6,8 +6,15 @@
       <input matInput formControlName="title">
     </mat-form-field>
     <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Stück</mat-label>
+      <input type="text" matInput [formControl]="pieceCtrl" [matAutocomplete]="auto">
+      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayPiece.bind(this)">
+        <mat-option *ngFor="let p of filteredPieces$ | async" [value]="p">{{ p.title }}</mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+    <mat-form-field appearance="fill" class="full-width">
       <mat-label>Text</mat-label>
-      <textarea matInput rows="5" formControlName="text"></textarea>
+      <textarea matInput rows="5" formControlName="text" placeholder="Markdown möglich"></textarea>
     </mat-form-field>
   </form>
 </div>

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
@@ -1,9 +1,13 @@
 import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { Post } from '@core/models/post';
+import { ApiService } from '@core/services/api.service';
+import { LookupPiece } from '@core/models/lookup-piece';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'app-post-dialog',
@@ -14,24 +18,58 @@ import { Post } from '@core/models/post';
 export class PostDialogComponent {
   form: FormGroup;
   isEdit = false;
+  pieceCtrl = new FormControl<string | LookupPiece | null>('');
+  filteredPieces$!: Observable<LookupPiece[]>;
+  allPieces: LookupPiece[] = [];
   constructor(
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<PostDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { post?: Post } | null
+    @Inject(MAT_DIALOG_DATA) public data: { post?: Post } | null,
+    private api: ApiService
   ) {
     this.form = this.fb.group({
       title: ['', Validators.required],
-      text: ['', Validators.required]
+      text: ['', Validators.required],
+      pieceId: [null]
     });
     if (data?.post) {
       this.isEdit = true;
-      this.form.patchValue({ title: data.post.title, text: data.post.text });
+      this.form.patchValue({ title: data.post.title, text: data.post.text, pieceId: data.post.piece?.id });
+      if (data.post.piece) this.pieceCtrl.setValue({
+        id: data.post.piece.id,
+        title: data.post.piece.title,
+        composerName: '',
+        collectionTitle: null,
+        reference: null
+      });
     }
+
+    this.api.getRepertoireForLookup().subscribe(pieces => {
+      this.allPieces = pieces;
+      this.filteredPieces$ = this.pieceCtrl.valueChanges.pipe(
+        startWith(''),
+        map(value => {
+          const title = typeof value === 'string' ? value : value?.title;
+          return title ? this._filter(title) : this.allPieces.slice();
+        })
+      );
+    });
+  }
+
+  private _filter(value: string): LookupPiece[] {
+    const filterValue = value.toLowerCase();
+    return this.allPieces.filter(p => p.title.toLowerCase().includes(filterValue));
+  }
+
+  displayPiece(piece: LookupPiece): string {
+    return piece && piece.title ? piece.title : '';
   }
 
   save(): void {
     if (this.form.valid) {
-      this.dialogRef.close(this.form.value);
+      const piece = this.pieceCtrl.value;
+      const pieceId = piece && typeof piece === 'object' ? piece.id : null;
+      this.dialogRef.close({ title: this.form.value.title, text: this.form.value.text, pieceId });
     }
   }
 

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -10,7 +10,10 @@
         <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }}</mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
-        <p>{{ p.text }}</p>
+        <div [innerHTML]="p.text | markdown"></div>
+        <div *ngIf="p.piece" class="piece-link">
+          <a [routerLink]="['/pieces', p.piece.id]">Zum Stück "{{ p.piece.title }}"</a>
+        </div>
       </mat-card-content>
       <mat-card-actions *ngIf="canEdit(p)" class="actions">
         <button mat-icon-button (click)="editPost(p)" matTooltip="Bearbeiten"><mat-icon>edit</mat-icon></button>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -9,11 +9,12 @@ import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { PostDialogComponent } from './post-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
+import { MarkdownPipe } from '@shared/pipes/markdown.pipe';
 
 @Component({
   selector: 'app-post-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule, MarkdownPipe],
   templateUrl: './post-list.component.html'
 })
 export class PostListComponent implements OnInit {

--- a/choir-app-frontend/src/app/shared/pipes/markdown.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/markdown.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+@Pipe({
+  name: 'markdown',
+  standalone: true
+})
+export class MarkdownPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+  transform(value: string): SafeHtml {
+    if (!value) return '';
+    const html = marked.parse(value) as string;
+    const sanitized = DOMPurify.sanitize(html);
+    return this.sanitizer.bypassSecurityTrustHtml(sanitized);
+  }
+}


### PR DESCRIPTION
## Summary
- Allow posts to reference repertoire pieces and include sanitized Markdown content
- Add piece selector in post dialog and show piece link on posts list
- Support Markdown rendering via new pipe

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68947ba68eb08320ba31c625e8a6665f