### PR TITLE
refactor: add reusable form dialog base

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-publishers/publisher-dialog/publisher-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-publishers/publisher-dialog/publisher-dialog.component.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angula
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { Publisher } from '@core/models/publisher';
+import { BaseFormDialog } from '@shared/dialogs/base-form-dialog';
 
 @Component({
   selector: 'app-publisher-dialog',
@@ -11,25 +12,21 @@ import { Publisher } from '@core/models/publisher';
   imports: [CommonModule, ReactiveFormsModule, MaterialModule],
   templateUrl: './publisher-dialog.component.html',
 })
-export class PublisherDialogComponent {
-  form: FormGroup;
+export class PublisherDialogComponent extends BaseFormDialog<Publisher, Publisher | null> {
   title = 'Verlag hinzufügen';
 
   constructor(
-    private fb: FormBuilder,
-    public dialogRef: MatDialogRef<PublisherDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: Publisher | null
+    fb: FormBuilder,
+    dialogRef: MatDialogRef<PublisherDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public override data: Publisher | null
   ) {
+    super(fb, dialogRef, data);
     this.title = data ? 'Verlag bearbeiten' : 'Verlag hinzufügen';
-    this.form = this.fb.group({
-      name: [data?.name || '', Validators.required]
-    });
   }
 
-  onCancel(): void { this.dialogRef.close(); }
-  onSave(): void {
-    if (this.form.valid) {
-      this.dialogRef.close(this.form.value);
-    }
+  protected buildForm(): FormGroup {
+    return this.fb.group({
+      name: [this.data?.name || '', Validators.required]
+    });
   }
 }

--- a/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/categories/category-dialog/category-dialog.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
+import { BaseFormDialog } from '@shared/dialogs/base-form-dialog';
 
 @Component({
   selector: 'app-category-dialog',
@@ -10,22 +11,21 @@ import { MaterialModule } from '@modules/material.module';
   imports: [CommonModule, ReactiveFormsModule, MaterialModule],
   templateUrl: './category-dialog.component.html',
 })
-export class CategoryDialogComponent {
-  form: FormGroup;
-
+export class CategoryDialogComponent extends BaseFormDialog<string> {
   constructor(
-    private fb: FormBuilder,
-    public dialogRef: MatDialogRef<CategoryDialogComponent>
+    fb: FormBuilder,
+    dialogRef: MatDialogRef<CategoryDialogComponent>
   ) {
-    this.form = this.fb.group({
+    super(fb, dialogRef);
+  }
+
+  protected buildForm(): FormGroup {
+    return this.fb.group({
       name: ['', Validators.required]
     });
   }
 
-  onCancel(): void { this.dialogRef.close(); }
-  onSave(): void {
-    if (this.form.valid) {
-      this.dialogRef.close(this.form.value.name);
-    }
+  protected override getResult(): string {
+    return this.form.value.name;
   }
 }

--- a/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.spec.ts
+++ b/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.spec.ts
@@ -15,7 +15,7 @@ describe('ComposerDialogComponent', () => {
       imports: [ComposerDialogComponent, HttpClientTestingModule, RouterTestingModule],
       providers: [
         { provide: MatDialogRef, useValue: {} },
-        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: { role: 'composer' } },
         { provide: MatDialog, useValue: {} },
         { provide: MatSnackBar, useValue: { open: () => {} } }
       ]

--- a/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/composers/composer-dialog/composer-dialog.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
+import { BaseFormDialog } from '@shared/dialogs/base-form-dialog';
 
 @Component({
   selector: 'app-composer-dialog',
@@ -14,33 +15,26 @@ import { MaterialModule } from '@modules/material.module';
   ],
   templateUrl: './composer-dialog.component.html',
 })
-export class ComposerDialogComponent {
-  form: FormGroup;
+export class ComposerDialogComponent extends BaseFormDialog<{ name: string; birthYear: string; deathYear: string }, { role: 'composer' | 'author'; record?: any }> {
   title = 'Neuen Komponisten erstellen';
 
   constructor(
-    private fb: FormBuilder,
-    public dialogRef: MatDialogRef<ComposerDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { role: 'composer' | 'author'; record?: any }
+    fb: FormBuilder,
+    dialogRef: MatDialogRef<ComposerDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public override data: { role: 'composer' | 'author'; record?: any }
   ) {
+    super(fb, dialogRef, data);
     const isEdit = !!data.record;
     this.title = data.role === 'author'
       ? isEdit ? 'Dichter bearbeiten' : 'Neuen Dichter erstellen'
       : isEdit ? 'Komponist bearbeiten' : 'Neuen Komponisten erstellen';
-    this.form = this.fb.group({
-      name: [data.record?.name || '', Validators.required],
-      birthYear: [data.record?.birthYear || ''],
-      deathYear: [data.record?.deathYear || '']
+  }
+
+  protected buildForm(): FormGroup {
+    return this.fb.group({
+      name: [this.data?.record?.name || '', Validators.required],
+      birthYear: [this.data?.record?.birthYear || ''],
+      deathYear: [this.data?.record?.deathYear || '']
     });
-  }
-
-  onCancel(): void {
-    this.dialogRef.close();
-  }
-
-  onSave(): void {
-    if (this.form.valid) {
-      this.dialogRef.close(this.form.value);
-    }
   }
 }

--- a/choir-app-frontend/src/app/shared/dialogs/base-form-dialog.ts
+++ b/choir-app-frontend/src/app/shared/dialogs/base-form-dialog.ts
@@ -1,0 +1,31 @@
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+
+export abstract class BaseFormDialog<T = any, D = any> {
+  form: FormGroup;
+
+  protected constructor(
+    protected fb: FormBuilder,
+    public dialogRef: MatDialogRef<any>,
+    public data?: D
+  ) {
+    this.form = this.buildForm();
+  }
+
+  protected abstract buildForm(): FormGroup;
+
+  protected getResult(): T {
+    return this.form.value as T;
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onSave(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.getResult());
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- extract BaseFormDialog to centralize form setup and dialog controls
- refactor composer, category, and publisher dialogs to extend the new base

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f4e186b6c8320893e26392aaefd48