### PR TITLE
Show composer in library for single editions

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -35,7 +35,10 @@
       <table mat-table [dataSource]="items" class="mat-elevation-z8" multiTemplateDataRows>
         <ng-container matColumnDef="title">
           <th mat-header-cell *matHeaderCellDef>Titel</th>
-          <td mat-cell *matCellDef="let element">{{element.collection?.title}}</td>
+          <td mat-cell *matCellDef="let element">
+            {{ element.collection?.title }}
+            <div class="subtitle-hint" *ngIf="getCollectionHint(element.collection) as hint">{{ hint }}</div>
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="copies">

--- a/choir-app-frontend/src/app/features/library/library.component.scss
+++ b/choir-app-frontend/src/app/features/library/library.component.scss
@@ -16,3 +16,8 @@
 .detail-row {
   height: 0;
 }
+
+.subtitle-hint {
+  font-size: 0.9rem;
+  color: #555;
+}

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -89,6 +89,15 @@ export class LibraryComponent implements OnInit {
     return this.expandedPieces.slice(start, start + this.piecePageSize);
   }
 
+  getCollectionHint(collection?: Collection): string {
+    if (!collection) return '';
+    if (collection.singleEdition || (collection.pieces && collection.pieces.length === 1)) {
+      const piece = collection.pieces?.[0];
+      return piece?.composer?.name || piece?.origin || '';
+    }
+    return collection.subtitle || '';
+  }
+
   addToCart(item: LibraryItem, event: Event): void {
     event.stopPropagation();
     this.cart.addItem(item);


### PR DESCRIPTION
## Summary
- Display composer for single-edition library entries and subtitle for other collections.
- Add helper and style for determining and showing appropriate secondary text.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894bc94cc9c8320b85b2090a240fae2