### PR TITLE
feat(admin): add mobile layout for user management

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -7,7 +7,12 @@
   </mat-form-field>
 </div>
 
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<table
+  mat-table
+  [dataSource]="dataSource"
+  class="mat-elevation-z8"
+  *ngIf="!(isHandset$ | async)"
+>
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
     <td mat-cell *matCellDef="let element">{{ element.name }}</td>
@@ -64,3 +69,43 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
+
+<mat-accordion *ngIf="isHandset$ | async">
+  <mat-expansion-panel *ngFor="let element of dataSource.filteredData">
+    <mat-expansion-panel-header>
+      <mat-panel-title>{{ element.name }}</mat-panel-title>
+      <mat-panel-description>{{ element.email }}</mat-panel-description>
+    </mat-expansion-panel-header>
+    <div class="mobile-user-row">
+      <div><strong>E-Mail:</strong> {{ element.email }}</div>
+      <div>
+        <strong>Rollen:</strong>
+        <mat-form-field appearance="outline" class="roles-select">
+          <mat-select
+            [ngModel]="element.roles"
+            (ngModelChange)="onRolesChange(element, $event)"
+            multiple
+          >
+            <mat-option value="director">Dirigent</mat-option>
+            <mat-option value="choir_admin">Chor-Admin</mat-option>
+            <mat-option value="admin">Admin</mat-option>
+            <mat-option value="librarian">Bibliothekar</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div><strong>Chöre:</strong> {{ choirList(element) }}</div>
+      <div><strong>Letzter Login:</strong> {{ element.lastLogin | date:'short' }}</div>
+    </div>
+    <div class="mobile-actions">
+      <button mat-icon-button color="primary" (click)="editUser(element)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button (click)="sendReset(element)">
+        <mat-icon>mail</mat-icon>
+      </button>
+      <button mat-icon-button color="warn" (click)="deleteUser(element)">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </div>
+  </mat-expansion-panel>
+</mat-accordion>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.scss
@@ -19,3 +19,14 @@
 .roles-select {
   width: 200px;
 }
+
+.mobile-user-row > div {
+  margin-bottom: 0.5rem;
+}
+
+.mobile-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -8,6 +8,9 @@ import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserDialogComponent } from './user-dialog/user-dialog.component';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-manage-users',
@@ -21,8 +24,18 @@ export class ManageUsersComponent implements OnInit {
   displayedColumns = ['name', 'email', 'roles', 'choirs', 'lastLogin', 'actions'];
   dataSource = new MatTableDataSource<User>();
   filterValue = '';
+  isHandset$: Observable<boolean>;
 
-  constructor(private api: ApiService, private dialog: MatDialog, private snack: MatSnackBar) {}
+  constructor(
+    private api: ApiService,
+    private dialog: MatDialog,
+    private snack: MatSnackBar,
+    private breakpointObserver: BreakpointObserver
+  ) {
+    this.isHandset$ = this.breakpointObserver
+      .observe([Breakpoints.Handset])
+      .pipe(map(result => result.matches));
+  }
 
   ngOnInit(): void {
     this.dataSource.filterPredicate = (data, filter) => {


### PR DESCRIPTION
## Summary
- add BreakpointObserver-driven handset detection for ManageUsers
- render user list as expansion panels on mobile and keep table for larger screens
- style mobile user rows and action buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c815f0d308320aaa3d503f97c04d7