### PR TITLE
feat: add mobile list views for collections

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -13,6 +13,7 @@
 </div>
 <p class="subtitle">Verwalten von globalen Sammlungen und Hinzufügen zum Chorrepertoire.</p>
 
+<ng-container *ngIf="!(isHandset$ | async); else mobileView">
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">
   <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
@@ -98,3 +99,39 @@
                  [pageSize]="pageSize"
                  showFirstLastButtons></mat-paginator>
 </div>
+</ng-container>
+
+<ng-template #mobileView>
+  <div class="mobile-list">
+    <div class="mobile-item" *ngFor="let collection of dataSource.data" (click)="toggleSelection(collection)">
+      <img *ngIf="collection.coverImageData" [src]="collection.coverImageData" alt="Cover" class="cover-img" />
+      <div><strong>{{ collection.title }}</strong></div>
+      <div class="subtitle-hint" *ngIf="collection.subtitle">{{ collection.subtitle }}</div>
+      <div class="prefix-hint" *ngIf="!collection.singleEdition && collection.prefix">{{ collection.prefix }}</div>
+      <div class="prefix-hint" *ngIf="collection.singleEdition">{{ getCollectionComposer(collection) }}</div>
+      <div class="detail">Status:
+        <mat-icon [color]="collection.isAdded ? 'primary' : 'disabled'">{{ collection.isAdded ? 'check_circle' : 'do_not_disturb_on' }}</mat-icon>
+      </div>
+      <div class="detail">Stücke: {{ collection.pieceCount || 0 }}</div>
+      <div class="detail">Verlag: {{ collection.publisher || '-' }}</div>
+      <div class="mobile-actions" *ngIf="selectedCollection === collection">
+        <button
+          mat-icon-button
+          color="primary"
+          (click)="syncCollection(collection); $event.stopPropagation()"
+          [matTooltip]="collection.isAdded ? 'Aktualisieren' : 'Zum Repertoire hinzufügen'">
+            <mat-icon>{{ collection.isAdded ? 'sync' : 'add_circle_outline' }}</mat-icon>
+        </button>
+        <mat-icon
+          *ngIf="libraryItemIds.has(collection.id)"
+          class="library-icon"
+          matTooltip="In Notenbibliothek vorhanden">
+          library_music
+        </mat-icon>
+        <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
+            <mat-icon>edit</mat-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.scss
@@ -104,29 +104,35 @@ mat-paginator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
 }
 
-@media (max-width: 600px) {
-    .table-wrapper .mat-header-row {
-        display: none;
-    }
+.mobile-list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+    overflow: hidden;
+}
 
