### PR TITLE
feat: add loan management tab

### DIFF
--- a/choir-app-backend/src/models/library_item.model.js
+++ b/choir-app-backend/src/models/library_item.model.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
       defaultValue: 1
     },
     status: {
-      type: DataTypes.ENUM('available', 'borrowed'),
+      type: DataTypes.ENUM('available', 'requested', 'borrowed', 'due', 'partial_return'),
       defaultValue: 'available'
     },
     availableAt: {

--- a/choir-app-backend/src/routes/library.routes.js
+++ b/choir-app-backend/src/routes/library.routes.js
@@ -11,6 +11,7 @@ const validate = require("../validators/validate");
 router.use(authJwt.verifyToken);
 
 router.get('/', wrap(controller.findAll));
+router.get('/loans', role.requireLibrarian, wrap(controller.listLoans));
 router.post('/', role.requireLibrarian, createLibraryItemValidation, validate, wrap(controller.create));
 router.post('/import', role.requireLibrarian, upload.single('csvfile'), wrap(controller.importCsv));
 router.put('/:id', role.requireLibrarian, updateLibraryItemValidation, validate, wrap(controller.update));

--- a/choir-app-backend/src/validators/library.validation.js
+++ b/choir-app-backend/src/validators/library.validation.js
@@ -17,7 +17,7 @@ exports.loanRequestValidation = [
 
 exports.updateLibraryItemValidation = [
   body('copies').optional().isInt({ min: 1 }).withMessage('copies must be an integer'),
-  body('status').optional().isIn(['available', 'borrowed']).withMessage('status must be valid'),
+  body('status').optional().isIn(['available', 'requested', 'borrowed', 'due', 'partial_return']).withMessage('status must be valid'),
   body('availableAt').optional().isISO8601().toDate()
 ];
 

--- a/choir-app-frontend/src/app/core/models/library-item.ts
+++ b/choir-app-frontend/src/app/core/models/library-item.ts
@@ -5,6 +5,6 @@ export interface LibraryItem {
   collection?: Collection;
   collectionId?: number;
   copies: number;
-  status: 'available' | 'borrowed';
+  status: 'available' | 'requested' | 'borrowed' | 'due' | 'partial_return';
   availableAt?: string | null;
 }

--- a/choir-app-frontend/src/app/core/models/loan.ts
+++ b/choir-app-frontend/src/app/core/models/loan.ts
@@ -1,0 +1,8 @@
+export interface Loan {
+  id: number;
+  collectionTitle: string;
+  choirName: string;
+  startDate?: string;
+  endDate?: string;
+  status: 'available' | 'requested' | 'borrowed' | 'due' | 'partial_return';
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -20,6 +20,7 @@ import { PieceChange } from '../models/piece-change';
 import { Post } from '../models/post';
 import { LibraryItem } from '../models/library-item';
 import { LoanRequestPayload } from '../models/loan-request';
+import { Loan } from '../models/loan';
 import { PieceService } from './piece.service';
 import { ComposerService } from './composer.service';
 import { AuthorService } from './author.service';
@@ -517,6 +518,10 @@ export class ApiService {
 
   requestLibraryLoan(data: LoanRequestPayload): Observable<any> {
     return this.libraryService.requestLoan(data);
+  }
+
+  getLibraryLoans(): Observable<Loan[]> {
+    return this.libraryService.getLoans();
   }
 
   getMyChoirDetails(options?: { choirId?: number }): Observable<Choir> {

--- a/choir-app-frontend/src/app/core/services/library.service.ts
+++ b/choir-app-frontend/src/app/core/services/library.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { LibraryItem } from '../models/library-item';
 import { LoanRequestPayload } from '../models/loan-request';
+import { Loan } from '../models/loan';
 import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
@@ -43,5 +44,9 @@ export class LibraryService {
 
   requestLoan(data: LoanRequestPayload): Observable<any> {
     return this.http.post(`${this.apiUrl}/request`, data);
+  }
+
+  getLoans(): Observable<Loan[]> {
+    return this.http.get<Loan[]>(`${this.apiUrl}/loans`);
   }
 }

--- a/choir-app-frontend/src/app/features/library/library-status-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/library-status-dialog.component.html
@@ -26,8 +26,11 @@
   <mat-form-field appearance="fill" class="full-width">
     <mat-label>Entleihstatus</mat-label>
     <mat-select formControlName="status">
-      <mat-option value="available">available</mat-option>
-      <mat-option value="borrowed">borrowed</mat-option>
+      <mat-option value="available">Verfügbar</mat-option>
+      <mat-option value="requested">Angefragt</mat-option>
+      <mat-option value="borrowed">Entliehen</mat-option>
+      <mat-option value="due">Fällig</mat-option>
+      <mat-option value="partial_return">Teilweise Rückgabe</mat-option>
     </mat-select>
   </mat-form-field>
 </div>

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -103,4 +103,8 @@
     </table>
     <mat-paginator #libraryPaginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" showFirstLastButtons></mat-paginator>
   </mat-tab>
+
+  <mat-tab *ngIf="isAdmin || isLibrarian" label="Ausleihen">
+    <app-loan-list></app-loan-list>
+  </mat-tab>
 </mat-tab-group>

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -20,12 +20,13 @@ import { FileUploadService } from '@core/services/file-upload.service';
 import { LibraryUtilService } from '@core/services/library-util.service';
 import { map } from 'rxjs/operators';
 import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
+import { LoanListComponent } from './loan-list.component';
 
 
 @Component({
   selector: 'app-library',
   standalone: true,
-  imports: [CommonModule, MaterialModule, RouterModule, LoanStatusLabelPipe],
+  imports: [CommonModule, MaterialModule, RouterModule, LoanStatusLabelPipe, LoanListComponent],
   templateUrl: './library.component.html',
   styleUrls: ['./library.component.scss']
 })

--- a/choir-app-frontend/src/app/features/library/loan-list.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.html
@@ -1,0 +1,29 @@
+<table mat-table [dataSource]="loans" class="mat-elevation-z8">
+  <ng-container matColumnDef="collectionTitle">
+    <th mat-header-cell *matHeaderCellDef>Sammlungstitel</th>
+    <td mat-cell *matCellDef="let element">{{element.collectionTitle}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="choirName">
+    <th mat-header-cell *matHeaderCellDef>Chor</th>
+    <td mat-cell *matCellDef="let element">{{element.choirName}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="startDate">
+    <th mat-header-cell *matHeaderCellDef>Startdatum</th>
+    <td mat-cell *matCellDef="let element">{{element.startDate | date}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="endDate">
+    <th mat-header-cell *matHeaderCellDef>Enddatum</th>
+    <td mat-cell *matCellDef="let element">{{element.endDate | date}}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="status">
+    <th mat-header-cell *matHeaderCellDef>Status</th>
+    <td mat-cell *matCellDef="let element">{{element.status | loanStatusLabel}}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/library/loan-list.component.scss
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.scss
@@ -1,0 +1,1 @@
+table { width: 100%; }

--- a/choir-app-frontend/src/app/features/library/loan-list.component.ts
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Loan } from '@core/models/loan';
+import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
+
+@Component({
+  selector: 'app-loan-list',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, LoanStatusLabelPipe],
+  templateUrl: './loan-list.component.html',
+  styleUrls: ['./loan-list.component.scss']
+})
+export class LoanListComponent implements OnInit {
+  displayedColumns: string[] = ['collectionTitle', 'choirName', 'startDate', 'endDate', 'status'];
+  loans: Loan[] = [];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.getLibraryLoans().subscribe(loans => this.loans = loans);
+  }
+}

--- a/choir-app-frontend/src/app/shared/pipes/loan-status-label.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/loan-status-label.pipe.ts
@@ -15,8 +15,14 @@ export class LoanStatusLabelPipe implements PipeTransform {
     switch (value) {
       case 'available':
         return 'Verfügbar';
+      case 'requested':
+        return 'Angefragt';
       case 'borrowed':
-        return 'Verliehen';
+        return 'Entliehen';
+      case 'due':
+        return 'Fällig';
+      case 'partial_return':
+        return 'Teilweise Rückgabe';
       default:
         return value;
     }


### PR DESCRIPTION
## Summary
- extend library item status handling with requested, due and partial return
- show new loan management tab for librarians
- backend endpoint to list current loans

## Testing
- `npm test --prefix choir-app-frontend` *(fails: libXdamage.so.1 missing)*
- `npm run check --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_6896f8a8fdb08320ba0e97981dda3f59