### PR TITLE
feat: add loan management actions

### DIFF
--- a/choir-app-backend/src/routes/library.routes.js
+++ b/choir-app-backend/src/routes/library.routes.js
@@ -12,6 +12,8 @@ router.use(authJwt.verifyToken);
 
 router.get('/', wrap(controller.findAll));
 router.get('/loans', role.requireLibrarian, wrap(controller.listLoans));
+router.put('/loans/:id', role.requireLibrarian, wrap(controller.updateLoan));
+router.post('/loans/:id/end', role.requireLibrarian, wrap(controller.endLoan));
 router.post('/', role.requireLibrarian, createLibraryItemValidation, validate, wrap(controller.create));
 router.post('/import', role.requireLibrarian, upload.single('csvfile'), wrap(controller.importCsv));
 router.put('/:id', role.requireLibrarian, updateLibraryItemValidation, validate, wrap(controller.update));

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -524,6 +524,14 @@ export class ApiService {
     return this.libraryService.getLoans();
   }
 
+  updateLibraryLoan(id: number, data: Partial<Loan>): Observable<any> {
+    return this.libraryService.updateLoan(id, data);
+  }
+
+  endLibraryLoan(id: number): Observable<any> {
+    return this.libraryService.endLoan(id);
+  }
+
   getMyChoirDetails(options?: { choirId?: number }): Observable<Choir> {
     return this.choirService.getMyChoirDetails(options?.choirId);
   }

--- a/choir-app-frontend/src/app/core/services/library.service.ts
+++ b/choir-app-frontend/src/app/core/services/library.service.ts
@@ -49,4 +49,12 @@ export class LibraryService {
   getLoans(): Observable<Loan[]> {
     return this.http.get<Loan[]>(`${this.apiUrl}/loans`);
   }
+
+  updateLoan(id: number, data: Partial<Loan>): Observable<any> {
+    return this.http.put(`${this.apiUrl}/loans/${id}`, data);
+  }
+
+  endLoan(id: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/loans/${id}/end`, {});
+  }
 }

--- a/choir-app-frontend/src/app/features/library/loan-edit-dialog.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-edit-dialog.component.html
@@ -1,0 +1,29 @@
+<h1 mat-dialog-title>Ausleihe bearbeiten</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form">
+    <mat-form-field appearance="fill">
+      <mat-label>Startdatum</mat-label>
+      <input matInput [matDatepicker]="startPicker" formControlName="startDate" />
+      <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+      <mat-datepicker #startPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Enddatum</mat-label>
+      <input matInput [matDatepicker]="endPicker" formControlName="endDate" />
+      <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+      <mat-datepicker #endPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Status</mat-label>
+      <mat-select formControlName="status">
+        <mat-option *ngFor="let s of statuses" [value]="s">{{ s | loanStatusLabel }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-raised-button color="primary" (click)="save()">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/library/loan-edit-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/library/loan-edit-dialog.component.ts
@@ -1,0 +1,46 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { Loan } from '@core/models/loan';
+import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
+
+@Component({
+  selector: 'app-loan-edit-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MaterialModule, LoanStatusLabelPipe],
+  templateUrl: './loan-edit-dialog.component.html'
+})
+export class LoanEditDialogComponent {
+  form: FormGroup;
+  statuses = ['available', 'requested', 'borrowed', 'due', 'partial_return'];
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<LoanEditDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { loan: Loan }
+  ) {
+    const loan = data.loan;
+    this.form = this.fb.group({
+      startDate: [loan.startDate ? new Date(loan.startDate) : null],
+      endDate: [loan.endDate ? new Date(loan.endDate) : null],
+      status: [loan.status]
+    });
+  }
+
+  save(): void {
+    if (this.form.valid) {
+      const { startDate, endDate, status } = this.form.value;
+      this.dialogRef.close({
+        startDate: startDate ? startDate.toISOString() : null,
+        endDate: endDate ? endDate.toISOString() : null,
+        status
+      });
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/features/library/loan-list.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.html
@@ -24,6 +24,19 @@
     <td mat-cell *matCellDef="let element">{{element.status | loanStatusLabel}}</td>
   </ng-container>
 
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef></th>
+    <td mat-cell *matCellDef="let element">
+      <button mat-icon-button [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item (click)="openEdit(element)">Ausleihe bearbeiten</button>
+        <button mat-menu-item (click)="endLoan(element)">Ausleihe beenden</button>
+      </mat-menu>
+    </td>
+  </ng-container>
+
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 </table>

--- a/choir-app-frontend/src/app/features/library/loan-list.component.ts
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.ts
@@ -4,6 +4,8 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { Loan } from '@core/models/loan';
 import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
+import { MatDialog } from '@angular/material/dialog';
+import { LoanEditDialogComponent } from './loan-edit-dialog.component';
 
 @Component({
   selector: 'app-loan-list',
@@ -13,12 +15,29 @@ import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
   styleUrls: ['./loan-list.component.scss']
 })
 export class LoanListComponent implements OnInit {
-  displayedColumns: string[] = ['collectionTitle', 'choirName', 'startDate', 'endDate', 'status'];
+  displayedColumns: string[] = ['collectionTitle', 'choirName', 'startDate', 'endDate', 'status', 'actions'];
   loans: Loan[] = [];
 
-  constructor(private api: ApiService) {}
+  constructor(private api: ApiService, private dialog: MatDialog) {}
 
   ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
     this.api.getLibraryLoans().subscribe(loans => this.loans = loans);
+  }
+
+  openEdit(loan: Loan): void {
+    const ref = this.dialog.open(LoanEditDialogComponent, { data: { loan } });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.api.updateLibraryLoan(loan.id, result).subscribe(() => this.load());
+      }
+    });
+  }
+
+  endLoan(loan: Loan): void {
+    this.api.endLibraryLoan(loan.id).subscribe(() => this.load());
   }
 }


### PR DESCRIPTION
## Summary
- add backend endpoints to update and end library loans
- introduce frontend dialog for editing loan settings and ending loans
- expose loan operations through Angular services and UI

## Testing
- `npm test` (backend)
- `npm test` *(frontend, fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68970c8617088320bf63e662235903a5