### PR TITLE
Fix collection reference typing for piece details

### DIFF
--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -12,6 +12,10 @@ export interface PieceNote {
 }
 
 export interface CollectionReference {
+  /**
+   * Unique identifier of the referenced collection.
+   */
+  id: number;
   prefix: string;
   title?: string;
   singleEdition?: boolean;


### PR DESCRIPTION
## Summary
- include missing `id` field in `CollectionReference` so piece detail template can navigate to collections
- ensure markdown dependencies are present for parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894911e0a3883208c5f25d51cf4b0b4