### PR TITLE
feat: add library loan status dialog

### DIFF
--- a/choir-app-frontend/src/app/features/library/library-status-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-status-dialog.component.html
@@ -1,0 +1,37 @@
+<h1 mat-dialog-title>Entleihstatus ändern</h1>
+<div mat-dialog-content [formGroup]="form">
+  <mat-form-field appearance="fill" class="full-width">
+    <mat-label>Entleiher</mat-label>
+    <input matInput formControlName="borrower" />
+  </mat-form-field>
+
+  <div class="date-fields">
+    <mat-form-field appearance="fill">
+      <mat-label>Startdatum</mat-label>
+      <input matInput [matDatepicker]="startPicker" formControlName="startDate" />
+      <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+      <mat-datepicker #startPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Enddatum</mat-label>
+      <input matInput [matDatepicker]="endPicker" formControlName="endDate" />
+      <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+      <mat-datepicker #endPicker></mat-datepicker>
+    </mat-form-field>
+
+    <button mat-stroked-button type="button" (click)="extendPeriod()">Entleihperiode verlängern</button>
+  </div>
+
+  <mat-form-field appearance="fill" class="full-width">
+    <mat-label>Entleihstatus</mat-label>
+    <mat-select formControlName="status">
+      <mat-option value="available">available</mat-option>
+      <mat-option value="borrowed">borrowed</mat-option>
+    </mat-select>
+  </mat-form-field>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-button color="primary" (click)="save()">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/library/library-status-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/library/library-status-dialog.component.ts
@@ -1,0 +1,54 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { LibraryItem } from '@core/models/library-item';
+
+@Component({
+  selector: 'app-library-status-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MaterialModule],
+  templateUrl: './library-status-dialog.component.html'
+})
+export class LibraryStatusDialogComponent {
+  form: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<LibraryStatusDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { item: LibraryItem }
+  ) {
+    const item = data.item;
+    const endDate = item.availableAt ? new Date(item.availableAt) : null;
+    const startDate = endDate ? new Date(endDate) : null;
+    if (startDate) startDate.setMonth(startDate.getMonth() - 3);
+    this.form = this.fb.group({
+      borrower: [''],
+      status: [item.status],
+      startDate: [startDate],
+      endDate: [endDate]
+    });
+  }
+
+  extendPeriod(): void {
+    const current: Date = this.form.value.endDate ? new Date(this.form.value.endDate) : new Date();
+    current.setMonth(current.getMonth() + 3);
+    this.form.patchValue({ endDate: current });
+  }
+
+  save(): void {
+    if (this.form.valid) {
+      const { status, endDate } = this.form.value;
+      this.dialogRef.close({
+        status,
+        availableAt: endDate ? endDate.toISOString() : null
+      });
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}
+

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -10,6 +10,7 @@ import { AuthService } from '@core/services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
 import { RouterModule } from '@angular/router';
 import { LibraryItemDialogComponent } from './library-item-dialog.component';
+import { LibraryStatusDialogComponent } from './library-status-dialog.component';
 import { LoanCartService } from '@core/services/loan-cart.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
@@ -160,8 +161,12 @@ export class LibraryComponent implements OnInit, AfterViewInit {
 
   changeStatus(item: LibraryItem, event: Event): void {
     event.stopPropagation();
-    const newStatus = item.status === 'available' ? 'borrowed' : 'available';
-    this.apiService.updateLibraryItem(item.id, { status: newStatus }).subscribe(() => this.load());
+    const ref = this.dialog.open(LibraryStatusDialogComponent, { data: { item } });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.apiService.updateLibraryItem(item.id, result).subscribe(() => this.load());
+      }
+    });
   }
 
   deleteItem(item: LibraryItem, event: Event): void {


### PR DESCRIPTION
## Summary
- open a new dialog to edit loan details when changing library item status
- allow specifying borrower, loan period and status, with a quick extend option

## Testing
- `npm test` *(fails: error while loading shared libraries: libxkbcommon.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689641ad29a0832095260bc1752e59ba