### PR TITLE
refactor: streamline controller CRUD via BaseCrudController

### DIFF
--- a/choir-app-backend/src/controllers/category.controller.js
+++ b/choir-app-backend/src/controllers/category.controller.js
@@ -2,58 +2,62 @@ const db = require("../models");
 const Category = db.category;
 const { Op } = require('sequelize');
 const BaseCrudController = require("./baseCrud.controller");
-const base = new BaseCrudController(Category);
 
-exports.create = async (req, res, next) => {
-    try {
-        const category = await base.service.create({ name: req.body.name });
-        res.status(201).send(category);
-    } catch (err) {
-        if (err.name === 'SequelizeUniqueConstraintError') {
-            return res.status(409).send({ message: "A category with this name already exists." });
-        }
-        if (next) return next(err);
-        res.status(500).send({ message: err.message });
+class CategoryController extends BaseCrudController {
+    constructor() {
+        super(Category);
+        this.create = this.create.bind(this);
+        this.findAll = this.findAll.bind(this);
     }
-};
 
-exports.findAll = async (req, res, next) => {
-    const { collectionIds } = req.query;
-    try {
-        if (collectionIds) {
-            let ids = Array.isArray(collectionIds) ? collectionIds : String(collectionIds).split(',');
-            ids = ids.map(id => parseInt(id, 10)).filter(id => !isNaN(id));
-            if (ids.length) {
-                const categories = await Category.findAll({
-                    include: [{
-                        model: db.piece,
-                        as: 'pieces',
-                        attributes: [],
+    async create(req, res, next) {
+        try {
+            req.body = { name: req.body.name };
+            return await super.create(req, res, next);
+        } catch (err) {
+            if (err.name === 'SequelizeUniqueConstraintError') {
+                return res.status(409).send({ message: "A category with this name already exists." });
+            }
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+
+    async findAll(req, res, next) {
+        const { collectionIds } = req.query;
+        try {
+            if (collectionIds) {
+                let ids = Array.isArray(collectionIds) ? collectionIds : String(collectionIds).split(',');
+                ids = ids.map(id => parseInt(id, 10)).filter(id => !isNaN(id));
+                if (ids.length) {
+                    const categories = await Category.findAll({
                         include: [{
-                            model: db.collection,
-                            as: 'collections',
+                            model: db.piece,
+                            as: 'pieces',
                             attributes: [],
-                            through: { attributes: [] },
-                            where: { id: { [Op.in]: ids } },
+                            include: [{
+                                model: db.collection,
+                                as: 'collections',
+                                attributes: [],
+                                through: { attributes: [] },
+                                where: { id: { [Op.in]: ids } },
+                                required: true
+                            }],
                             required: true
                         }],
-                        required: true
-                    }],
-                    group: ['category.id'],
-                    order: [['name', 'ASC']]
-                });
-                return res.status(200).send(categories);
+                        group: ['category.id'],
+                        order: [['name', 'ASC']]
+                    });
+                    return res.status(200).send(categories);
+                }
             }
+            const categories = await this.service.findAll({ order: [['name', 'ASC']] });
+            res.status(200).send(categories);
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
         }
-        const categories = await base.service.findAll({ order: [['name', 'ASC']] });
-        res.status(200).send(categories);
-    } catch (err) {
-        if (next) return next(err);
-        res.status(500).send({ message: err.message });
     }
-};
+}
 
-// expose generic handlers for completeness
-exports.findById = base.findById;
-exports.update = base.update;
-exports.delete = base.delete;
+module.exports = new CategoryController();

--- a/choir-app-backend/src/controllers/creator.controller.js
+++ b/choir-app-backend/src/controllers/creator.controller.js
@@ -53,8 +53,8 @@ function createCreatorController(Model, options = {}) {
           return res.status(409).send({ message: `A ${entityName.toLowerCase()} with this name already exists.` });
         }
       }
-      const record = await base.service.create({ name, birthYear, deathYear });
-      res.status(201).send(record);
+      req.body = { name, birthYear, deathYear };
+      return await base.create(req, res, next);
     } catch (err) {
       if (next) return next(err);
       res.status(500).send({ message: err.message });
@@ -72,12 +72,7 @@ function createCreatorController(Model, options = {}) {
           return res.status(409).send({ message: `A ${entityName.toLowerCase()} with this name already exists.` });
         }
       }
-      const num = await base.service.update(id, req.body);
-      if (num === 1) {
-        const updated = await base.service.findById(id);
-        return res.status(200).send(updated);
-      }
-      res.status(404).send({ message: `${entityName} not found.` });
+      return await base.update(req, res, next);
     } catch (err) {
       if (next) return next(err);
       res.status(500).send({ message: err.message });

--- a/choir-app-backend/src/controllers/publisher.controller.js
+++ b/choir-app-backend/src/controllers/publisher.controller.js
@@ -1,67 +1,72 @@
 const db = require("../models");
 const Publisher = db.publisher;
 const BaseCrudController = require("./baseCrud.controller");
-const base = new BaseCrudController(Publisher);
 
-exports.create = async (req, res, next) => {
-    try {
-        const publisher = await base.service.create({ name: req.body.name });
-        res.status(201).send(publisher);
-    } catch (err) {
-        if (err.name === 'SequelizeUniqueConstraintError') {
-            return res.status(409).send({ message: "A publisher with this name already exists." });
-        }
-        if (next) return next(err);
-        res.status(500).send({ message: err.message });
+class PublisherController extends BaseCrudController {
+    constructor() {
+        super(Publisher);
+        this.create = this.create.bind(this);
+        this.update = this.update.bind(this);
+        this.findAll = this.findAll.bind(this);
+        this.delete = this.delete.bind(this);
     }
-};
 
-exports.update = async (req, res, next) => {
-    try {
-        const id = req.params.id;
-        const num = await base.service.update(id, req.body);
-        if (num === 1) {
-            const updated = await base.service.findById(id);
-            return res.status(200).send(updated);
+    async create(req, res, next) {
+        try {
+            req.body = { name: req.body.name };
+            return await super.create(req, res, next);
+        } catch (err) {
+            if (err.name === 'SequelizeUniqueConstraintError') {
+                return res.status(409).send({ message: "A publisher with this name already exists." });
+            }
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
         }
-        res.status(404).send({ message: "Publisher not found." });
-    } catch (err) {
-        if (err.name === 'SequelizeUniqueConstraintError') {
-            return res.status(409).send({ message: "A publisher with this name already exists." });
-        }
-        if (next) return next(err);
-        res.status(500).send({ message: err.message });
     }
-};
 
-exports.findAll = async (req, res, next) => {
-    try {
-        const publishers = await base.service.findAll({ order: [['name', 'ASC']] });
-        const result = await Promise.all(
-            publishers.map(async (publisher) => {
-                const collectionCount = await publisher.countCollections();
-                return { ...publisher.get({ plain: true }), canDelete: collectionCount === 0 };
-            })
-        );
-        res.status(200).send(result);
-    } catch (err) {
-        if (next) return next(err);
-        res.status(500).send({ message: err.message });
-    }
-};
-
-exports.delete = async (req, res, next) => {
-    const { id } = req.params;
-    try {
-        const publisher = await Publisher.findByPk(id);
-        if (!publisher) return res.status(404).send({ message: "Publisher not found." });
-        const collectionCount = await publisher.countCollections();
-        if (collectionCount > 0) {
-            return res.status(400).send({ message: "Publisher has linked collections." });
+    async update(req, res, next) {
+        try {
+            return await super.update(req, res, next);
+        } catch (err) {
+            if (err.name === 'SequelizeUniqueConstraintError') {
+                return res.status(409).send({ message: "A publisher with this name already exists." });
+            }
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
         }
-        return base.delete(req, res, next);
-    } catch (err) {
-        if (next) return next(err);
-        res.status(500).send({ message: err.message });
     }
-};
+
+    async findAll(req, res, next) {
+        try {
+            const publishers = await this.service.findAll({ order: [['name', 'ASC']] });
+            const result = await Promise.all(
+                publishers.map(async (publisher) => {
+                    const collectionCount = await publisher.countCollections();
+                    return { ...publisher.get({ plain: true }), canDelete: collectionCount === 0 };
+                })
+            );
+            res.status(200).send(result);
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+
+    async delete(req, res, next) {
+        const { id } = req.params;
+        try {
+            const publisher = await Publisher.findByPk(id);
+            if (!publisher) return res.status(404).send({ message: "Publisher not found." });
+            const collectionCount = await publisher.countCollections();
+            if (collectionCount > 0) {
+                return res.status(400).send({ message: "Publisher has linked collections." });
+            }
+            return super.delete(req, res, next);
+        } catch (err) {
+            if (next) return next(err);
+            res.status(500).send({ message: err.message });
+        }
+    }
+}
+
+module.exports = new PublisherController();


### PR DESCRIPTION
## Summary
- refactor publisher and category controllers to extend and invoke BaseCrudController methods
- update generic creator controller to delegate create/update to BaseCrudController

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d97ad74c8320a3d08682c2a578c6