### PR TITLE
refactor: unify CRUD services

### DIFF
--- a/choir-app-frontend/src/app/core/services/category.service.ts
+++ b/choir-app-frontend/src/app/core/services/category.service.ts
@@ -1,24 +1,20 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from 'src/environments/environment';
 import { Category } from '../models/category';
+import { CreatorService } from './creator.service';
 
 @Injectable({ providedIn: 'root' })
-export class CategoryService {
-  private apiUrl = environment.apiUrl;
-
-  constructor(private http: HttpClient) {}
+export class CategoryService extends CreatorService<Category> {
+  constructor(http: HttpClient) { super(http, 'categories'); }
 
   getCategories(collectionIds?: number[]): Observable<Category[]> {
-    let params = new HttpParams();
-    if (collectionIds && collectionIds.length) {
-      params = params.set('collectionIds', collectionIds.join(','));
-    }
-    return this.http.get<Category[]>(`${this.apiUrl}/categories`, { params });
+    if (!collectionIds || !collectionIds.length) return this.getAll();
+    const params = new HttpParams().set('collectionIds', collectionIds.join(','));
+    return this.http.get<Category[]>(this.url(), { params });
   }
 
-  createCategory(name: string): Observable<Category> {
-    return this.http.post<Category>(`${this.apiUrl}/categories`, { name });
+  createCategory(name: string, force = false): Observable<Category> {
+    return this.create({ name }, force);
   }
 }

--- a/choir-app-frontend/src/app/core/services/publisher.service.ts
+++ b/choir-app-frontend/src/app/core/services/publisher.service.ts
@@ -1,28 +1,22 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from 'src/environments/environment';
 import { Publisher } from '../models/publisher';
+import { CreatorService } from './creator.service';
 
 @Injectable({ providedIn: 'root' })
-export class PublisherService {
-  private apiUrl = environment.apiUrl;
+export class PublisherService extends CreatorService<Publisher> {
+  constructor(http: HttpClient) { super(http, 'publishers'); }
 
-  constructor(private http: HttpClient) {}
+  getPublishers(): Observable<Publisher[]> { return this.getAll(); }
 
-  getPublishers(): Observable<Publisher[]> {
-    return this.http.get<Publisher[]>(`${this.apiUrl}/publishers`);
+  createPublisher(data: { name: string }, force = false): Observable<Publisher> {
+    return this.create(data, force);
   }
 
-  createPublisher(data: { name: string }): Observable<Publisher> {
-    return this.http.post<Publisher>(`${this.apiUrl}/publishers`, data);
+  updatePublisher(id: number, data: { name: string }, force = false): Observable<Publisher> {
+    return this.update(id, data, force);
   }
 
-  updatePublisher(id: number, data: { name: string }): Observable<Publisher> {
-    return this.http.put<Publisher>(`${this.apiUrl}/publishers/${id}`, data);
-  }
-
-  deletePublisher(id: number): Observable<any> {
-    return this.http.delete(`${this.apiUrl}/publishers/${id}`);
-  }
+  deletePublisher(id: number): Observable<any> { return this.delete(id); }
 }


### PR DESCRIPTION
## Summary
- refactor publisher and category services to reuse generic CreatorService methods
- drop redundant environment-based HTTP logic in favor of shared CRUD helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f15f1c8d08320a87c6c14213137bc