### PR TITLE
fix: allow mobile sidenav to stay open

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -166,8 +166,14 @@ export class MainLayoutComponent implements OnInit, AfterViewInit{
     this.drawerOpenByWidth = (this.drawerWidth / width) <= this.maxDrawerRatio;
 
     if (this.isHandset) {
-      this._appDrawer?.close();
-    } else if (this.drawerOpenByWidth) {
+      // Do not automatically toggle the drawer on handset devices while it is open.
+      if (!this._appDrawer?.opened) {
+        this._appDrawer?.close();
+      }
+      return;
+    }
+
+    if (this.drawerOpenByWidth) {
       this._appDrawer?.open();
     } else {
       this._appDrawer?.close();


### PR DESCRIPTION
## Summary
- prevent automatic closing of drawer on handset devices while it is open

## Testing
- `npm test` *(fails: ChromeHeadless failed to start: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c2a413a1c8320a1c5f381d6c04b7b