### PR TITLE
Hide status and availability columns in library

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -53,16 +53,6 @@
         <td mat-cell *matCellDef="let element">{{element.copies}}</td>
       </ng-container>
 
-      <ng-container matColumnDef="status">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
-        <td mat-cell *matCellDef="let element">{{element.status | loanStatusLabel}}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="availableAt">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Verfügbar ab</th>
-        <td mat-cell *matCellDef="let element">{{element.availableAt | date}}</td>
-      </ng-container>
-
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let element">

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -19,14 +19,13 @@ import { MatSort } from '@angular/material/sort';
 import { FileUploadService } from '@core/services/file-upload.service';
 import { LibraryUtilService } from '@core/services/library-util.service';
 import { map } from 'rxjs/operators';
-import { LoanStatusLabelPipe } from '@shared/pipes/loan-status-label.pipe';
 import { LoanListComponent } from './loan-list.component';
 
 
 @Component({
   selector: 'app-library',
   standalone: true,
-  imports: [CommonModule, MaterialModule, RouterModule, LoanStatusLabelPipe, LoanListComponent],
+  imports: [CommonModule, MaterialModule, RouterModule, LoanListComponent],
   templateUrl: './library.component.html',
   styleUrls: ['./library.component.scss']
 })
@@ -37,7 +36,7 @@ export class LibraryComponent implements OnInit, AfterViewInit {
   collections$!: Observable<Collection[]>;
   isAdmin = false;
   isLibrarian = false;
-  displayedColumns: string[] = ['cover', 'title', 'copies', 'status', 'availableAt', 'actions'];
+  displayedColumns: string[] = ['cover', 'title', 'copies', 'actions'];
 
   dataSource = new MatTableDataSource<LibraryItem>();
 
@@ -66,8 +65,6 @@ export class LibraryComponent implements OnInit, AfterViewInit {
       switch (property) {
         case 'title':
           return item.collection?.title.toLowerCase() || '';
-        case 'availableAt':
-          return item.availableAt ? new Date(item.availableAt).getTime() : 0;
         default:
           return (item as any)[property];
       }


### PR DESCRIPTION
## Summary
- remove Status and Verfügbar ab columns from library list
- drop unused loan status pipe import

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_68972a72e82483209384bcb61aba1066