### PR TITLE
Add configurable system admin email setting

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -535,3 +535,26 @@ exports.updateFrontendUrl = async (req, res) => {
         res.status(500).send({ message: err.message });
     }
 };
+
+exports.getSystemAdminEmail = async (req, res) => {
+    try {
+        const setting = await db.system_setting.findByPk('SYSTEM_ADMIN_EMAIL');
+        res.status(200).send({ value: setting?.value || null });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.updateSystemAdminEmail = async (req, res) => {
+    try {
+        const { value } = req.body;
+        const [setting] = await db.system_setting.findOrCreate({
+            where: { key: 'SYSTEM_ADMIN_EMAIL' },
+            defaults: { value }
+        });
+        await setting.update({ value });
+        res.status(200).send({ value: setting.value });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -48,6 +48,8 @@ router.put('/mail-templates', wrap(controller.updateMailTemplates));
 router.post('/mail-templates/test/:type', wrap(controller.sendMailTemplateTest));
 router.get('/frontend-url', wrap(controller.getFrontendUrl));
 router.put('/frontend-url', wrap(controller.updateFrontendUrl));
+router.get('/system-admin-email', wrap(controller.getSystemAdminEmail));
+router.put('/system-admin-email', wrap(controller.updateSystemAdminEmail));
 
 module.exports = router;
 

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -87,6 +87,10 @@ async function seedDatabase(options = {}) {
                 where: { key: 'FRONTEND_URL' },
                 defaults: { value: process.env.FRONTEND_URL || 'https://nak-chorleiter.de' }
             });
+            await db.system_setting.findOrCreate({
+                where: { key: 'SYSTEM_ADMIN_EMAIL' },
+                defaults: { value: process.env.SYSTEM_ADMIN_EMAIL || '' }
+            });
             console.log("Initial seeding completed successfully.");
         } else {
             console.log("Database already seeded. Skipping initial setup.");

--- a/choir-app-frontend/src/app/core/models/system-admin-email.ts
+++ b/choir-app-frontend/src/app/core/models/system-admin-email.ts
@@ -1,0 +1,3 @@
+export interface SystemAdminEmail {
+  value: string;
+}

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -9,6 +9,7 @@ import { StatsSummary } from '../models/stats-summary';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
+import { SystemAdminEmail } from '../models/system-admin-email';
 import { UploadOverview } from '../models/backend-file';
 
 @Injectable({ providedIn: 'root' })
@@ -161,5 +162,13 @@ export class AdminService {
 
   updateFrontendUrl(data: FrontendUrl): Observable<FrontendUrl> {
     return this.http.put<FrontendUrl>(`${this.apiUrl}/admin/frontend-url`, data);
+  }
+
+  getSystemAdminEmail(): Observable<SystemAdminEmail> {
+    return this.http.get<SystemAdminEmail>(`${this.apiUrl}/admin/system-admin-email`);
+  }
+
+  updateSystemAdminEmail(data: SystemAdminEmail): Observable<SystemAdminEmail> {
+    return this.http.put<SystemAdminEmail>(`${this.apiUrl}/admin/system-admin-email`, data);
   }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -40,6 +40,7 @@ import { RepertoireFilter } from '../models/repertoire-filter';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
+import { SystemAdminEmail } from '../models/system-admin-email';
 import { UploadOverview } from '../models/backend-file';
 import { FilterPresetService } from './filter-preset.service';
 import { UserAvailability } from '../models/user-availability';
@@ -716,6 +717,14 @@ export class ApiService {
 
   updateFrontendUrl(value: string): Observable<FrontendUrl> {
     return this.adminService.updateFrontendUrl({ value });
+  }
+
+  getSystemAdminEmail(): Observable<SystemAdminEmail> {
+    return this.adminService.getSystemAdminEmail();
+  }
+
+  updateSystemAdminEmail(value: string): Observable<SystemAdminEmail> {
+    return this.adminService.updateSystemAdminEmail({ value });
   }
 
   checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {

--- a/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.html
@@ -1,0 +1,11 @@
+<form [formGroup]="form" (ngSubmit)="save()" class="admin-email-form">
+  <mat-form-field appearance="fill">
+    <mat-label>System-Admin E-Mail</mat-label>
+    <input matInput formControlName="email" />
+    <mat-hint>E-Mail für Systemausfall-Benachrichtigungen</mat-hint>
+    <mat-error *ngIf="form.controls['email'].invalid">Ungültige E-Mail-Adresse</mat-error>
+  </mat-form-field>
+  <div class="actions">
+    <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid">Speichern</button>
+  </div>
+</form>

--- a/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.scss
+++ b/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.scss
@@ -1,0 +1,16 @@
+.admin-email-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  mat-form-field {
+    width: 100%;
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.ts
@@ -1,0 +1,53 @@
+import { Component, HostListener, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { PendingChanges } from '@core/guards/pending-changes.guard';
+
+@Component({
+  selector: 'app-admin-email-settings',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './admin-email-settings.component.html',
+  styleUrls: ['./admin-email-settings.component.scss']
+})
+export class AdminEmailSettingsComponent implements OnInit, PendingChanges {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar) {
+    this.form = this.fb.group({
+      email: ['', Validators.email]
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.getSystemAdminEmail().subscribe(data => {
+      if (data && data.value) {
+        this.form.patchValue({ email: data.value });
+        this.form.markAsPristine();
+      }
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    this.api.updateSystemAdminEmail(this.form.value.email).subscribe(() => {
+      this.snack.open('Gespeichert', 'OK', { duration: 2000 });
+      this.form.markAsPristine();
+    });
+  }
+
+  hasPendingChanges(): boolean {
+    return this.form.dirty;
+  }
+
+  @HostListener('window:beforeunload', ['$event'])
+  confirmUnload(event: BeforeUnloadEvent): void {
+    if (this.hasPendingChanges()) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.html
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.html
@@ -7,6 +7,12 @@
   </mat-expansion-panel>
   <mat-expansion-panel>
     <mat-expansion-panel-header>
+      <mat-panel-title>System-Admin E-Mail</mat-panel-title>
+    </mat-expansion-panel-header>
+    <app-admin-email-settings></app-admin-email-settings>
+  </mat-expansion-panel>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
       <mat-panel-title>Mail-Server</mat-panel-title>
     </mat-expansion-panel-header>
     <app-mail-settings></app-mail-settings>

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
@@ -5,22 +5,25 @@ import { MailSettingsComponent } from '../mail-settings/mail-settings.component'
 import { MailTemplatesComponent } from '../mail-templates/mail-templates.component';
 import { BackupComponent } from '../backup/backup.component';
 import { FrontendUrlSettingsComponent } from '../frontend-url-settings/frontend-url-settings.component';
+import { AdminEmailSettingsComponent } from '../admin-email-settings/admin-email-settings.component';
 import { PendingChanges } from '@core/guards/pending-changes.guard';
 
 @Component({
   selector: 'app-general-settings',
   standalone: true,
-  imports: [CommonModule, MaterialModule, FrontendUrlSettingsComponent, MailSettingsComponent, MailTemplatesComponent, BackupComponent],
+  imports: [CommonModule, MaterialModule, FrontendUrlSettingsComponent, AdminEmailSettingsComponent, MailSettingsComponent, MailTemplatesComponent, BackupComponent],
   templateUrl: './general-settings.component.html',
   styleUrls: ['./general-settings.component.scss']
 })
 export class GeneralSettingsComponent implements PendingChanges {
   @ViewChild(FrontendUrlSettingsComponent) frontendUrl?: FrontendUrlSettingsComponent;
+  @ViewChild(AdminEmailSettingsComponent) adminEmail?: AdminEmailSettingsComponent;
   @ViewChild(MailSettingsComponent) mailSettings?: MailSettingsComponent;
   @ViewChild(MailTemplatesComponent) mailTemplates?: MailTemplatesComponent;
 
   hasPendingChanges(): boolean {
     return (this.frontendUrl?.hasPendingChanges() ?? false) ||
+           (this.adminEmail?.hasPendingChanges() ?? false) ||
            (this.mailSettings?.hasPendingChanges() ?? false) ||
            (this.mailTemplates?.hasPendingChanges() ?? false);
   }


### PR DESCRIPTION
## Summary
- allow storing a system admin email for outage notifications in backend
- expose admin email setting through frontend services and UI
- include seeding for SYSTEM_ADMIN_EMAIL

## Testing
- `npm test` (backend)
- `npm test` *(frontend, fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a3a9251388320aa6a8df453ff7321