### PR TITLE
Ensure admin role for specific user

### DIFF
--- a/choir-app-backend/src/init/assignAdminRole.js
+++ b/choir-app-backend/src/init/assignAdminRole.js
@@ -1,0 +1,22 @@
+const db = require('../models');
+
+async function assignAdminRole() {
+    const email = 'm.free@nak-goettingen.de';
+    try {
+        const user = await db.user.findOne({ where: { email } });
+        if (!user) {
+            return;
+        }
+        let roles = Array.isArray(user.roles) ? [...user.roles] : [];
+        if (!roles.includes('admin')) {
+            roles.push('admin');
+            user.roles = roles;
+            await user.save();
+            console.log(`Added admin role to ${email}.`);
+        }
+    } catch (err) {
+        console.error('Failed to assign admin role:', err);
+    }
+}
+
+module.exports = { assignAdminRole };

--- a/choir-app-backend/src/init/index.js
+++ b/choir-app-backend/src/init/index.js
@@ -2,6 +2,7 @@ const { syncDatabase } = require('./dbSync');
 const { ensureJoinHashes } = require('./joinHashes');
 const { seedDatabase } = require('../seed');
 const { migrateRoles } = require('./migrateRoles');
+const { assignAdminRole } = require('./assignAdminRole');
 
 async function init(options = {}) {
     const { includeDemoData = true, syncOptions = { alter: true } } = options;
@@ -9,6 +10,7 @@ async function init(options = {}) {
     await syncDatabase(syncOptions);
     await ensureJoinHashes();
     await seedDatabase({ includeDemoData });
+    await assignAdminRole();
 }
 
 module.exports = {
@@ -16,4 +18,5 @@ module.exports = {
     syncDatabase,
     ensureJoinHashes,
     migrateRoles,
+    assignAdminRole,
 };


### PR DESCRIPTION
## Summary
- assign admin role to m.free@nak-goettingen.de if missing
- invoke admin role assignment during initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a2e49fefc83208357a6acdfbb7b2f