### PR TITLE
feat(frontend): introduce generic ListDataSource wrapper

### DIFF
--- a/choir-app-frontend/src/app/shared/util/list-data-source.ts
+++ b/choir-app-frontend/src/app/shared/util/list-data-source.ts
@@ -1,0 +1,18 @@
+import { MatPaginator } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import { PaginatorService } from '@core/services/paginator.service';
+
+export class ListDataSource<T> extends MatTableDataSource<T> {
+  constructor(private paginatorService: PaginatorService, private key: string, data: T[] = []) {
+    super(data);
+  }
+
+  connectPaginator(paginator: MatPaginator, pageSizeOptions: number[]): number {
+    const defaultSize = pageSizeOptions[0];
+    const size = this.paginatorService.getPageSize(this.key, defaultSize);
+    paginator.pageSize = size;
+    paginator.page.subscribe(e => this.paginatorService.setPageSize(this.key, e.pageSize));
+    this.paginator = paginator;
+    return size;
+  }
+}


### PR DESCRIPTION
## Summary
- add generic `ListDataSource` to streamline MatTableDataSource setup with paginator and saved page size
- refactor `EventListComponent` to use the new wrapper and remove duplicated paginator logic

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689f160b6a108320bce1ad95d18df039