### PR TITLE
feat: show system roles in profile

### DIFF
--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -28,7 +28,7 @@ exports.getMe = async (req, res) => {
  * @description Update the profile of the currently logged-in user.
  */
 exports.updateMe = async (req, res) => {
-     const { name, email, street, postalCode, city, shareWithChoir, oldPassword, newPassword } = req.body;
+     const { name, email, street, postalCode, city, shareWithChoir, oldPassword, newPassword, roles } = req.body;
 
     try {
         const user = await User.findByPk(req.userId);
@@ -55,6 +55,10 @@ exports.updateMe = async (req, res) => {
         }
         if (shareWithChoir !== undefined) {
             updateData.shareWithChoir = !!shareWithChoir;
+        }
+        if (Array.isArray(roles) && user.roles.includes('admin')) {
+            const newRoles = roles.includes('admin') ? roles : [...roles, 'admin'];
+            updateData.roles = newRoles;
         }
 
         if (newPassword) {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -449,7 +449,7 @@ export class ApiService {
     return this.userService.getCurrentUser();
   }
 
-  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string }): Observable<any> {
+  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.userService.updateCurrentUser(profileData);
   }
 

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string }): Observable<any> {
+  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -7,9 +7,6 @@
   </div>
 
   <ng-template #profileContent>
-    <div *ngIf="currentUser?.roles?.includes('admin')" class="admin-info">
-      Sie sind als Administrator angemeldet.
-    </div>
     <form [formGroup]="profileForm" (ngSubmit)="onSubmit()" class="profile-form">
       <mat-card>
         <mat-card-header>
@@ -45,6 +42,28 @@
           </mat-form-field>
 
           <mat-checkbox formControlName="shareWithChoir">Erlaube Nutzung meiner Daten für Chorleiter</mat-checkbox>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-header>
+          <mat-card-title>Systemrolle</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <ng-container *ngIf="profileForm.get('roles')?.enabled; else readonlyRoles">
+            <mat-form-field appearance="outline">
+              <mat-label>Systemrollen</mat-label>
+              <mat-select formControlName="roles" multiple>
+                <mat-option value="director">Dirigent</mat-option>
+                <mat-option value="choir_admin">Chor-Admin</mat-option>
+                <mat-option value="admin" disabled>Administrator</mat-option>
+                <mat-option value="librarian">Bibliothekar</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </ng-container>
+          <ng-template #readonlyRoles>
+            <div class="roles-display">{{ profileForm.get('roles')?.value?.join(', ') }}</div>
+          </ng-template>
         </mat-card-content>
       </mat-card>
 

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
@@ -3,8 +3,17 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { ApiService } from '@core/services/api.service';
 
 import { ProfileComponent } from './profile.component';
+
+class MockApiService {
+  getCurrentUser() {
+    return of({ id: 1, name: 'Admin', email: 'admin@example.com', roles: ['admin'] });
+  }
+  updateCurrentUser() { return of({}); }
+}
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
@@ -17,7 +26,8 @@ describe('ProfileComponent', () => {
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useValue: {} },
-        { provide: MatSnackBar, useValue: { open: () => {} } }
+        { provide: MatSnackBar, useValue: { open: () => {} } },
+        { provide: ApiService, useClass: MockApiService }
       ]
     })
     .compileComponents();
@@ -31,11 +41,10 @@ describe('ProfileComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display admin info when user has admin role', () => {
+  it('should enable roles control for admin users', () => {
     component.currentUser = { id: 1, name: 'Admin', email: 'admin@example.com', roles: ['admin'] } as any;
     component.isLoading = false;
     fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.admin-info')?.textContent).toContain('Administrator');
+    expect(component.profileForm.get('roles')?.enabled).toBeTrue();
   });
 });

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -49,6 +49,7 @@ export class ProfileComponent implements OnInit {
       postalCode: [''],
       city: [''],
       shareWithChoir: [false],
+      roles: [{ value: [], disabled: true }],
       passwords: this.fb.group({
         oldPassword: [''],
         newPassword: [''],
@@ -68,8 +69,12 @@ export class ProfileComponent implements OnInit {
           street: user.street || '',
           postalCode: user.postalCode || '',
           city: user.city || '',
-          shareWithChoir: !!user.shareWithChoir
+          shareWithChoir: !!user.shareWithChoir,
+          roles: user.roles || []
         });
+        if (user.roles?.includes('admin')) {
+          this.profileForm.get('roles')?.enable();
+        }
         this.isLoading = false;
       },
       error: (err) => {
@@ -85,7 +90,7 @@ export class ProfileComponent implements OnInit {
     }
 
     const formValue = this.profileForm.value;
-    const updatePayload: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string } = {
+    const updatePayload: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] } = {
       name: formValue.name,
       email: formValue.email,
       street: formValue.street,
@@ -93,6 +98,11 @@ export class ProfileComponent implements OnInit {
       city: formValue.city,
       shareWithChoir: formValue.shareWithChoir
     };
+
+    if (this.profileForm.get('roles')?.enabled) {
+      const roles = formValue.roles as string[];
+      updatePayload.roles = roles?.includes('admin') ? roles : [...roles, 'admin'];
+    }
 
     const passwordGroup = formValue.passwords;
     // Senden Sie die Passwörter nur, wenn das neue Passwort-Feld ausgefüllt ist.


### PR DESCRIPTION
## Summary
- display system roles on the profile page and allow admins to edit them
- keep admin role when updating profile
- extend API and backend to handle role updates

## Testing
- `npm test`
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_689a2cde89fc8320963e1980b4debb25