### PR TITLE
refactor: modularize library component responsibilities

### DIFF
--- a/choir-app-frontend/src/app/core/services/file-upload.service.ts
+++ b/choir-app-frontend/src/app/core/services/file-upload.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FileUploadService {
+  constructor(private api: ApiService) {}
+
+  importLibraryCsv(file: File): Observable<any> {
+    return this.api.importLibraryCsv(file);
+  }
+}

--- a/choir-app-frontend/src/app/core/services/library-util.service.ts
+++ b/choir-app-frontend/src/app/core/services/library-util.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { PageEvent } from '@angular/material/paginator';
+import { LibraryItem } from '@core/models/library-item';
+import { Piece } from '@core/models/piece';
+import { Collection } from '@core/models/collection';
+import { ApiService } from './api.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LibraryUtilService {
+  expandedItem: LibraryItem | null = null;
+  expandedPieces: Piece[] = [];
+  piecePageSize = 10;
+  piecePageIndex = 0;
+  private composerCache = new Map<number, string>();
+
+  constructor(private api: ApiService, private router: Router) {}
+
+  toggleCollection(item: LibraryItem): void {
+    const colId = item.collection?.id;
+    if (!colId) return;
+
+    if (this.expandedItem === item) {
+      this.expandedItem = null;
+      return;
+    }
+
+    this.api.getCollectionById(colId).subscribe(col => {
+      if ((col.singleEdition || (col.pieces && col.pieces.length === 1)) && col.pieces && col.pieces.length === 1) {
+        this.router.navigate(['/pieces', col.pieces[0].id]);
+      } else {
+        this.expandedItem = item;
+        this.expandedPieces = col.pieces || [];
+        this.piecePageIndex = 0;
+      }
+    });
+  }
+
+  onPiecePage(event: PageEvent): void {
+    this.piecePageIndex = event.pageIndex;
+    this.piecePageSize = event.pageSize;
+  }
+
+  get paginatedPieces(): Piece[] {
+    const start = this.piecePageIndex * this.piecePageSize;
+    return this.expandedPieces.slice(start, start + this.piecePageSize);
+  }
+
+  getCollectionHint(collection?: Collection): string {
+    if (!collection) return '';
+    return collection.subtitle || '';
+  }
+
+  getCollectionComposer(collection?: Collection): string {
+    if (!collection) return '';
+
+    if (collection.pieceCount === 1) {
+      const cached = this.composerCache.get(collection.id);
+      if (cached !== undefined) {
+        return cached;
+      }
+      this.composerCache.set(collection.id, '');
+      this.api.getCollectionById(collection.id).subscribe(col => {
+        const name = col.pieces?.[0]?.composer?.name || col.pieces?.[0]?.origin || '';
+        this.composerCache.set(collection.id, name);
+      });
+    }
+    return '';
+  }
+}

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -68,13 +68,13 @@
 
         <ng-container matColumnDef="expandedDetail">
           <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
-            <div *ngIf="expandedItem === element">
+            <div *ngIf="libraryUtil.expandedItem === element">
               <mat-nav-list>
                 <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
                   {{ piece.title }}
                 </a>
               </mat-nav-list>
-              <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
+              <mat-paginator [length]="libraryUtil.expandedPieces.length" [pageSize]="libraryUtil.piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
             </div>
           </td>
         </ng-container>


### PR DESCRIPTION
## Summary
- extract file uploading into dedicated `FileUploadService`
- add `LibraryUtilService` to manage collection expansion, pagination, and composer caching
- update library component and template to delegate helper logic to reusable services

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8911dc48320bfc6df079369f8f6