### PR TITLE
Use icons for collection actions and show library presence

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -67,12 +67,18 @@
         <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let collection" class="actions-cell">
             <button
-              mat-stroked-button
+              mat-icon-button
               color="primary"
-              (click)="syncCollection(collection); $event.stopPropagation()">
+              (click)="syncCollection(collection); $event.stopPropagation()"
+              [matTooltip]="collection.isAdded ? 'Aktualisieren' : 'Zum Repertoire hinzufügen'">
                 <mat-icon>{{ collection.isAdded ? 'sync' : 'add_circle_outline' }}</mat-icon>
-                <span>{{ collection.isAdded ? 'Aktualisieren' : 'Zum Repertoire hinzufügen' }}</span>
             </button>
+            <mat-icon
+              *ngIf="libraryItemIds.has(collection.id)"
+              class="library-icon"
+              matTooltip="In Notenbibliothek vorhanden">
+              library_music
+            </mat-icon>
             <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
                 <mat-icon>edit</mat-icon>
             </button>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -53,6 +53,10 @@ mat-card-actions button mat-icon {
     button {
         margin-left: 8px;
     }
+
+    .library-icon {
+        margin-left: 8px;
+    }
 }
 
 // ADD THIS NEW STYLE

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -12,6 +12,7 @@ import { map } from 'rxjs/operators';
 import { RouterLink, Router } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
 import { PaginatorService } from '@core/services/paginator.service';
+import { LibraryItem } from '@core/models/library-item';
 
 @Component({
   selector: 'app-collection-list',
@@ -43,6 +44,7 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
   public displayedColumns: string[] = ['cover', 'status', 'title', 'titles', 'publisher', 'actions'];
+  public libraryItemIds = new Set<number>();
 
   /**
    * Cache for the composer names of single-edition collections.
@@ -62,6 +64,13 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.loadCollections();
+    this.apiService.getLibraryItems().subscribe((items: LibraryItem[]) => {
+      this.libraryItemIds.clear();
+      items.forEach(i => {
+        const id = i.collectionId || i.collection?.id;
+        if (id != null) this.libraryItemIds.add(id);
+      });
+    });
     this.apiService.checkChoirAdminStatus().subscribe(r => this.isChoirAdmin = r.isChoirAdmin);
     this.authService.isAdmin$.subscribe(v => this.isAdmin = v);
   }


### PR DESCRIPTION
## Summary
- Replace text buttons for repertoire actions with icon buttons and tooltips
- Indicate library availability of collections with a library icon
- Style actions cell to align new icons

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689a380ac4548320b23a821cae0e42d2