### PR TITLE
Show admin status on profile page

### DIFF
--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -7,6 +7,9 @@
   </div>
 
   <ng-template #profileContent>
+    <div *ngIf="currentUser?.roles?.includes('admin')" class="admin-info">
+      Sie sind als Administrator angemeldet.
+    </div>
     <form [formGroup]="profileForm" (ngSubmit)="onSubmit()" class="profile-form">
       <mat-card>
         <mat-card-header>

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.scss
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.scss
@@ -9,6 +9,11 @@
     gap: 1.5rem;
 }
 
+.admin-info {
+    margin-bottom: 1rem;
+    font-weight: 500;
+}
+
 mat-form-field {
     width: 100%;
 }

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
@@ -30,4 +30,12 @@ describe('ProfileComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should display admin info when user has admin role', () => {
+    component.currentUser = { id: 1, name: 'Admin', email: 'admin@example.com', roles: ['admin'] } as any;
+    component.isLoading = false;
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.admin-info')?.textContent).toContain('Administrator');
+  });
 });


### PR DESCRIPTION
## Summary
- Display an informational banner on the profile page when the logged-in user has the `admin` role
- Style the admin banner for better visibility
- Add unit test covering admin banner display

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6899b076238c8320a3d47960d00e2baf