### PR TITLE
fix: remember when help wizard was shown

### DIFF
--- a/choir-app-frontend/src/app/core/services/help.service.spec.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { HelpService } from './help.service';
+import { UserPreferencesService } from './user-preferences.service';
+import { User } from '../models/user';
+
+describe('HelpService', () => {
+  let service: HelpService;
+  const user: User = { id: 1, name: 'Test', email: 'test@example.com' };
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        HelpService,
+        { provide: UserPreferencesService, useValue: { getPreference: () => undefined, update: () => of({}) } }
+      ]
+    });
+    service = TestBed.inject(HelpService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should not show help again after being marked as shown', () => {
+    expect(service.shouldShowHelp(user)).toBeTrue();
+    service.markHelpShown(user);
+    expect(service.shouldShowHelp(user)).toBeFalse();
+  });
+});
+

--- a/choir-app-frontend/src/app/core/services/help.service.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.ts
@@ -13,6 +13,10 @@ export class HelpService {
     if (user.roles?.includes('demo')) {
       return true;
     }
+    const storageKey = `helpShown_${user.id}`;
+    if (localStorage.getItem(storageKey) === 'true') {
+      return false;
+    }
     return !this.prefs.getPreference('helpShown');
   }
 
@@ -20,6 +24,8 @@ export class HelpService {
     if (!user || user.roles?.includes('demo')) {
       return;
     }
+    const storageKey = `helpShown_${user.id}`;
+    localStorage.setItem(storageKey, 'true');
     this.prefs.update({ helpShown: true }).subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- persist help wizard dismissal per user using localStorage
- add unit test for help service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c23453958832087952bbdc086ad98