### PR TITLE
Refactor email service modules and add tests

### DIFF
--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.duplicate.test.js && node tests/join.controller.test.js",
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.duplicate.test.js && node tests/join.controller.test.js && node tests/emailTemplateManager.test.js && node tests/emailTransporter.test.js",
     "check": "node --check server.js",
     "init": "node scripts/init.js",
     "seed": "node scripts/seed.js"

--- a/choir-app-backend/src/services/emailTemplateManager.js
+++ b/choir-app-backend/src/services/emailTemplateManager.js
@@ -1,0 +1,26 @@
+function replacePlaceholders(text, type, replacements) {
+  let result = text;
+  for (const [key, value] of Object.entries(replacements)) {
+    const anchor = key.toLowerCase().includes('link')
+      ? `<a href="${value}">${value}</a>`
+      : value;
+    result = result.split(`{{${key}}}`).join(value);
+    result = result.split(`{{${key}-html}}`).join(anchor);
+    if (type) {
+      result = result.split(`{{${type}-${key}}}`).join(value);
+      result = result.split(`{{${type}-${key}-html}}`).join(anchor);
+    }
+  }
+  return result;
+}
+
+function buildTemplate(template, type, replacements) {
+  const subjectTemplate = template?.subject || '';
+  const bodyTemplate = template?.body || '';
+  const subject = replacePlaceholders(subjectTemplate, type, replacements);
+  const html = replacePlaceholders(bodyTemplate, type, replacements);
+  const text = html.replace(/<[^>]+>/g, ' ');
+  return { subject, html, text };
+}
+
+module.exports = { replacePlaceholders, buildTemplate };

--- a/choir-app-backend/src/services/emailTransporter.js
+++ b/choir-app-backend/src/services/emailTransporter.js
@@ -1,0 +1,33 @@
+const nodemailer = require('nodemailer');
+
+function emailDisabled() {
+  return process.env.DISABLE_EMAIL === 'true';
+}
+
+async function createTransporter(existingSettings) {
+  const settings = existingSettings || await require('../models').mail_setting.findByPk(1);
+  return nodemailer.createTransport({
+    host: settings?.host || process.env.SMTP_HOST,
+    port: settings?.port || process.env.SMTP_PORT || 587,
+    secure: settings?.secure || false,
+    requireTLS: settings?.starttls || process.env.SMTP_STARTTLS === 'true' || false,
+    auth: {
+      user: settings?.user || process.env.SMTP_USER,
+      pass: settings?.pass || process.env.SMTP_PASS
+    }
+  });
+}
+
+function getFromAddress(settings) {
+  const address = settings?.fromAddress || process.env.EMAIL_FROM || 'no-reply@nak-chorleiter.de';
+  return { name: address, address };
+}
+
+async function sendMail(options, overrideSettings) {
+  if (emailDisabled()) return;
+  const settings = overrideSettings || await require('../models').mail_setting.findByPk(1);
+  const transporter = await createTransporter(settings);
+  return transporter.sendMail({ from: getFromAddress(settings), ...options });
+}
+
+module.exports = { emailDisabled, createTransporter, getFromAddress, sendMail };

--- a/choir-app-backend/tests/emailTemplateManager.test.js
+++ b/choir-app-backend/tests/emailTemplateManager.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { replacePlaceholders, buildTemplate } = require('../src/services/emailTemplateManager');
+
+(async () => {
+  try {
+    const types = ['invite', 'reset', 'monthly-plan'];
+    for (const type of types) {
+      const template = `Hello {{surname}} {{link}} {{link-html}} {{${type}-link}} {{${type}-link-html}}`;
+      const replaced = replacePlaceholders(template, type, { surname: 'Anna', link: 'http://example.com' });
+      assert.ok(!replaced.includes('{{'), `Unreplaced placeholder for ${type}`);
+      assert.ok(replaced.includes('<a href="http://example.com">http://example.com</a>'));
+    }
+
+    const mail = buildTemplate({ subject: 'Hi {{surname}}', body: '<p>Use {{link}}</p>' }, 'reset', { surname: 'Bob', link: 'http://example.com' });
+    assert.strictEqual(mail.subject, 'Hi Bob');
+    assert.strictEqual(mail.text.trim(), 'Use http://example.com');
+    console.log('emailTemplateManager tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/choir-app-backend/tests/emailTransporter.test.js
+++ b/choir-app-backend/tests/emailTransporter.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const nodemailer = require('nodemailer');
+
+let createdOptions;
+nodemailer.createTransport = (opts) => {
+  createdOptions = opts;
+  return { sendMail: (mailOpts) => Promise.resolve(mailOpts) };
+};
+
+const { sendMail } = require('../src/services/emailTransporter');
+
+(async () => {
+  try {
+    const result = await sendMail(
+      { to: 'a@b.c', subject: 'sub', html: '<p>hi</p>', text: 'hi' },
+      { host: 'smtp.example.com', port: 25, user: 'u', pass: 'p', fromAddress: 'from@example.com' }
+    );
+    assert.strictEqual(createdOptions.host, 'smtp.example.com');
+    assert.strictEqual(result.to, 'a@b.c');
+    assert.strictEqual(result.from.address, 'from@example.com');
+    console.log('emailTransporter tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- Split email service into `emailTemplateManager` and `emailTransporter`
- Rework email.service to use new modules for template building and transport
- Add tests validating placeholder replacement and transport configuration

## Testing
- `node tests/emailTemplateManager.test.js && node tests/emailTransporter.test.js`
- `npm test` *(passes with database setup; output omitted)*

------
https://chatgpt.com/codex/tasks/task_e_6894d882d8888320b38f2990f844fdb9