### PR TITLE
Link collections from search results

### DIFF
--- a/choir-app-frontend/src/app/features/search-results/search-results.component.html
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.html
@@ -19,6 +19,10 @@
 <section *ngIf="results.collections.length">
   <h3>Sammlungen</h3>
   <ul>
-    <li *ngFor="let c of results.collections">{{ c.title }}<span *ngIf="c.subtitle"> – {{ c.subtitle }}</span></li>
+    <li *ngFor="let c of results.collections">
+      <a [routerLink]="['/collections/edit', c.id]">
+        {{ c.title }}<span *ngIf="c.subtitle"> – {{ c.subtitle }}</span>
+      </a>
+    </li>
   </ul>
 </section>

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.spec.ts
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.spec.ts
@@ -5,8 +5,6 @@ import { SearchService } from '@core/services/search.service';
 import { SearchResultsComponent } from './search-results.component';
 
 describe('SearchResultsComponent', () => {
-  let component: SearchResultsComponent;
-  let fixture: ComponentFixture<SearchResultsComponent>;
   let searchSpy: jasmine.SpyObj<SearchService>;
 
   beforeEach(async () => {
@@ -18,14 +16,26 @@ describe('SearchResultsComponent', () => {
         { provide: SearchService, useValue: searchSpy }
       ]
     }).compileComponents();
-
-    searchSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [] }));
-    fixture = TestBed.createComponent(SearchResultsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
+  function createComponent() {
+    const fixture: ComponentFixture<SearchResultsComponent> = TestBed.createComponent(SearchResultsComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    return { fixture, component };
+  }
+
   it('should create', () => {
+    searchSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [] }));
+    const { component } = createComponent();
     expect(component).toBeTruthy();
+  });
+
+  it('should render collection results as links', () => {
+    searchSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [{ id: 1, title: 'Test' }] }));
+    const { fixture } = createComponent();
+    const link: HTMLAnchorElement | null = fixture.nativeElement.querySelector('section:last-child ul li a');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('ng-reflect-router-link')).toContain('/collections/edit,1');
   });
 });


### PR DESCRIPTION
## Summary
- Render global search results for collections as links to their edit pages
- Test that collection results include router links

## Testing
- `npm test` (fails: /root/.cache/puppeteer/chrome/linux-138.0.7204.94/chrome-linux64/chrome: error while loading shared libraries: libcups.so.2)
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6896475e5e9c83209fbd1aaf05496b02