### PR TITLE
Fix mobile main menu toggle

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar color="primary" class="main-toolbar">
-  <button type="button" aria-label="Menü umschalten" mat-icon-button (click)="appDrawer?.toggle()">
+  <button type="button" aria-label="Menü umschalten" mat-icon-button (click)="toggleDrawer()">
     <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
   </button>
 
@@ -65,16 +65,18 @@
 </mat-toolbar>
 
 <mat-sidenav-container class="site-container">
-  <mat-sidenav *ngIf="isLoggedIn$ | async" #appDrawer [fixedInViewport]="false"
-    [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
-    [mode]="(isHandset$ | async) ? 'over' : 'side'"
-    class="appDrawer">
+  <ng-container *ngIf="isLoggedIn$ | async">
+    <mat-sidenav #appDrawer [fixedInViewport]="false"
+      [attr.role]="(isHandset$ | async) ? 'dialog' : 'navigation'"
+      [mode]="(isHandset$ | async) ? 'over' : 'side'"
+      class="appDrawer">
 
-    <mat-nav-list>
-      <app-choir-switcher></app-choir-switcher>
-      <app-menu-list-item *ngFor="let item of navItems" [item]="item"></app-menu-list-item>
-    </mat-nav-list>
-  </mat-sidenav>
+      <mat-nav-list>
+        <app-choir-switcher></app-choir-switcher>
+        <app-menu-list-item *ngFor="let item of navItems" [item]="item"></app-menu-list-item>
+      </mat-nav-list>
+    </mat-sidenav>
+  </ng-container>
 
 
   <mat-sidenav-content class="main-content">

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -173,6 +173,10 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
     }
   }
 
+  toggleDrawer() {
+    this._appDrawer?.toggle();
+  }
+
   private getDeepestRouteData(route: ActivatedRoute): { title: string | null; showChoirName: boolean } {
     let child = route.firstChild;
     let data = { title: child?.snapshot?.data?.['title'] ?? null, showChoirName: child?.snapshot?.data?.['showChoirName'] ?? false };


### PR DESCRIPTION
## Summary
- Ensure main navigation drawer is created only when logged in while keeping template reference accessible
- Add `toggleDrawer` method and use it to open the side nav from toolbar

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689ba731e6b8832082f7f35b2aad4c9c