### PR TITLE
Validate password reset link only once

### DIFF
--- a/choir-app-backend/src/controllers/password-reset.controller.js
+++ b/choir-app-backend/src/controllers/password-reset.controller.js
@@ -26,6 +26,24 @@ exports.requestPasswordReset = async (req, res) => {
   }
 };
 
+exports.validateToken = async (req, res) => {
+  const { token } = req.params;
+  try {
+    const user = await db.user.findOne({
+      where: {
+        resetToken: token,
+        resetTokenExpiry: { [Op.gt]: new Date() }
+      }
+    });
+    if (!user) {
+      return res.status(400).send({ message: 'Invalid or expired token.' });
+    }
+    res.status(200).send({ message: 'Token is valid.' });
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
 exports.resetPassword = async (req, res) => {
   const { token } = req.params;
   const { password } = req.body;

--- a/choir-app-backend/src/routes/password-reset.routes.js
+++ b/choir-app-backend/src/routes/password-reset.routes.js
@@ -3,6 +3,7 @@ const controller = require('../controllers/password-reset.controller');
 const { handler: wrap } = require('../utils/async');
 
 router.post('/request', wrap(controller.requestPasswordReset));
+router.get('/validate/:token', wrap(controller.validateToken));
 router.post('/reset/:token', wrap(controller.resetPassword));
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -569,6 +569,10 @@ export class ApiService {
     return this.userService.requestPasswordReset(email);
   }
 
+  validateResetToken(token: string): Observable<any> {
+    return this.userService.validateResetToken(token);
+  }
+
   resetPassword(token: string, password: string): Observable<any> {
     return this.userService.resetPassword(token, password);
   }

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -26,6 +26,10 @@ export class UserService {
     return this.http.post(`${this.apiUrl}/password-reset/request`, { email });
   }
 
+  validateResetToken(token: string): Observable<any> {
+    return this.http.get(`${this.apiUrl}/password-reset/validate/${token}`);
+  }
+
   resetPassword(token: string, password: string): Observable<any> {
     return this.http.post(`${this.apiUrl}/password-reset/reset/${token}`, { password });
   }

--- a/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.ts
+++ b/choir-app-frontend/src/app/features/user/password-reset/password-reset.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 
@@ -12,16 +12,26 @@ import { ApiService } from '@core/services/api.service';
   templateUrl: './password-reset.component.html',
   styleUrls: ['./password-reset.component.scss']
 })
-export class PasswordResetComponent {
+export class PasswordResetComponent implements OnInit {
   form: ReturnType<FormBuilder['group']>;
   isLoading = false;
   message = '';
   token: string;
 
-  constructor(private fb: FormBuilder, private route: ActivatedRoute, private api: ApiService) {
+  constructor(private fb: FormBuilder, private route: ActivatedRoute, private api: ApiService, private router: Router) {
     this.token = this.route.snapshot.params['token'];
     this.form = this.fb.group({
       password: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.validateResetToken(this.token).subscribe({
+      error: err => {
+        this.message = err.error?.message || 'Link ungültig oder abgelaufen.';
+        this.form.disable();
+        setTimeout(() => this.router.navigate(['/login']), 3000);
+      }
     });
   }
 
@@ -36,6 +46,7 @@ export class PasswordResetComponent {
       error: err => {
         this.message = err.error?.message || 'Link ungültig oder abgelaufen.';
         this.isLoading = false;
+        setTimeout(() => this.router.navigate(['/login']), 3000);
       }
     });
   }


### PR DESCRIPTION
## Summary
- add backend endpoint to validate password reset tokens
- verify token on password reset page and redirect to login if invalid

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689a639d398c8320aec19b3f68c279c2