### PR TITLE
fix: remove duplicate HTTP client test import

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -8,7 +8,6 @@ import { ApiService } from '@core/services/api.service';
 import { AuthService } from '@core/services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('PieceDetailComponent', () => {
   let component: PieceDetailComponent;


### PR DESCRIPTION
## Summary
- remove duplicate `HttpClientTestingModule` import from `PieceDetailComponent` spec

## Testing
- `npm test` *(fails: cannot start ChromeHeadless: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68948dfbd5948320b620bb1fd3a9c8f7