### PR TITLE
feat(frontend): confirm password reset and redirect

### DIFF
--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.html
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.html
@@ -12,6 +12,13 @@
           <mat-label>Neues Passwort</mat-label>
           <input matInput type="password" formControlName="password">
         </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Neues Passwort wiederholen</mat-label>
+          <input matInput type="password" formControlName="passwordRepeat">
+          <mat-error *ngIf="form.hasError('passwordsMismatch') && form.get('passwordRepeat')?.touched">
+            Passwörter stimmen nicht überein
+          </mat-error>
+        </mat-form-field>
 
         <div>
           <button mat-raised-button color="primary" type="submit" [disabled]="form.invalid || isLoading">

--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.ts
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { AbstractControl, FormBuilder, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 
@@ -18,11 +18,18 @@ export class PasswordResetComponent {
   message = '';
   token: string;
 
-  constructor(private fb: FormBuilder, private route: ActivatedRoute, private api: ApiService) {
+  constructor(private fb: FormBuilder, private route: ActivatedRoute, private api: ApiService, private router: Router) {
     this.token = this.route.snapshot.params['token'];
     this.form = this.fb.group({
-      password: ['', Validators.required]
-    });
+      password: ['', Validators.required],
+      passwordRepeat: ['', Validators.required]
+    }, { validators: this.passwordsMatch });
+  }
+
+  private passwordsMatch(control: AbstractControl): ValidationErrors | null {
+    const password = control.get('password')?.value;
+    const repeat = control.get('passwordRepeat')?.value;
+    return password && repeat && password !== repeat ? { passwordsMismatch: true } : null;
   }
 
   submit(): void {
@@ -30,8 +37,9 @@ export class PasswordResetComponent {
     this.isLoading = true;
     this.api.resetPassword(this.token, this.form.value.password || '').subscribe({
       next: () => {
-        this.message = 'Dein Passwort wurde aktualisiert. Du kannst dich jetzt anmelden.';
+        this.message = 'Dein Passwort wurde aktualisiert. Du wirst in 5 Sekunden zum Login weitergeleitet.';
         this.isLoading = false;
+        setTimeout(() => this.router.navigate(['/login']), 5000);
       },
       error: err => {
         this.message = err.error?.message || 'Link ungültig oder abgelaufen.';


### PR DESCRIPTION
## Summary
- require users to confirm new password before saving
- redirect to login after password reset, with 5-second delay

## Testing
- `npm test` *(fails: ChromeHeadless missing shared library)*

------
https://chatgpt.com/codex/tasks/task_e_689a6366aae88320a3223f5cf4343a52