### PR TITLE
Show composer and opus for pieces in library collections

### DIFF
--- a/choir-app-frontend/src/app/features/library/library-collection-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-collection-dialog.component.html
@@ -3,6 +3,10 @@
   <mat-nav-list>
     <a mat-list-item *ngFor="let piece of collection.pieces" [routerLink]="['/pieces', piece.id]" (click)="dialogRef.close()">
       {{ piece.title }}
+      <span *ngIf="piece.composer?.name || piece.origin">
+        – {{ piece.composer?.name || piece.origin }}
+      </span>
+      <span *ngIf="piece.opus"> ({{ piece.opus }})</span>
     </a>
   </mat-nav-list>
 </div>

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -78,6 +78,10 @@
             <mat-nav-list>
               <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
                 {{ piece.title }}
+                <span *ngIf="piece.composer?.name || piece.origin">
+                  – {{ piece.composer?.name || piece.origin }}
+                </span>
+                <span *ngIf="piece.opus"> ({{ piece.opus }})</span>
               </a>
             </mat-nav-list>
             <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>


### PR DESCRIPTION
## Summary
- display composer and optional opus when listing pieces of a collection in the library view
- show composer and opus information in the library's collection dialog

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6894f16368d48320a69220af3ecef6c9