### PR TITLE
feat: add librarian role and library item management

### DIFF
--- a/choir-app-backend/src/controllers/library.controller.js
+++ b/choir-app-backend/src/controllers/library.controller.js
@@ -62,6 +62,30 @@ exports.importCsv = async (req, res) => {
   res.status(200).send({ message: 'Import complete.' });
 };
 
+// Update copies or status of a library item
+exports.update = async (req, res) => {
+  const id = req.params.id;
+  const { copies, status, availableAt } = req.body;
+  const item = await LibraryItem.findByPk(id);
+  if (!item) return res.status(404).send({ message: 'Library item not found.' });
+
+  const data = {};
+  if (copies !== undefined) data.copies = copies;
+  if (status) {
+    data.status = status;
+    if (status === 'available') {
+      data.availableAt = null;
+    } else if (availableAt) {
+      data.availableAt = availableAt;
+    }
+  } else if (availableAt !== undefined) {
+    data.availableAt = availableAt;
+  }
+
+  await item.update(data);
+  res.status(200).send(item);
+};
+
 // Borrow an item - only directors may borrow
 exports.borrow = async (req, res) => {
   const id = req.params.id;
@@ -82,6 +106,15 @@ exports.returnItem = async (req, res) => {
   if (!item) return res.status(404).send({ message: 'Library item not found.' });
   await item.update({ status: 'available', availableAt: null });
   res.status(200).send(item);
+};
+
+// Delete a library item
+exports.remove = async (req, res) => {
+  const id = req.params.id;
+  const item = await LibraryItem.findByPk(id);
+  if (!item) return res.status(404).send({ message: 'Library item not found.' });
+  await item.destroy();
+  res.status(204).send();
 };
 
 // Create loan request for multiple library items

--- a/choir-app-backend/src/middleware/role.middleware.js
+++ b/choir-app-backend/src/middleware/role.middleware.js
@@ -41,10 +41,16 @@ async function requireChoirAdmin(req, res, next) {
 }
 
 function requireDirector(req, res, next) {
-    if (['director', 'choir_admin', 'admin'].includes(req.userRole)) {
+    if (['director', 'choir_admin', 'admin', 'librarian'].includes(req.userRole)) {
         return next();
     }
     return res.status(403).send({ message: 'Require Director Role!' });
 }
 
-module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector };
+function requireLibrarian(req, res, next) {
+    if (['librarian', 'admin'].includes(req.userRole)) {
+        return next();
+    }
+    return res.status(403).send({ message: 'Require Librarian Role!' });
+}
+module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector, requireLibrarian };

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -22,7 +22,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       role: {
         // Include 'singer' so regular choir members can register
-        type: DataTypes.ENUM('director', 'choir_admin', 'admin', 'demo', 'singer'),
+        type: DataTypes.ENUM('director', 'choir_admin', 'admin', 'demo', 'singer', 'librarian'),
         defaultValue: 'director'
       },
       lastDonation: {

--- a/choir-app-backend/src/routes/library.routes.js
+++ b/choir-app-backend/src/routes/library.routes.js
@@ -5,14 +5,16 @@ const router = require("express").Router();
 const { handler: wrap } = require("../utils/async");
 const { memoryUpload } = require('../utils/upload');
 const upload = memoryUpload();
-const { createLibraryItemValidation, loanRequestValidation } = require("../validators/library.validation");
+const { createLibraryItemValidation, loanRequestValidation, updateLibraryItemValidation } = require("../validators/library.validation");
 const validate = require("../validators/validate");
 
 router.use(authJwt.verifyToken);
 
 router.get('/', wrap(controller.findAll));
-router.post('/', role.requireAdmin, createLibraryItemValidation, validate, wrap(controller.create));
-router.post('/import', role.requireAdmin, upload.single('csvfile'), wrap(controller.importCsv));
+router.post('/', role.requireLibrarian, createLibraryItemValidation, validate, wrap(controller.create));
+router.post('/import', role.requireLibrarian, upload.single('csvfile'), wrap(controller.importCsv));
+router.put('/:id', role.requireLibrarian, updateLibraryItemValidation, validate, wrap(controller.update));
+router.delete('/:id', role.requireLibrarian, wrap(controller.remove));
 router.post('/:id/borrow', role.requireDirector, wrap(controller.borrow));
 router.post('/:id/return', role.requireDirector, wrap(controller.returnItem));
 router.post('/request', role.requireDirector, loanRequestValidation, validate, wrap(controller.requestLoan));

--- a/choir-app-backend/src/validators/library.validation.js
+++ b/choir-app-backend/src/validators/library.validation.js
@@ -15,3 +15,9 @@ exports.loanRequestValidation = [
   body('reason').optional().isString()
 ];
 
+exports.updateLibraryItemValidation = [
+  body('copies').optional().isInt({ min: 1 }).withMessage('copies must be an integer'),
+  body('status').optional().isIn(['available', 'borrowed']).withMessage('status must be valid'),
+  body('availableAt').optional().isISO8601().toDate()
+];
+

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -26,7 +26,7 @@ export interface User {
   shareWithChoir?: boolean;
 
 
-  role?: 'director' | 'choir_admin' | 'admin' | 'demo' | 'singer';
+  role?: 'director' | 'choir_admin' | 'admin' | 'demo' | 'singer' | 'librarian';
 
   /**
    * The JSON Web Token received upon successful login.

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -503,6 +503,18 @@ export class ApiService {
     return this.libraryService.borrowItem(id);
   }
 
+  returnLibraryItem(id: number): Observable<any> {
+    return this.libraryService.returnItem(id);
+  }
+
+  updateLibraryItem(id: number, data: Partial<LibraryItem>): Observable<LibraryItem> {
+    return this.libraryService.updateItem(id, data);
+  }
+
+  deleteLibraryItem(id: number): Observable<any> {
+    return this.libraryService.deleteItem(id);
+  }
+
   requestLibraryLoan(data: LoanRequestPayload): Observable<any> {
     return this.libraryService.requestLoan(data);
   }

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -28,12 +28,14 @@ export class AuthService {
 
   // --- Wir leiten die Berechtigungen direkt vom currentUser$ ab ---
   public isAdmin$: Observable<boolean>;
+  public isLibrarian$: Observable<boolean>;
 
   constructor(private http: HttpClient,
               private router: Router,
               private theme: ThemeService,
               private prefs: UserPreferencesService) {
     this.isAdmin$ = this.currentUser$.pipe(map(user => user?.role === 'admin'));
+    this.isLibrarian$ = this.currentUser$.pipe(map(user => user?.role === 'librarian'));
     if (this.hasToken()) {
       this.prefs.load().subscribe(p => {
         if (p.theme) {

--- a/choir-app-frontend/src/app/core/services/library.service.ts
+++ b/choir-app-frontend/src/app/core/services/library.service.ts
@@ -29,6 +29,18 @@ export class LibraryService {
     return this.http.post(`${this.apiUrl}/${id}/borrow`, {});
   }
 
+  returnItem(id: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/${id}/return`, {});
+  }
+
+  updateItem(id: number, data: Partial<LibraryItem>): Observable<LibraryItem> {
+    return this.http.put<LibraryItem>(`${this.apiUrl}/${id}`, data);
+  }
+
+  deleteItem(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/${id}`);
+  }
+
   requestLoan(data: LoanRequestPayload): Observable<any> {
     return this.http.post(`${this.apiUrl}/request`, data);
   }

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -20,7 +20,7 @@
   </mat-tab>
 
   <mat-tab label="Bibliotheksliste">
-    <div class="list-header" *ngIf="isAdmin">
+    <div class="list-header" *ngIf="isAdmin || isLibrarian">
       <input type="file" #fileInput (change)="onFileSelected($event)" hidden />
       <button mat-icon-button [matMenuTriggerFor]="adminMenu">
         <mat-icon>more_vert</mat-icon>
@@ -69,6 +69,14 @@
           <button mat-icon-button color="primary" *ngIf="element.status === 'available'" (click)="addToCart(element, $event)">
             <mat-icon>add_shopping_cart</mat-icon>
           </button>
+          <button mat-icon-button *ngIf="isAdmin || isLibrarian" [matMenuTriggerFor]="itemMenu" (click)="$event.stopPropagation()">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #itemMenu="matMenu">
+            <button mat-menu-item (click)="editCopies(element, $event)">Bestand ändern</button>
+            <button mat-menu-item (click)="changeStatus(element, $event)">Entleihstatus ändern</button>
+            <button mat-menu-item class="delete-button" (click)="deleteItem(element, $event)">Löschen</button>
+          </mat-menu>
         </td>
       </ng-container>
 

--- a/choir-app-frontend/src/app/features/library/library.component.scss
+++ b/choir-app-frontend/src/app/features/library/library.component.scss
@@ -33,3 +33,7 @@
   width: auto;
   object-fit: cover;
 }
+
+.delete-button {
+  color: red;
+}

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -33,6 +33,7 @@ export class LibraryComponent implements OnInit, AfterViewInit {
 
   collections$!: Observable<Collection[]>;
   isAdmin = false;
+  isLibrarian = false;
   displayedColumns: string[] = ['cover', 'title', 'copies', 'status', 'availableAt', 'actions'];
 
   dataSource = new MatTableDataSource<LibraryItem>();
@@ -57,6 +58,7 @@ export class LibraryComponent implements OnInit, AfterViewInit {
     this.load();
     this.collections$ = this.apiService.getCollections();
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
+    this.auth.isLibrarian$.subscribe(l => this.isLibrarian = l);
   }
 
   ngAfterViewInit(): void {
@@ -143,5 +145,29 @@ export class LibraryComponent implements OnInit, AfterViewInit {
     event.stopPropagation();
     this.cart.addItem(item);
     this.snack.open('Zur Anfrage hinzugefügt', undefined, { duration: 2000 });
+  }
+
+  editCopies(item: LibraryItem, event: Event): void {
+    event.stopPropagation();
+    const input = prompt('Neue Anzahl Exemplare:', item.copies.toString());
+    if (input !== null) {
+      const copies = Number(input);
+      if (!isNaN(copies) && copies > 0) {
+        this.apiService.updateLibraryItem(item.id, { copies }).subscribe(() => this.load());
+      }
+    }
+  }
+
+  changeStatus(item: LibraryItem, event: Event): void {
+    event.stopPropagation();
+    const newStatus = item.status === 'available' ? 'borrowed' : 'available';
+    this.apiService.updateLibraryItem(item.id, { status: newStatus }).subscribe(() => this.load());
+  }
+
+  deleteItem(item: LibraryItem, event: Event): void {
+    event.stopPropagation();
+    if (confirm('Diesen Eintrag wirklich löschen?')) {
+      this.apiService.deleteLibraryItem(item.id).subscribe(() => this.load());
+    }
   }
 }

--- a/choir-app-frontend/src/app/shared/pipes/user-role-label.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/user-role-label.pipe.ts
@@ -19,6 +19,8 @@ export class UserRoleLabelPipe implements PipeTransform {
         return 'Chor-Admin';
       case 'admin':
         return 'Administrator';
+      case 'librarian':
+        return 'Bibliothekar';
       case 'demo':
         return 'Demo';
       case 'singer':


### PR DESCRIPTION
## Summary
- introduce global `librarian` role
- enable librarians to create, edit, or delete library items via new API endpoints
- show library row action menu for librarians/admins with stock, status, and delete options

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68962be020688320887df1a76997725c