### PR TITLE
fix: evaluate drawer width when sidenav initializes

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -60,6 +60,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
     this._appDrawer = drawer;
     if (drawer) {
       this.navService.appDrawer = drawer;
+      this.evaluateDrawerWidth();
     }
   }
   private isHandset: boolean = false;


### PR DESCRIPTION
## Summary
- ensure the navigation drawer evaluates width once it becomes available

## Testing
- `npm test` *(fails: ChromeHeadless failed to launch: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run check-backend`


------
https://chatgpt.com/codex/tasks/task_e_689c231f119c8320bc799620abd75b82