### PR TITLE
feat(admin): edit user roles inline

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -20,7 +20,20 @@
 
   <ng-container matColumnDef="roles">
     <th mat-header-cell *matHeaderCellDef>Rollen</th>
-    <td mat-cell *matCellDef="let element">{{ element.roles | userRoleLabel }}</td>
+    <td mat-cell *matCellDef="let element">
+      <mat-form-field appearance="outline" class="roles-select">
+        <mat-select
+          [ngModel]="element.roles"
+          (ngModelChange)="onRolesChange(element, $event)"
+          multiple
+        >
+          <mat-option value="director">Dirigent</mat-option>
+          <mat-option value="choir_admin">Chor-Admin</mat-option>
+          <mat-option value="admin">Admin</mat-option>
+          <mat-option value="librarian">Bibliothekar</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="choirs">

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
@@ -15,3 +15,7 @@
 .filter-field {
   width: 200px;
 }
+
+.roles-select {
+  width: 200px;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -89,4 +89,11 @@ export class ManageUsersComponent implements OnInit {
     const value = (event.target as HTMLInputElement | null)?.value ?? '';
     this.applyFilter(value);
   }
+
+  onRolesChange(user: User, roles: ('director' | 'choir_admin' | 'admin' | 'librarian')[]): void {
+    this.api.updateUser(user.id, { roles }).subscribe(() => {
+      user.roles = roles;
+      this.snack.open('Rollen aktualisiert', 'OK', { duration: 3000 });
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- allow admins to modify user roles directly from the user list
- wire role changes to backend
- style role selector in admin users table

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_689a2c8417a883208078c820e70a84e0