### PR TITLE
feat: configure singer menu visibility

### DIFF
--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -9,6 +9,11 @@ export interface Choir {
     modules?: {
         dienstplan?: boolean;
         joinByLink?: boolean;
+        /**
+         * Visibility configuration for main navigation items for singers.
+         * true means the item is visible, false hides it.
+         */
+        singerMenu?: Record<string, boolean>;
     };
     joinHash?: string;
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -84,6 +84,19 @@
     </mat-card-content>
   </mat-card>
 
+  <mat-card class="form-card" *ngIf="canManageMenu">
+    <mat-card-header>
+      <mat-card-title>Menü für Sänger</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <ng-container *ngFor="let opt of menuOptions">
+        <mat-checkbox [(ngModel)]="singerMenu[opt.key]" (change)="onModulesChange()">
+          {{ opt.label }} anzeigen
+        </mat-checkbox>
+      </ng-container>
+    </mat-card-content>
+  </mat-card>
+
   <!-- Card für die Mitglieder-Verwaltung -->
   <mat-card class="table-card" *ngIf="isChoirAdmin">
     <mat-card-header class="collapsible-header" (click)="toggleMembers()">

--- a/choir-app-frontend/src/app/shared/components/menu-list-item/nav-item.ts
+++ b/choir-app-frontend/src/app/shared/components/menu-list-item/nav-item.ts
@@ -1,6 +1,10 @@
 import { BehaviorSubject, Observable, Subject, Subscription } from "rxjs";
 
 export interface NavItem {
+    /**
+     * Unique key to identify the item in configuration settings.
+     */
+    key?: string;
     displayName: string;
     visibleSubject?: Observable<boolean>;
     visible?: boolean;


### PR DESCRIPTION
## Summary
- allow choir admins or directors to control which main menu items singers can see
- load singer menu settings and hide entries accordingly
- cover behavior with unit tests

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_689e3d34c2608320939c367c266b4e66