### PR TITLE
Fix mobile menu toggle

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -68,7 +68,7 @@
   <mat-sidenav *ngIf="isLoggedIn$ | async" #appDrawer [fixedInViewport]="false"
     [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
     [mode]="(isHandset$ | async) ? 'over' : 'side'"
-    [opened]="!(isHandset$ | async) && drawerOpenByWidth" class="appDrawer">
+    class="appDrawer">
 
     <mat-nav-list>
       <app-choir-switcher></app-choir-switcher>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -163,6 +163,14 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
   private evaluateDrawerWidth() {
     const width = window.innerWidth;
     this.drawerOpenByWidth = (this.drawerWidth / width) <= this.maxDrawerRatio;
+
+    if (this.isHandset) {
+      this._appDrawer?.close();
+    } else if (this.drawerOpenByWidth) {
+      this._appDrawer?.open();
+    } else {
+      this._appDrawer?.close();
+    }
   }
 
   private getDeepestRouteData(route: ActivatedRoute): { title: string | null; showChoirName: boolean } {


### PR DESCRIPTION
## Summary
- Allow sidenav menu to open on mobile by removing binding preventing toggle
- Automatically open or close drawer based on screen size

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b955ee02c8320b441723aa37f8465