### PR TITLE
Add library availability icon to piece collections

### DIFF
--- a/choir-app-frontend/src/app/features/library/library-item-info-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-item-info-dialog.component.html
@@ -1,0 +1,12 @@
+<h1 mat-dialog-title>{{ item.collection?.title }}</h1>
+<div mat-dialog-content>
+  <p><strong>Exemplare:</strong> {{ item.copies }}</p>
+  <p><strong>Status:</strong> {{ item.status }}</p>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="addToCart()" *ngIf="item.status === 'available'">
+    Zur Ausleihe hinzufügen
+  </button>
+  <span class="spacer"></span>
+  <button mat-button mat-dialog-close>Schließen</button>
+</div>

--- a/choir-app-frontend/src/app/features/library/library-item-info-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/library/library-item-info-dialog.component.ts
@@ -1,0 +1,28 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { LibraryItem } from '@core/models/library-item';
+import { LoanCartService } from '@core/services/loan-cart.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-library-item-info-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MaterialModule],
+  templateUrl: './library-item-info-dialog.component.html'
+})
+export class LibraryItemInfoDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public item: LibraryItem,
+    private dialogRef: MatDialogRef<LibraryItemInfoDialogComponent>,
+    private cart: LoanCartService,
+    private snack: MatSnackBar
+  ) {}
+
+  addToCart(): void {
+    this.cart.addItem(this.item);
+    this.snack.open('Zur Anfrage hinzugefügt', undefined, { duration: 2000 });
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -20,10 +20,17 @@
   <div *ngIf="piece.collections?.length">
     <p><strong>Enthalten in:</strong></p>
     <ul>
-      <li *ngFor="let c of piece.collections">
+      <li *ngFor="let c of piece.collections" class="collection-item">
         <a [routerLink]="['/collections/edit', c.id]">
           {{ c.title }} ({{ c.singleEdition ? (piece.composer?.name || piece.origin) : c.prefix }}{{ c.collection_piece.numberInCollection }})
         </a>
+        <mat-icon
+          *ngIf="libraryItems[c.id]"
+          class="library-icon"
+          matTooltip="In Notenbibliothek vorhanden"
+          (click)="openLibraryItem(c.id, $event)"
+          >library_music</mat-icon
+        >
       </li>
     </ul>
   </div>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.scss
@@ -21,3 +21,17 @@
   vertical-align: middle;
   margin-right: 0.25rem;
 }
+
+.collection-item {
+  display: flex;
+  align-items: center;
+}
+
+.collection-item a {
+  flex: 1;
+}
+
+.library-icon {
+  margin-left: auto;
+  cursor: pointer;
+}

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.spec.ts
@@ -26,7 +26,7 @@ describe('PieceDetailComponent', () => {
             }
           }
         },
-        { provide: ApiService, useValue: { getRepertoirePiece: () => of(null) } },
+        { provide: ApiService, useValue: { getRepertoirePiece: () => of(null), getLibraryItems: () => of([]) } },
         {
           provide: AuthService,
           useValue: { currentUser$: of(null), isAdmin$: of(false) }

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -15,6 +15,8 @@ import { PieceDialogComponent } from '../piece-dialog/piece-dialog.component';
 import { PieceReportDialogComponent } from '../piece-report-dialog/piece-report-dialog.component';
 import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
+import { LibraryItem } from '@core/models/library-item';
+import { LibraryItemInfoDialogComponent } from '../../library/library-item-info-dialog.component';
 
 @Component({
   selector: 'app-piece-detail',
@@ -38,6 +40,7 @@ export class PieceDetailComponent implements OnInit {
   pieceImage: string | null = null;
   fileLinks: (PieceLink & { isPdf: boolean; size?: number })[] = [];
   externalLinks: PieceLink[] = [];
+  libraryItems: { [collectionId: number]: LibraryItem } = {};
 
   constructor(
     private route: ActivatedRoute,
@@ -56,6 +59,7 @@ export class PieceDetailComponent implements OnInit {
     });
     this.auth.currentUser$.subscribe(u => this.userId = u?.id || null);
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
+    this.loadLibraryItems();
   }
 
   private loadPiece(id: number, afterLoad?: () => void): void {
@@ -133,6 +137,26 @@ export class PieceDetailComponent implements OnInit {
       this.piece!.notes.unshift(n as any);
       this.newNoteText = '';
     });
+  }
+
+  private loadLibraryItems(): void {
+    this.apiService.getLibraryItems().subscribe(items => {
+      this.libraryItems = {};
+      items.forEach(i => {
+        const id = i.collectionId || i.collection?.id;
+        if (id != null) {
+          this.libraryItems[id] = i;
+        }
+      });
+    });
+  }
+
+  openLibraryItem(collectionId: number, event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const item = this.libraryItems[collectionId];
+    if (!item) return;
+    this.dialog.open(LibraryItemInfoDialogComponent, { data: item });
   }
 
   openEditPieceDialog(): void {


### PR DESCRIPTION
## Summary
- indicate when a collection is available in the library on piece detail pages
- add dialog to view library entry and add it to loan cart
- style collection list entries with right-aligned library icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68964a229de0832096ae7a107e1d5f24