-    .table-wrapper .mat-row {
-        display: grid;
-        grid-template-columns: 64px 1fr auto;
-        align-items: center;
-        padding: 8px 0;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-    }
+.mobile-item {
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
 
-    .table-wrapper .mat-row .mat-cell {
-        border: none;
-        padding: 4px 8px;
-        display: block;
-    }
+.mobile-item:last-child {
+    border-bottom: none;
+}
 
-    .table-wrapper .mat-row .cover-cell { grid-column: 1; }
-    .table-wrapper .mat-row .status-cell { grid-column: 2; order: 1; }
-    .table-wrapper .mat-row .title-cell { grid-column: 2; order: 2; }
-    .table-wrapper .mat-row .titles-cell { grid-column: 2; order: 3; }
-    .table-wrapper .mat-row .publisher-cell { grid-column: 2; order: 4; }
-    .table-wrapper .mat-row .actions-cell { grid-column: 3; order: 5; text-align: right; }
+.cover-img {
+    width: 64px;
+    height: auto;
+    margin-bottom: 4px;
+}
+
+.detail {
+    font-size: 0.9rem;
+    color: #555;
+}
+
+.mobile-actions {
+    margin-top: 4px;
+    text-align: right;
 }

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -7,12 +7,13 @@ import { MatSort } from '@angular/material/sort';
 import { MatPaginator } from '@angular/material/paginator';
 import { ApiService } from '@core/services/api.service';
 import { Collection } from '@core/models/collection';
-import { forkJoin } from 'rxjs';
+import { forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { RouterLink, Router } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
 import { PaginatorService } from '@core/services/paginator.service';
 import { LibraryItem } from '@core/models/library-item';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 
 @Component({
   selector: 'app-collection-list',
@@ -45,6 +46,8 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
 
   public displayedColumns: string[] = ['cover', 'status', 'title', 'titles', 'publisher', 'actions'];
   public libraryItemIds = new Set<number>();
+  public isHandset$: Observable<boolean>;
+  public selectedCollection: Collection | null = null;
 
   /**
    * Cache for the composer names of single-edition collections.
@@ -57,9 +60,11 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
     private snackBar: MatSnackBar,
     private router: Router,
     private authService: AuthService,
-    private paginatorService: PaginatorService
+    private paginatorService: PaginatorService,
+    private breakpointObserver: BreakpointObserver
   ) {
     this.pageSize = this.paginatorService.getPageSize('collection-list', this.pageSizeOptions[0]);
+    this.isHandset$ = this.breakpointObserver.observe([Breakpoints.Handset]).pipe(map(result => result.matches));
   }
 
   ngOnInit(): void {
@@ -81,6 +86,10 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
       this.dataSource.paginator = this.paginator;
       this.paginator.page.subscribe(e => this.paginatorService.setPageSize('collection-list', e.pageSize));
     }
+  }
+
+  toggleSelection(collection: Collection): void {
+    this.selectedCollection = this.selectedCollection === collection ? null : collection;
   }
 
   loadCollections(): void {

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -11,6 +11,7 @@
   </button>
 </div>
 
+<ng-container *ngIf="!(isHandset$ | async); else mobileView">
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">
     <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
@@ -46,3 +47,21 @@
   </div>
   <mat-paginator [length]="totalPieces" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>
 </div>
+</ng-container>
+
+<ng-template #mobileView>
+  <div class="mobile-list">
+    <div class="mobile-item" *ngFor="let piece of dataSource.data" (click)="toggleSelection(piece)">
+      <div><strong>{{ piece.title }}</strong></div>
+      <div class="subtitle-hint" *ngIf="piece.subtitle">{{ piece.subtitle }}</div>
+      <div class="detail">Komponist/Ursprung: {{ piece.composer?.name || piece.origin || '-' }}</div>
+      <div class="detail">Dichter: {{ piece.author?.name || '-' }}</div>
+      <div class="detail">Anzahl in Sammlungen: {{ piece.collectionCount || 0 }}</div>
+      <div class="mobile-actions" *ngIf="selectedPiece === piece">
+        <button mat-icon-button (click)="openPiece(piece); $event.stopPropagation()" matTooltip="Details">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.scss
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.scss
@@ -27,3 +27,35 @@
 .count-cell {
   text-align: center;
 }
+
+.subtitle-hint {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.mobile-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.mobile-item {
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.mobile-item:last-child {
+  border-bottom: none;
+}
+
+.detail {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.mobile-actions {
+  margin-top: 4px;
+  text-align: right;
+}

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.ts
@@ -8,6 +8,9 @@ import { PieceService } from '@core/services/piece.service';
 import { Piece } from '@core/models/piece';
 import { Router } from '@angular/router';
 import { PaginatorService } from '@core/services/paginator.service';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-collection-piece-list',
@@ -26,14 +29,18 @@ export class CollectionPieceListComponent implements OnInit, AfterViewInit {
   pageSizeOptions: number[] = [10, 25, 50];
   pageSize = 10;
   viewMode: 'collections' | 'pieces' = 'pieces';
+  isHandset$: Observable<boolean>;
+  selectedPiece: Piece | null = null;
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
   constructor(private pieceService: PieceService,
               private router: Router,
-              private paginatorService: PaginatorService) {
+              private paginatorService: PaginatorService,
+              private breakpointObserver: BreakpointObserver) {
     this.pageSize = this.paginatorService.getPageSize('collection-piece-list', this.pageSizeOptions[0]);
+    this.isHandset$ = this.breakpointObserver.observe([Breakpoints.Handset]).pipe(map(result => result.matches));
   }
 
   ngOnInit(): void {
@@ -89,6 +96,10 @@ export class CollectionPieceListComponent implements OnInit, AfterViewInit {
 
   openPiece(piece: Piece): void {
     this.router.navigate(['/pieces', piece.id]);
+  }
+
+  toggleSelection(piece: Piece): void {
+    this.selectedPiece = this.selectedPiece === piece ? null : piece;
   }
 
   onViewChange(value: 'collections' | 'pieces'): void {


### PR DESCRIPTION
## Summary
- add BreakpointObserver-based mobile layout for collection list
- show stacked piece list with selectable actions on mobile

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c8391000083209357330ec74af6ae