### PR TITLE
Allow null subtitles for collections

### DIFF
--- a/choir-app-backend/src/validators/collection.validation.js
+++ b/choir-app-backend/src/validators/collection.validation.js
@@ -2,7 +2,7 @@ const { body } = require('express-validator');
 
 exports.createCollectionValidation = [
   body('title').notEmpty().withMessage('Title is required.'),
-  body('subtitle').optional().isString(),
+  body('subtitle').optional({ nullable: true }).isString(),
   body('pieces').optional().isArray().withMessage('pieces must be an array'),
   body('pieces.*.pieceId').optional().isInt().withMessage('pieceId must be an integer'),
   body('pieces.*.numberInCollection')
@@ -14,7 +14,7 @@ exports.createCollectionValidation = [
 
 exports.updateCollectionValidation = [
   body('title').optional().notEmpty(),
-  body('subtitle').optional().isString(),
+  body('subtitle').optional({ nullable: true }).isString(),
   body('pieces').optional().isArray(),
   body('pieces.*.pieceId').optional().isInt(),
   body('pieces.*.numberInCollection')

--- a/choir-app-backend/tests/collection.validation.test.js
+++ b/choir-app-backend/tests/collection.validation.test.js
@@ -19,6 +19,16 @@ const { createCollectionValidation, updateCollectionValidation } = require('../s
     res = validationResult(req3);
     assert.ok(!res.isEmpty(), 'create should fail when subtitle is not string');
 
+    const req6 = { body: { title: 'A', subtitle: null } };
+    for (const v of createCollectionValidation) { await v.run(req6); }
+    res = validationResult(req6);
+    assert.ok(res.isEmpty(), 'create should allow null subtitle');
+
+    const req7 = { body: { subtitle: null } };
+    for (const v of updateCollectionValidation) { await v.run(req7); }
+    res = validationResult(req7);
+    assert.ok(res.isEmpty(), 'update should allow null subtitle');
+
     const req4 = { body: { title: 'A', pieces: [{ pieceId: 1, numberInCollection: '11a' }] } };
     for (const v of createCollectionValidation) { await v.run(req4); }
     res = validationResult(req4);


### PR DESCRIPTION
## Summary
- permit `null` subtitles when creating or updating collections
- add tests ensuring null subtitles are accepted

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_6894cddd7120832092ac4e6822cafb0e