### PR TITLE
Migrate role column to roles array

### DIFF
--- a/choir-app-backend/src/init/index.js
+++ b/choir-app-backend/src/init/index.js
@@ -1,9 +1,11 @@
 const { syncDatabase } = require('./dbSync');
 const { ensureJoinHashes } = require('./joinHashes');
 const { seedDatabase } = require('../seed');
+const { migrateRoles } = require('./migrateRoles');
 
 async function init(options = {}) {
     const { includeDemoData = true, syncOptions = { alter: true } } = options;
+    await migrateRoles();
     await syncDatabase(syncOptions);
     await ensureJoinHashes();
     await seedDatabase({ includeDemoData });
@@ -13,4 +15,5 @@ module.exports = {
     init,
     syncDatabase,
     ensureJoinHashes,
+    migrateRoles,
 };

--- a/choir-app-backend/src/init/migrateRoles.js
+++ b/choir-app-backend/src/init/migrateRoles.js
@@ -1,0 +1,35 @@
+const db = require('../models');
+
+async function migrateRoles() {
+  const qi = db.sequelize.getQueryInterface();
+  try {
+    const table = await qi.describeTable('users');
+    if (!table.role) {
+      return; // nothing to migrate
+    }
+    // ensure roles column exists
+    if (!table.roles) {
+      await qi.addColumn('users', 'roles', {
+        type: db.Sequelize.JSON,
+        allowNull: false,
+        defaultValue: ['director'],
+      });
+    }
+    const [users] = await db.sequelize.query('SELECT id, role, roles FROM users');
+    for (const user of users) {
+      let roles = user.roles;
+      if (!Array.isArray(roles) || roles.length === 0) {
+        roles = user.role ? [user.role] : ['director'];
+        await db.sequelize.query('UPDATE users SET roles = :roles WHERE id = :id', {
+          replacements: { roles: JSON.stringify(roles), id: user.id },
+        });
+      }
+    }
+    await qi.removeColumn('users', 'role');
+    console.log(`Migrated role to roles for ${users.length} users.`);
+  } catch (err) {
+    // Table does not exist or other error, ignore
+  }
+}
+
+module.exports = { migrateRoles };


### PR DESCRIPTION
## Summary
- add migration script to convert legacy `role` column into `roles` array and drop old column
- run migration before database sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b9b61cec83208d1a7b63e4ec5115