### PR TITLE
fix: remove duplicate password reset form

### DIFF
--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.html
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.html
@@ -1,24 +1,3 @@
-<div class="reset-container">
-  <mat-card>
-    <mat-card-title>Neues Passwort</mat-card-title>
-    <mat-card-content>
-      <form [formGroup]="form" (ngSubmit)="submit()">
-        <mat-form-field appearance="outline">
-          <mat-label>Neues Passwort</mat-label>
-          <input matInput type="password" formControlName="password">
-        </mat-form-field>
-        <mat-card-actions align="end">
-          <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid || isLoading">
-            <span *ngIf="!isLoading">Speichern</span>
-            <mat-spinner *ngIf="isLoading" diameter="24"></mat-spinner>
-          </button>
-        </mat-card-actions>
-      </form>
-      <p *ngIf="message">{{ message }}</p>
-    </mat-card-content>
-  </mat-card>
-</div>
-
 <div class="login-page">
   <div class="login-page-header">
     <h1 class="login-brand">NAK Chorleiter</h1>

--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.scss
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.scss
@@ -1,3 +1,1 @@
 @use "../user.general.style.scss";
-
-.reset-container { display: flex; justify-content: center; margin-top: 2rem; }


### PR DESCRIPTION
## Summary
- remove extra password reset form that caused duplicate fields and runtime errors
- clean up unused styles

## Testing
- `npm test` *(fails: error while loading shared library libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a567474fc8320b7685f211a61f1ad