### PR TITLE
Expand library collections inline

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -23,7 +23,7 @@
 </div>
 
 <ng-container *ngIf="items$ | async as items">
-  <table mat-table [dataSource]="items" class="mat-elevation-z8">
+  <table mat-table [dataSource]="items" class="mat-elevation-z8" multiTemplateDataRows>
     <ng-container matColumnDef="title">
       <th mat-header-cell *matHeaderCellDef>Titel</th>
       <td mat-cell *matCellDef="let element">{{element.collection?.title}}</td>
@@ -53,7 +53,21 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="expandedDetail">
+      <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+        <div *ngIf="expandedItem === element">
+          <mat-nav-list>
+            <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
+              {{ piece.title }}
+            </a>
+          </mat-nav-list>
+          <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
+        </div>
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" class="clickable-row"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
   </table>
 </ng-container>

--- a/choir-app-frontend/src/app/features/library/library.component.scss
+++ b/choir-app-frontend/src/app/features/library/library.component.scss
@@ -9,3 +9,7 @@
 .clickable-row {
   cursor: pointer;
 }
+
+.detail-row {
+  height: 0;
+}

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -4,14 +4,15 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { LibraryItem } from '@core/models/library-item';
 import { Collection } from '@core/models/collection';
+import { Piece } from '@core/models/piece';
 import { Observable } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { LibraryItemDialogComponent } from './library-item-dialog.component';
-import { LibraryCollectionDialogComponent } from './library-collection-dialog.component';
 import { LoanCartService } from '@core/services/loan-cart.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { PageEvent } from '@angular/material/paginator';
 
 @Component({
   selector: 'app-library',
@@ -26,6 +27,10 @@ export class LibraryComponent implements OnInit {
   selectedFile: File | null = null;
   isAdmin = false;
   displayedColumns: string[] = ['title', 'copies', 'status', 'availableAt', 'actions'];
+  expandedItem: LibraryItem | null = null;
+  expandedPieces: Piece[] = [];
+  piecePageSize = 10;
+  piecePageIndex = 0;
 
   constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private router: Router, private cart: LoanCartService, private snack: MatSnackBar) {}
 
@@ -61,17 +66,34 @@ export class LibraryComponent implements OnInit {
     });
   }
 
-  openCollection(item: LibraryItem): void {
+  toggleCollection(item: LibraryItem): void {
     const colId = item.collection?.id;
     if (!colId) return;
+
+    if (this.expandedItem === item) {
+      this.expandedItem = null;
+      return;
+    }
 
     this.api.getCollectionById(colId).subscribe(col => {
       if ((col.singleEdition || (col.pieces && col.pieces.length === 1)) && col.pieces && col.pieces.length === 1) {
         this.router.navigate(['/pieces', col.pieces[0].id]);
-      } else if (col.pieces && col.pieces.length > 0) {
-        this.dialog.open(LibraryCollectionDialogComponent, { data: col });
+      } else {
+        this.expandedItem = item;
+        this.expandedPieces = col.pieces || [];
+        this.piecePageIndex = 0;
       }
     });
+  }
+
+  onPiecePage(event: PageEvent): void {
+    this.piecePageIndex = event.pageIndex;
+    this.piecePageSize = event.pageSize;
+  }
+
+  get paginatedPieces(): Piece[] {
+    const start = this.piecePageIndex * this.piecePageSize;
+    return this.expandedPieces.slice(start, start + this.piecePageSize);
   }
 
   addToCart(item: LibraryItem, event: Event): void {


### PR DESCRIPTION
## Summary
- show pieces inline when clicking a library collection
- add pagination for pieces and link titles to details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894ac066c548320a695f1d187072b8a