### PR TITLE
feat: add sorting and pagination to library list

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -31,58 +31,57 @@
       </mat-menu>
     </div>
 
-    <ng-container *ngIf="items$ | async as items">
-      <table mat-table [dataSource]="items" class="mat-elevation-z8" multiTemplateDataRows>
-        <ng-container matColumnDef="title">
-          <th mat-header-cell *matHeaderCellDef>Titel</th>
-          <td mat-cell *matCellDef="let element">
-            <div class="composer-hint" *ngIf="getCollectionComposer(element.collection) as composer">{{ composer }}</div>
-            <div class="title">{{ element.collection?.title }}</div>
-            <div class="subtitle-hint" *ngIf="getCollectionHint(element.collection) as hint">{{ hint }}</div>
-          </td>
-        </ng-container>
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8" multiTemplateDataRows>
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Titel</th>
+        <td mat-cell *matCellDef="let element">
+          <div class="composer-hint" *ngIf="getCollectionComposer(element.collection) as composer">{{ composer }}</div>
+          <div class="title">{{ element.collection?.title }}</div>
+          <div class="subtitle-hint" *ngIf="getCollectionHint(element.collection) as hint">{{ hint }}</div>
+        </td>
+      </ng-container>
 
-        <ng-container matColumnDef="copies">
-          <th mat-header-cell *matHeaderCellDef>Exemplare</th>
-          <td mat-cell *matCellDef="let element">{{element.copies}}</td>
-        </ng-container>
+      <ng-container matColumnDef="copies">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Exemplare</th>
+        <td mat-cell *matCellDef="let element">{{element.copies}}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>Status</th>
-          <td mat-cell *matCellDef="let element">{{element.status}}</td>
-        </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
+        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="availableAt">
-          <th mat-header-cell *matHeaderCellDef>Verfügbar ab</th>
-          <td mat-cell *matCellDef="let element">{{element.availableAt | date}}</td>
-        </ng-container>
+      <ng-container matColumnDef="availableAt">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Verfügbar ab</th>
+        <td mat-cell *matCellDef="let element">{{element.availableAt | date}}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let element">
-            <button mat-icon-button color="primary" *ngIf="element.status === 'available'" (click)="addToCart(element, $event)">
-              <mat-icon>add_shopping_cart</mat-icon>
-            </button>
-          </td>
-        </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-icon-button color="primary" *ngIf="element.status === 'available'" (click)="addToCart(element, $event)">
+            <mat-icon>add_shopping_cart</mat-icon>
+          </button>
+        </td>
+      </ng-container>
 
-        <ng-container matColumnDef="expandedDetail">
-          <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
-            <div *ngIf="expandedItem === element">
-              <mat-nav-list>
-                <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
-                  {{ piece.title }}
-                </a>
-              </mat-nav-list>
-              <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
-            </div>
-          </td>
-        </ng-container>
+      <ng-container matColumnDef="expandedDetail">
+        <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+          <div *ngIf="expandedItem === element">
+            <mat-nav-list>
+              <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
+                {{ piece.title }}
+              </a>
+            </mat-nav-list>
+            <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
+          </div>
+        </td>
+      </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></tr>
-        <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
-      </table>
-    </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
+    </table>
+    <mat-paginator #libraryPaginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" showFirstLastButtons></mat-paginator>
   </mat-tab>
 </mat-tab-group>

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
@@ -12,7 +12,9 @@ import { Router, RouterModule } from '@angular/router';
 import { LibraryItemDialogComponent } from './library-item-dialog.component';
 import { LoanCartService } from '@core/services/loan-cart.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { PageEvent } from '@angular/material/paginator';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
 
 @Component({
   selector: 'app-library',
@@ -21,11 +23,14 @@ import { PageEvent } from '@angular/material/paginator';
   templateUrl: './library.component.html',
   styleUrls: ['./library.component.scss']
 })
-export class LibraryComponent implements OnInit {
-  items$!: Observable<LibraryItem[]>;
+export class LibraryComponent implements OnInit, AfterViewInit {
+  @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild('libraryPaginator') paginator!: MatPaginator;
+
   collections$!: Observable<Collection[]>;
   isAdmin = false;
   displayedColumns: string[] = ['title', 'copies', 'status', 'availableAt', 'actions'];
+  dataSource = new MatTableDataSource<LibraryItem>();
   expandedItem: LibraryItem | null = null;
   expandedPieces: Piece[] = [];
   piecePageSize = 10;
@@ -40,8 +45,23 @@ export class LibraryComponent implements OnInit {
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
   }
 
+  ngAfterViewInit(): void {
+    this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sortingDataAccessor = (item, property) => {
+      switch (property) {
+        case 'title':
+          return item.collection?.title || '';
+        case 'availableAt':
+          return item.availableAt ? new Date(item.availableAt).getTime() : 0;
+        default:
+          return (item as any)[property];
+      }
+    };
+  }
+
   load(): void {
-    this.items$ = this.apiService.getLibraryItems();
+    this.apiService.getLibraryItems().subscribe(items => (this.dataSource.data = items));
   }
 
   onFileSelected(event: any): void {


### PR DESCRIPTION
## Summary
- enable sorting and table pagination in the library list
- use MatTableDataSource with MatSort and MatPaginator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894dbc97edc8320b2b9439391bf6e25