### PR TITLE
fix: update search results link test

### DIFF
--- a/choir-app-frontend/src/app/features/search-results/search-results.component.spec.ts
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.spec.ts
@@ -34,8 +34,9 @@ describe('SearchResultsComponent', () => {
   it('should render collection results as links', () => {
     searchSpy.searchAll.and.returnValue(of({ pieces: [], events: [], collections: [{ id: 1, title: 'Test' }] }));
     const { fixture } = createComponent();
+    fixture.detectChanges();
     const link: HTMLAnchorElement | null = fixture.nativeElement.querySelector('section:last-child ul li a');
     expect(link).not.toBeNull();
-    expect(link?.getAttribute('ng-reflect-router-link')).toContain('/collections/edit,1');
+    expect(link?.getAttribute('href')).toContain('/collections/edit/1');
   });
 });


### PR DESCRIPTION
## Summary
- adjust SearchResultsComponent spec to assert rendered link href

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964dd2a4708320a866ab1b1e2360a9