### PR TITLE
Normalize person names during import

### DIFF
--- a/choir-app-backend/src/utils/name.utils.js
+++ b/choir-app-backend/src/utils/name.utils.js
@@ -36,4 +36,15 @@ function isDuplicate(a, b) {
   return similarity >= 0.8;
 }
 
-module.exports = { normalize, levenshtein, isDuplicate };
+function formatPersonName(name) {
+  if (!name) return name;
+  const trimmed = name.trim();
+  if (trimmed.includes(',')) return trimmed;
+  const parts = trimmed.split(/\s+/);
+  if (parts.length <= 1) return trimmed;
+  const lastName = parts.pop();
+  const firstNames = parts.join(' ');
+  return `${lastName}, ${firstNames}`;
+}
+
+module.exports = { normalize, levenshtein, isDuplicate, formatPersonName };

--- a/choir-app-backend/tests/import.controller.test.js
+++ b/choir-app-backend/tests/import.controller.test.js
@@ -35,6 +35,24 @@ const jobs = require('../src/services/import-jobs.service');
 
     console.log('import.controller auto numbering test passed');
 
+    // Test name formatting for composer and author
+    await db.sequelize.sync({ force: true });
+
+    const collectionFmt = await db.collection.create({ title: 'Fmt', prefix: 'F' });
+    const recordsFmt = [
+      { title: 'Formatted Piece', composer: 'Johann Sebastian Bach', author: 'Martin Luther' }
+    ];
+    const jobFmt = jobs.createJob('jobFmt');
+    jobFmt.status = 'running';
+    await controller._test.processImport(jobFmt, collectionFmt, recordsFmt);
+
+    const storedComposer = await db.composer.findOne();
+    const storedAuthor = await db.author.findOne();
+    assert.strictEqual(storedComposer.name, 'Bach, Johann Sebastian');
+    assert.strictEqual(storedAuthor.name, 'Luther, Martin');
+
+    console.log('import.controller name formatting test passed');
+
     await db.sequelize.sync({ force: true });
 
     const choir = await db.choir.create({ name: 'Test Choir' });


### PR DESCRIPTION
## Summary
- Format composer and author names to "Lastname, Firstname" during piece import
- Avoid duplicate creators by case-insensitive lookup
- Verify formatting with new tests

## Testing
- `npm test --prefix choir-app-backend`
- `npm run check --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_6894f5f9a8c88320b5e830624f4b784a