### PR TITLE
Open external piece links in new tab

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -46,7 +46,7 @@
       <h3>Links</h3>
       <ul>
         <li *ngFor="let link of externalLinks">
-          <a [href]="getLinkUrl(link)">{{ link.description }}</a>
+          <a [href]="getLinkUrl(link)" target="_blank" rel="noopener noreferrer">{{ link.description }}</a>
         </li>
       </ul>
     </div>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -7,6 +7,7 @@ import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('PieceDetailComponent', () => {
   let component: PieceDetailComponent;
@@ -14,7 +15,7 @@ describe('PieceDetailComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PieceDetailComponent],
+      imports: [PieceDetailComponent, HttpClientTestingModule],
       providers: [
         {
           provide: ActivatedRoute,


### PR DESCRIPTION
## Summary
- ensure external links on piece detail page open in a new tab
- fix unit tests by including HttpClientTestingModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68947a476d6883209c8ca2130ae9d732