### PR TITLE
Compute piece counts for library collections

### DIFF
--- a/choir-app-backend/src/controllers/library.controller.js
+++ b/choir-app-backend/src/controllers/library.controller.js
@@ -17,7 +17,16 @@ exports.findAll = async (req, res) => {
       }
     ]
   });
-  res.status(200).send(items);
+
+  const result = items.map(item => {
+    const plain = item.toJSON();
+    if (plain.collection) {
+      plain.collection.pieceCount = plain.collection.pieces ? plain.collection.pieces.length : 0;
+    }
+    return plain;
+  });
+
+  res.status(200).send(result);
 };
 
 // Create a library item referencing a collection

--- a/choir-app-backend/tests/library.controller.test.js
+++ b/choir-app-backend/tests/library.controller.test.js
@@ -35,6 +35,7 @@ const controller = require('../src/controllers/library.controller');
     assert.strictEqual(listRes.data[0].collection.id, collection.id);
     assert.strictEqual(listRes.data[0].collection.pieces.length, 1);
     assert.strictEqual(listRes.data[0].collection.pieces[0].id, piece.id);
+    assert.strictEqual(listRes.data[0].collection.pieceCount, 1);
 
     console.log('library.controller tests passed');
     await db.sequelize.close();


### PR DESCRIPTION
## Summary
- populate `pieceCount` in library item collections so composer names render correctly
- add regression test for library controller piece count

## Testing
- `npm run check --prefix choir-app-backend`
- `node tests/library.controller.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6894c726e9108320ad5d1ae0fda581ec