### PR TITLE
feat: move rehearsal list to statistics

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -204,33 +204,4 @@
     </mat-card-content>
   </mat-card>
 
-  <mat-card class="table-card">
-    <mat-card-header>
-      <mat-card-title>Probe</mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="table-wrapper mat-elevation-z4">
-        <table mat-table [dataSource]="rehearsalDataSource">
-          <ng-container matColumnDef="title">
-            <th mat-header-cell *matHeaderCellDef> Titel </th>
-            <td mat-cell *matCellDef="let piece">
-              <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="composer">
-            <th mat-header-cell *matHeaderCellDef> Komponist/Ursprung </th>
-            <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</td>
-          </ng-container>
-          <tr mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></tr>
-          <tr class="mat-row" *matNoDataRow>
-            <td class="mat-cell" [attr.colspan]="displayedRehearsalColumns.length">
-              Keine Stücke in Probe.
-            </td>
-          </tr>
-        </table>
-      </div>
-    </mat-card-content>
-  </mat-card>
-
 </div>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -13,7 +13,6 @@ import { Choir } from 'src/app/core/models/choir';
 import { UserInChoir } from 'src/app/core/models/user';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { Collection } from 'src/app/core/models/collection';
-import { Piece } from 'src/app/core/models/piece';
 import { InviteUserDialogComponent } from '../invite-user-dialog/invite-user-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { ActivatedRoute, RouterModule } from '@angular/router';
@@ -53,9 +52,6 @@ export class ManageChoirComponent implements OnInit {
 
   displayedCollectionColumns: string[] = ['title', 'publisher', 'actions'];
   collectionDataSource = new MatTableDataSource<Collection>();
-
-  displayedRehearsalColumns: string[] = ['title', 'composer'];
-  rehearsalDataSource = new MatTableDataSource<Piece>();
 
 
   // Für die Mitglieder-Tabelle
@@ -120,7 +116,6 @@ export class ManageChoirComponent implements OnInit {
         }
         this.dataSource.data = pageData.members;
         this.collectionDataSource.data = pageData.collections;
-        this.loadRehearsalPieces();
       }
     });
   }
@@ -312,10 +307,4 @@ export class ManageChoirComponent implements OnInit {
     });
   }
 
-
-  private loadRehearsalPieces(): void {
-    this.apiService
-      .getMyRepertoire(undefined, undefined, undefined, undefined, undefined, 100, ['IN_REHEARSAL'])
-      .subscribe(res => (this.rehearsalDataSource.data = res.data));
-  }
 }

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -56,5 +56,34 @@
       <p>Singfähig: {{ stats.singableCount }}</p>
       <p>Probe: {{ stats.rehearsalCount }}</p>
     </mat-card>
+
+    <mat-card class="table-card">
+      <mat-card-header>
+        <mat-card-title>Probe</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="table-wrapper mat-elevation-z4">
+          <table mat-table [dataSource]="rehearsalDataSource">
+            <ng-container matColumnDef="title">
+              <th mat-header-cell *matHeaderCellDef> Titel </th>
+              <td mat-cell *matCellDef="let piece">
+                <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="composer">
+              <th mat-header-cell *matHeaderCellDef> Komponist/Ursprung </th>
+              <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></tr>
+            <tr class="mat-row" *matNoDataRow>
+              <td class="mat-cell" [attr.colspan]="displayedRehearsalColumns.length">
+                Keine Stücke in Probe.
+              </td>
+            </tr>
+          </table>
+        </div>
+      </mat-card-content>
+    </mat-card>
   </ng-container>
 </div>

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.scss
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.scss
@@ -7,3 +7,18 @@
     }
   }
 }
+
+.table-card {
+  position: relative;
+}
+
+.table-wrapper {
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.title-link {
+  cursor: pointer;
+  color: #3f51b5;
+  text-decoration: underline;
+}

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
@@ -5,6 +5,8 @@ import { ApiService } from '@core/services/api.service';
 import { StatsSummary, PieceStat } from '@core/models/stats-summary';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { MatTableDataSource } from '@angular/material/table';
+import { Piece } from '@core/models/piece';
 
 @Component({
   selector: 'app-statistics',
@@ -18,6 +20,9 @@ export class StatisticsComponent implements OnInit {
 
   leastUsedPieces: PieceStat[] = [];
 
+  displayedRehearsalColumns: string[] = ['title', 'composer'];
+  rehearsalDataSource = new MatTableDataSource<Piece>();
+
   startDate?: Date;
   endDate?: Date;
   activeMonths?: number;
@@ -27,6 +32,7 @@ export class StatisticsComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadStats();
+    this.loadRehearsalPieces();
   }
 
   loadStats(): void {
@@ -35,5 +41,11 @@ export class StatisticsComponent implements OnInit {
       this.stats = s;
       this.leastUsedPieces = s.leastUsedPieces;
     });
+  }
+
+  private loadRehearsalPieces(): void {
+    this.apiService
+      .getMyRepertoire(undefined, undefined, undefined, undefined, undefined, 100, ['IN_REHEARSAL'])
+      .subscribe(res => (this.rehearsalDataSource.data = res.data));
   }
 }


### PR DESCRIPTION
## Summary
- relocate rehearsal pieces list from choir management to statistics page
- show rehearsal pieces in stats using table layout
- style statistics table consistent with management view

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6895c5ccfb848320b3c1e60d1a32b806