### PR TITLE
Handle abbreviated composer names in CSV import

### DIFF
--- a/choir-app-backend/tests/import.controller.test.js
+++ b/choir-app-backend/tests/import.controller.test.js
@@ -53,6 +53,23 @@ const jobs = require('../src/services/import-jobs.service');
 
     console.log('import.controller name formatting test passed');
 
+    // Test interpolation of abbreviated composer names
+    await db.sequelize.sync({ force: true });
+
+    const collectionAbbr = await db.collection.create({ title: 'Abbr', prefix: 'A' });
+    const existingComp = await db.composer.create({ name: 'Bach, Johann Sebastian' });
+    const recordsAbbr = [
+      { title: 'Abbrev Piece', composer: 'J. S. Bach' }
+    ];
+    const jobAbbr = jobs.createJob('jobAbbr');
+    jobAbbr.status = 'running';
+    await controller._test.processImport(jobAbbr, collectionAbbr, recordsAbbr);
+    const composers = await db.composer.findAll();
+    assert.strictEqual(composers.length, 1, 'should reuse existing composer');
+    assert.strictEqual(composers[0].id, existingComp.id);
+
+    console.log('import.controller abbreviation match test passed');
+
     await db.sequelize.sync({ force: true });
 
     const choir = await db.choir.create({ name: 'Test Choir' });


### PR DESCRIPTION
## Summary
- match abbreviated composer and author names to existing entries during CSV import
- create new people only when no match is found
- test CSV import with abbreviated composer name

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`
- `npm run check --prefix choir-app-backend >/tmp/check.log && tail -n 20 /tmp/check.log`


------
https://chatgpt.com/codex/tasks/task_e_689584388a288320a218024773ff7e43