### PR TITLE
Fix admin role checks for multi-role users

### DIFF
--- a/choir-app-frontend/src/app/core/guards/admin-guard.ts
+++ b/choir-app-frontend/src/app/core/guards/admin-guard.ts
@@ -1,17 +1,21 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
+import { CanActivate, Router, UrlTree } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class AdminGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(): boolean {
-    if (this.authService.isAdmin$) {
-      return true; // Zugriff erlaubt
-    }
-    // Wenn kein Admin, zum Dashboard umleiten
-    this.router.navigate(['/dashboard']);
-    return false;
+  canActivate(): Observable<boolean | UrlTree> {
+    return this.authService.isAdmin$.pipe(
+      map(isAdmin => {
+        if (isAdmin) {
+          return true;
+        }
+        return this.router.createUrlTree(['/dashboard']);
+      })
+    );
   }
 }

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -35,12 +35,24 @@ export class AuthService {
               private theme: ThemeService,
               private prefs: UserPreferencesService) {
     this.isAdmin$ = this.currentUser$.pipe(
-      map(user => user?.roles?.some(r => {
-        const lower = r.toLowerCase();
-        return lower === 'admin' || lower === 'role_admin';
-      }) ?? false)
+      map(user => {
+        const roles = Array.isArray(user?.roles)
+          ? user.roles
+          : user?.roles ? [user.roles] : [];
+        return roles.some(r => {
+          const lower = r.toLowerCase();
+          return lower === 'admin' || lower === 'role_admin';
+        });
+      })
     );
-    this.isLibrarian$ = this.currentUser$.pipe(map(user => user?.roles?.includes('librarian') ?? false));
+    this.isLibrarian$ = this.currentUser$.pipe(
+      map(user => {
+        const roles = Array.isArray(user?.roles)
+          ? user.roles
+          : user?.roles ? [user.roles] : [];
+        return roles.includes('librarian');
+      })
+    );
     if (this.hasToken()) {
       this.prefs.load().subscribe(p => {
         if (p.theme) {


### PR DESCRIPTION
## Summary
- handle multi-role arrays when computing admin and librarian flags
- update admin guard to rely on observable role checks

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_6899b53a717483208f18acc174f946c5