### PR TITLE
Fix admin menu visibility for administrators

### DIFF
--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -34,7 +34,12 @@ export class AuthService {
               private router: Router,
               private theme: ThemeService,
               private prefs: UserPreferencesService) {
-    this.isAdmin$ = this.currentUser$.pipe(map(user => user?.roles?.includes('admin') ?? false));
+    this.isAdmin$ = this.currentUser$.pipe(
+      map(user => user?.roles?.some(r => {
+        const lower = r.toLowerCase();
+        return lower === 'admin' || lower === 'role_admin';
+      }) ?? false)
+    );
     this.isLibrarian$ = this.currentUser$.pipe(map(user => user?.roles?.includes('librarian') ?? false));
     if (this.hasToken()) {
       this.prefs.load().subscribe(p => {


### PR DESCRIPTION
## Summary
- ensure admin role detection is case-insensitive and supports ROLE_ADMIN prefix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b08e3f24832080d8cc9014ae92da