### PR TITLE
Keep admin menu open on admin pages

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -268,7 +268,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
         displayName: 'Administration',
         //svgIconName: 's-settings',
         visibleSubject: this.isAdmin$,
-        route: '',
+        route: 'admin',
         children: [
           {
             displayName: 'Allgemein',


### PR DESCRIPTION
## Summary
- keep Admin menu expanded when navigating admin routes by giving the navigation item a matching route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894e6b6f5d883208601c7581cb45f5a