### PR TITLE
Persist HelpWizard state for regular users

### DIFF
--- a/choir-app-frontend/src/app/core/services/help.service.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.ts
@@ -7,15 +7,19 @@ export class HelpService {
   constructor(private prefs: UserPreferencesService) {}
 
   shouldShowHelp(user: User | null): boolean {
-    if (!user) return false;
-    if (user.roles?.includes('demo') && !this.prefs.getPreference('helpShown')) {
+    if (!user) {
+      return false;
+    }
+    if (user.roles?.includes('demo')) {
       return true;
     }
     return !this.prefs.getPreference('helpShown');
   }
 
   markHelpShown(user: User | null): void {
-    if (!user) return;
+    if (!user || user.roles?.includes('demo')) {
+      return;
+    }
     this.prefs.update({ helpShown: true }).subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- ensure HelpWizard opens every time for demo accounts
- store HelpWizard completion in user preferences for regular accounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c1d929cbc83209522482c0463293a