### PR TITLE
Translate loan status to German

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -55,7 +55,7 @@
 
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
-        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+        <td mat-cell *matCellDef="let element">{{element.status | loanStatusLabel}}</td>
       </ng-container>
 
       <ng-container matColumnDef="availableAt">

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -18,12 +18,13 @@ import { MatSort } from '@angular/material/sort';
 import { FileUploadService } from '@core/services/file-upload.service';
 import { LibraryUtilService } from '@core/services/library-util.service';
 import { map } from 'rxjs/operators';
+import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
 
 
 @Component({
   selector: 'app-library',
   standalone: true,
-  imports: [CommonModule, MaterialModule, RouterModule],
+  imports: [CommonModule, MaterialModule, RouterModule, LoanStatusLabelPipe],
   templateUrl: './library.component.html',
   styleUrls: ['./library.component.scss']
 })

--- a/choir-app-frontend/src/app/shared/pipes/loan-status-label.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/loan-status-label.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Wandelt den Ausleihstatus in deutsche Bezeichnungen um.
+ */
+@Pipe({
+  name: 'loanStatusLabel',
+  standalone: true
+})
+export class LoanStatusLabelPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+    switch (value) {
+      case 'available':
+        return 'Verfügbar';
+      case 'borrowed':
+        return 'Verliehen';
+      default:
+        return value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `LoanStatusLabelPipe` to map library item statuses to German terms
- apply the new pipe in the library component so status column shows German labels

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6896415ae72c8320be2dbe65a4f9cb5e