### PR TITLE
refactor: consolidate logging

### DIFF
--- a/choir-app-backend/scripts/init.js
+++ b/choir-app-backend/scripts/init.js
@@ -1,8 +1,9 @@
 const { init } = require('../src/init');
+const logger = require("../src/config/logger");
 
 init().then(() => {
-    console.log('Initialization completed.');
+    logger.info('Initialization completed.');
 }).catch(err => {
-    console.error('Initialization failed:', err);
+    logger.error('Initialization failed:', err);
     process.exit(1);
 });

--- a/choir-app-backend/scripts/seed.js
+++ b/choir-app-backend/scripts/seed.js
@@ -1,10 +1,11 @@
 const { seedDatabase } = require('../src/seed');
+const logger = require("../src/config/logger");
 
 const includeDemo = process.env.INCLUDE_DEMO === 'true';
 
 seedDatabase({ includeDemoData: includeDemo }).then(() => {
-    console.log('Seeding completed.');
+    logger.info('Seeding completed.');
 }).catch(err => {
-    console.error('Seeding failed:', err);
+    logger.error('Seeding failed:', err);
     process.exit(1);
 });

--- a/choir-app-backend/server.js
+++ b/choir-app-backend/server.js
@@ -36,16 +36,16 @@ async function start() {
     try {
         await init({ includeDemoData: true });
         const server = app.listen(PORT, ADDRESS, () => {
-            console.log(`Server is running on port ${PORT}, listening ${ADDRESS}.`);
+            logger.info(`Server is running on port ${PORT}, listening ${ADDRESS}.`);
         });
         // Close requests that take longer than 20 seconds
         server.setTimeout(20 * 1000);
         server.on('timeout', (socket) => {
-            console.warn('Request timed out.');
+            logger.warn('Request timed out.');
             socket.destroy();
         });
     } catch (err) {
-        console.error("Database startup failed:", err);
+        logger.error("Database startup failed:", err);
     }
 }
 

--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -2,6 +2,7 @@ const db = require("../models");
 const crypto = require('crypto');
 const emailService = require('../services/email.service');
 const { Op } = require('sequelize');
+const logger = require("../config/logger");
 
 // Holt alle Entitäten eines bestimmten Typs für die Admin-Tabellen
 exports.getAll = (model) => async (req, res) => {
@@ -352,7 +353,7 @@ exports.updateChoirMember = async (req, res) => {
     const { rolesInChoir } = req.body;
 
     try {
-        console.log("Updating choir member:", userId, "in choir:", choirId);
+        logger.debug("Updating choir member:", userId, "in choir:", choirId);
         const association = await db.user_choir.findOne({ where: { userId, choirId } });
         if (!association) return res.status(412).send({ message: 'User is not a member of this choir.' });
 

--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -215,11 +215,15 @@ exports.updateMember = async (req, res, next) => {
     const { rolesInChoir } = req.body;
     const choirId = req.activeChoirId;
 
-    console.log("Update member request:", JSON.stringify(req.params), JSON.stringify(req.body));
+    logger.debug(
+        "Update member request:",
+        JSON.stringify(req.params),
+        JSON.stringify(req.body)
+    );
 
 
     try {
-        console.log("Updating member:", userId, "for choirId:", choirId);
+        logger.debug("Updating member:", userId, "for choirId:", choirId);
         const association = await db.user_choir.findOne({ where: { userId, choirId } });
         if (!association) return res.status(412).send({ message: 'User is not a member of this choir.' });
 
@@ -244,14 +248,14 @@ exports.updateMember = async (req, res, next) => {
 
 exports.getChoirCollections = async (req, res, next) => {
     try {
-        console.log("Fetching collections for choirId:", req.activeChoirId);
+        logger.debug("Fetching collections for choirId:", req.activeChoirId);
 
         const choir = await db.choir.findByPk(req.activeChoirId);
         if (!choir) {
             return res.status(404).send({ message: "Active choir not found." });
         }
 
-        console.log("Choir found: ", choir.name, " getting collections...");
+        logger.debug("Choir found: ", choir.name, " getting collections...");
         const collections = await choir.getCollections({
             attributes: {
                 include: [
@@ -269,7 +273,9 @@ exports.getChoirCollections = async (req, res, next) => {
             order: [['title', 'ASC']]
         });
 
-        console.log(`Found ${collections.length} collections for choirId ${req.activeChoirId}.`);
+        logger.info(
+            `Found ${collections.length} collections for choirId ${req.activeChoirId}.`
+        );
         const result = collections.map(c => {
             const plain = c.get ? c.get() : c;
             return {

--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -72,7 +72,7 @@ exports.lookup = async (req, res) => {
         res.status(200).send(lookupResults);
 
     } catch (err) {
-        console.error("ERROR in repertoire lookup:", err);
+        logger.error("ERROR in repertoire lookup:", err);
         res.status(500).send({ message: "An error occurred during repertoire lookup." });
     }
 };
@@ -460,7 +460,7 @@ exports.findOne = async (req, res) => {
 
         res.status(200).send(result);
     } catch (err) {
-        console.error('ERROR finding repertoire piece:', err);
+        logger.error('ERROR finding repertoire piece:', err);
         res.status(500).send({ message: err.message || 'Error retrieving piece.' });
     }
 };

--- a/choir-app-backend/src/init/assignAdminRole.js
+++ b/choir-app-backend/src/init/assignAdminRole.js
@@ -1,4 +1,5 @@
 const db = require('../models');
+const logger = require("../config/logger");
 
 async function assignAdminRole() {
     const email = 'm.free@nak-goettingen.de';
@@ -12,10 +13,10 @@ async function assignAdminRole() {
             roles.push('admin');
             user.roles = roles;
             await user.save();
-            console.log(`Added admin role to ${email}.`);
+            logger.info(`Added admin role to ${email}.`);
         }
     } catch (err) {
-        console.error('Failed to assign admin role:', err);
+        logger.error('Failed to assign admin role:', err);
     }
 }
 

--- a/choir-app-backend/src/init/dbSync.js
+++ b/choir-app-backend/src/init/dbSync.js
@@ -1,8 +1,9 @@
 const db = require('../models');
+const logger = require("../config/logger");
 
 async function syncDatabase(options = { alter: true }) {
     await db.sequelize.sync(options);
-    console.log('Database synchronized.');
+    logger.info('Database synchronized.');
 }
 
 module.exports = { syncDatabase };

--- a/choir-app-backend/src/init/joinHashes.js
+++ b/choir-app-backend/src/init/joinHashes.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const db = require('../models');
+const logger = require("../config/logger");
 
 async function ensureJoinHashes() {
     const choirs = await db.choir.findAll({ where: { joinHash: null } });
@@ -8,7 +9,7 @@ async function ensureJoinHashes() {
         await choir.save();
     }
     if (choirs.length > 0) {
-        console.log(`Generated join hashes for ${choirs.length} choirs.`);
+        logger.info(`Generated join hashes for ${choirs.length} choirs.`);
     }
 }
 

--- a/choir-app-backend/src/init/migrateRoles.js
+++ b/choir-app-backend/src/init/migrateRoles.js
@@ -1,4 +1,5 @@
 const db = require('../models');
+const logger = require("../config/logger");
 
 async function migrateRoles() {
   const qi = db.sequelize.getQueryInterface();
@@ -26,7 +27,7 @@ async function migrateRoles() {
       }
     }
     await qi.removeColumn('users', 'role');
-    console.log(`Migrated role to roles for ${users.length} users.`);
+    logger.info(`Migrated role to roles for ${users.length} users.`);
   } catch (err) {
     // Table does not exist or other error, ignore
   }

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -1,6 +1,7 @@
 const bcrypt = require("bcryptjs");
 const crypto = require("crypto");
 const db = require("./models");
+const logger = require("./config/logger");
 
 async function seedDatabase(options = {}) {
     const { includeDemoData = false } = options;
@@ -9,7 +10,7 @@ async function seedDatabase(options = {}) {
         // Initial seed
         const userCount = await db.user.count();
         if (userCount === 0) {
-            console.log("No users found. Seeding initial admin user and choir...");
+            logger.info("No users found. Seeding initial admin user and choir...");
             const [choir] = await db.choir.findOrCreate({
                 where: { name: "My First Choir" },
                 defaults: { name: "My First Choir" },
@@ -91,12 +92,12 @@ async function seedDatabase(options = {}) {
                 where: { key: 'SYSTEM_ADMIN_EMAIL' },
                 defaults: { value: process.env.SYSTEM_ADMIN_EMAIL || '' }
             });
-            console.log("Initial seeding completed successfully.");
+            logger.info("Initial seeding completed successfully.");
         } else {
-            console.log("Database already seeded. Skipping initial setup.");
+            logger.info("Database already seeded. Skipping initial setup.");
         }
     } catch (error) {
-        console.error("Error during initial seeding:", error);
+        logger.error("Error during initial seeding:", error);
     }
 
     if (includeDemoData) {
@@ -124,7 +125,7 @@ async function seedDatabase(options = {}) {
                 await choir.addCollection(collection).catch(() => { });
             }
         } catch (err) {
-            console.error("Error during demo seeding:", err);
+            logger.error("Error during demo seeding:", err);
         }
     }
 }

--- a/choir-app-backend/tests/availability.controller.test.js
+++ b/choir-app-backend/tests/availability.controller.test.js
@@ -41,8 +41,6 @@ const controller = require('../src/controllers/availability.controller');
   const xmasDates = res.data.map(a => a.date);
   assert.ok(xmasDates.includes('2021-12-25'));
   assert.ok(!xmasDates.includes('2021-12-26'));
-
-    console.log('availability.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/choir-management.controller.test.js
+++ b/choir-app-backend/tests/choir-management.controller.test.js
@@ -26,8 +26,6 @@ const controller = require('../src/controllers/choir-management.controller');
 
     await controller.updateMyChoir({ activeChoirId: choir.id, userId: adminUser.id, userRoles: ['admin'], body: { modules: { dienstplan: false } } }, res);
     assert.strictEqual(res.statusCode, 200, 'admin should change modules');
-
-    console.log('choir-management controller permissions test passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/collection.validation.test.js
+++ b/choir-app-backend/tests/collection.validation.test.js
@@ -38,8 +38,6 @@ const { createCollectionValidation, updateCollectionValidation } = require('../s
     for (const v of createCollectionValidation) { await v.run(req5); }
     res = validationResult(req5);
     assert.ok(!res.isEmpty(), 'create should fail for invalid numberInCollection');
-
-    console.log('collection.validation tests passed');
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/choir-app-backend/tests/creator.duplicate.test.js
+++ b/choir-app-backend/tests/creator.duplicate.test.js
@@ -50,8 +50,6 @@ const authorController = require('../src/controllers/author.controller');
     assert.strictEqual(migratedPiece2.authorId, a2.id);
     const deletedAuthor = await db.author.findByPk(a1.id);
     assert.strictEqual(deletedAuthor, null);
-
-    console.log('creator duplicate tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/creator.enrich.test.js
+++ b/choir-app-backend/tests/creator.enrich.test.js
@@ -45,8 +45,6 @@ global.fetch = async () => {
     const updated = await db.composer.findByPk(composer.id);
     assert.strictEqual(updated.birthYear, '1800');
     assert.strictEqual(calls, 2, 'should retry once');
-
-    console.log('creator enrich tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/emailTemplateManager.test.js
+++ b/choir-app-backend/tests/emailTemplateManager.test.js
@@ -14,7 +14,6 @@ const { replacePlaceholders, buildTemplate } = require('../src/services/emailTem
     const mail = buildTemplate({ subject: 'Hi {{surname}}', body: '<p>Use {{link}}</p>' }, 'reset', { surname: 'Bob', link: 'http://example.com' });
     assert.strictEqual(mail.subject, 'Hi Bob');
     assert.strictEqual(mail.text.trim(), 'Use http://example.com');
-    console.log('emailTemplateManager tests passed');
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/choir-app-backend/tests/emailTransporter.test.js
+++ b/choir-app-backend/tests/emailTransporter.test.js
@@ -18,7 +18,6 @@ const { sendMail } = require('../src/services/emailTransporter');
     assert.strictEqual(createdOptions.host, 'smtp.example.com');
     assert.strictEqual(result.to, 'a@b.c');
     assert.strictEqual(result.from.address, 'from@example.com');
-    console.log('emailTransporter tests passed');
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/choir-app-backend/tests/event.controller.test.js
+++ b/choir-app-backend/tests/event.controller.test.js
@@ -75,8 +75,6 @@ const controller = require('../src/controllers/event.controller');
     const ids = res.data.map(e => e.id);
     assert.ok(ids.includes(futureId));
     assert.ok(!ids.includes(res.data.find(e => e.id !== futureId)?.id || false));
-
-    console.log('event.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/frontend-url.test.js
+++ b/choir-app-backend/tests/frontend-url.test.js
@@ -14,8 +14,6 @@ const { getFrontendUrl } = require('../src/utils/frontend-url');
     process.env.FRONTEND_URL = 'https://foo.bar/app/';
     url = await getFrontendUrl();
     assert.strictEqual(url, 'https://foo.bar/app');
-
-    console.log('frontend-url tests passed');
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/choir-app-backend/tests/holiday.service.test.js
+++ b/choir-app-backend/tests/holiday.service.test.js
@@ -15,7 +15,6 @@ const { isPublicHoliday } = require('../src/services/holiday.service');
     assert.ok(isPublicHoliday(entMarch));
     assert.ok(isPublicHoliday(entJuly));
     assert.ok(isPublicHoliday(entNov));
-    console.log('holiday.service tests passed');
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/choir-app-backend/tests/import.controller.test.js
+++ b/choir-app-backend/tests/import.controller.test.js
@@ -33,8 +33,6 @@ const jobs = require('../src/services/import-jobs.service');
       ['10', '11', '12']
     );
 
-    console.log('import.controller auto numbering test passed');
-
     // Test name formatting for composer and author
     await db.sequelize.sync({ force: true });
 
@@ -51,8 +49,6 @@ const jobs = require('../src/services/import-jobs.service');
     assert.strictEqual(storedComposer.name, 'Bach, Johann Sebastian');
     assert.strictEqual(storedAuthor.name, 'Luther, Martin');
 
-    console.log('import.controller name formatting test passed');
-
     // Test interpolation of abbreviated composer names
     await db.sequelize.sync({ force: true });
 
@@ -67,8 +63,6 @@ const jobs = require('../src/services/import-jobs.service');
     const composers = await db.composer.findAll();
     assert.strictEqual(composers.length, 1, 'should reuse existing composer');
     assert.strictEqual(composers[0].id, existingComp.id);
-
-    console.log('import.controller abbreviation match test passed');
 
     await db.sequelize.sync({ force: true });
 
@@ -94,8 +88,6 @@ const jobs = require('../src/services/import-jobs.service');
 
     const rep = await db.choir_repertoire.findOne({ where: { choirId: choir.id, pieceId: piece.id } });
     assert.strictEqual(rep.status, 'CAN_BE_SUNG', 'status should be updated');
-
-    console.log('import.controller duplicate handling test passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/join.controller.test.js
+++ b/choir-app-backend/tests/join.controller.test.js
@@ -26,8 +26,6 @@ const controller = require('../src/controllers/join.controller');
 
     await controller.joinChoir({ params: { token: 'token123' }, body: { name: 'User', email: 'u@example.com', password: 'pw' } }, res);
     assert.strictEqual(res.statusCode, 201, 'join should succeed when enabled');
-
-    console.log('join.controller test passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/library.controller.test.js
+++ b/choir-app-backend/tests/library.controller.test.js
@@ -36,8 +36,6 @@ const controller = require('../src/controllers/library.controller');
     assert.strictEqual(listRes.data[0].collection.pieces.length, 1);
     assert.strictEqual(listRes.data[0].collection.pieces[0].id, piece.id);
     assert.strictEqual(listRes.data[0].collection.pieceCount, 1);
-
-    console.log('library.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/loan-request.controller.test.js
+++ b/choir-app-backend/tests/loan-request.controller.test.js
@@ -33,8 +33,6 @@ const controller = require('../src/controllers/library.controller');
     assert.strictEqual(res.data.items[0].quantity, 2);
     assert.strictEqual(res.data.choirId, choir.id);
     assert.strictEqual(res.data.userId, user.id);
-
-    console.log('loan-request.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/log.service.test.js
+++ b/choir-app-backend/tests/log.service.test.js
@@ -18,8 +18,6 @@ const service = require('../src/services/log.service');
 
     if (!Array.isArray(errorEntries) || errorEntries.length !== 1) throw new Error('error log parse failed');
     if (!Array.isArray(jsonEntries) || jsonEntries.length !== 1) throw new Error('json log parse failed');
-
-    console.log('log.service tests passed');
     fs.rmSync(logDir, { recursive: true, force: true });
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -40,8 +40,6 @@ const db = require('../src/models');
     assert(db.choir.associations.events, 'Choir should have events association');
     assert(db.choir.associations.monthlyPlans, 'Choir should have monthlyPlans association');
     assert(db.choir.associations.planRules, 'Choir should have planRules association');
-
-    console.log('All model tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/monthlyPlan.controller.test.js
+++ b/choir-app-backend/tests/monthlyPlan.controller.test.js
@@ -44,8 +44,6 @@ const controller = require('../src/controllers/monthlyPlan.controller');
     const dates = entries2021.map(e => e.date.toISOString().split('T')[0]);
     assert.ok(dates.includes('2021-12-25'));
     assert.ok(!dates.includes('2021-12-26'));
-
-    console.log('monthlyPlan controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/piece.controller.test.js
+++ b/choir-app-backend/tests/piece.controller.test.js
@@ -95,8 +95,6 @@ const controller = require('../src/controllers/piece.controller');
   assert.strictEqual(res.data.message.includes('deleted'), true);
   const deleted = await db.piece.findByPk(created.id);
   assert.strictEqual(deleted, null);
-
-    console.log('piece.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/piece.validation.test.js
+++ b/choir-app-backend/tests/piece.validation.test.js
@@ -18,8 +18,6 @@ const { createPieceValidation, updatePieceValidation } = require('../src/validat
     for (const v of updatePieceValidation) { await v.run(req2); }
     res = validationResult(req2);
     assert.ok(!res.isEmpty(), 'update should fail with invalid arrangerIds');
-
-    console.log('piece.validation tests passed');
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/choir-app-backend/tests/role.middleware.test.js
+++ b/choir-app-backend/tests/role.middleware.test.js
@@ -68,8 +68,6 @@ async function sendRequest(middleware, context) {
     res = await sendRequest(requireChoirAdmin, { userRoles: ['singer'], userId: normal.id, activeChoirId: choir.id });
     assert.strictEqual(res.status, 500, 'db error should return 500');
     db.user_choir.findOne = originalFindOne;
-
-    console.log('role.middleware tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-backend/tests/search.controller.test.js
+++ b/choir-app-backend/tests/search.controller.test.js
@@ -26,8 +26,6 @@ const controller = require('../src/controllers/search.controller');
     const reqOrigin = { query: { q: 'Trad' }, activeChoirId: choir.id };
     await controller.search(reqOrigin, res);
     assert.ok(res.data.pieces.find(p => p.title === 'Folk'));
-
-    console.log('search.controller tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-frontend/src/app/app.component.ts
+++ b/choir-app-frontend/src/app/app.component.ts
@@ -23,11 +23,9 @@ export class AppComponent {
     this.api.pingBackend().subscribe({
       next: () => {
         this.backendAvailable = true;
-        console.log("Successfully connected.");
       },
       error: () => {
         this.backendAvailable = false;
-        console.error("Could not connect to the backend.");
       }
     });
   }

--- a/choir-app-frontend/src/app/core/interceptors/auth-interceptor.ts
+++ b/choir-app-frontend/src/app/core/interceptors/auth-interceptor.ts
@@ -40,7 +40,6 @@ export class AuthInterceptor implements HttpInterceptor {
         return next.handle(request).pipe(
             catchError((error: HttpErrorResponse) => {
                 if (error.status === 401) {
-                    console.warn('Unauthorized error detected. Logging out user.');
                     const svc = this.injector.get(AuthService);
                     svc.logout('sessionExpired');
                 } else if (error.status === 403) {

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.ts
@@ -49,7 +49,6 @@ export class ManageChoirsComponent implements OnInit {
   }
 
   editChoir(choir: Choir): void {
-    console.log('Editing choir:', choir.id);
     this.router.navigate(['/manage-choir'], { queryParams: { choirId: choir.id } }
   );
   }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -25,7 +25,6 @@ export class ManageChoirResolver implements Resolve<any> {
       switchMap(isAdmin => {
         const choirIdParam = route.queryParamMap.get('choirId');
         const choirId = choirIdParam ? parseInt(choirIdParam, 10) : null;
-        console.log('ManageChoirResolver: Resolving data for choirId:', choirId);
 
         const opts = isAdmin && choirId ? { choirId } : undefined;
 
@@ -70,7 +69,6 @@ export class ManageChoirResolver implements Resolve<any> {
         }
 
         const errorMessage = error.error?.message || 'Could not load data for choir management.';
-        console.error('ManageChoirResolver error', error);
         this.errorService.setError({
           message: errorMessage,
           status: error.status,

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -173,7 +173,6 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
         this.apiService.getGlobalPieces().subscribe((pieces) => {
             //console.log('Fetched pieces:', pieces);
             if (!pieces || pieces.length === 0) {
-                console.warn('No pieces found, initializing with empty array.');
                 pieces = [];
             }
             // Assign the fetched pieces to allPieces.

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.ts
@@ -101,8 +101,6 @@ export class ImportDialogComponent implements OnDestroy {
     this.statusSubscription = timer(0, 500).pipe(
       // Holen Sie den Job-Status vom Server
       switchMap(() => this.apiService.getImportStatus(jobId)),
-      // Loggen Sie den Job-Status zum Debuggen
-      tap(job => console.log('Polling status:', job)),
       // Fahren Sie fort, bis der Job abgeschlossen oder fehlgeschlagen ist
       takeWhile(job => job.status === 'running' || job.status === 'pending', true)
     ).subscribe({

--- a/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.ts
@@ -70,7 +70,6 @@ export class EventImportDialogComponent implements OnDestroy {
 
     this.statusSubscription = timer(0, 500).pipe(
       switchMap(() => this.apiService.getImportStatus(jobId)),
-      tap(job => console.log('Polling status:', job)),
       takeWhile(job => job.status === 'running' || job.status === 'pending', true)
     ).subscribe({
       next: job => {

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -415,12 +415,10 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
           }
         });
 
-        console.log(`Status for piece ${pieceId} updated to ${newStatus}`);
         this.snackBar.open('Status updated.', 'OK', { duration: 2000 });
       },
 
       error: (err) => {
-        console.error('Failed to update status', err);
         const msg = err.error?.message || 'Could not update status.';
         this.errorService.setError({
           message: msg,

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -140,10 +140,6 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
         }
       }
     }
-    if (this.isChoirAdmin) {
-      console.log('CounterPlan timestamps:',
-        this.counterPlanDateKeys.map(d => ({ date: d, ts: this.timestamp(d) })));
-    }
   }
 
   constructor(private api: ApiService,
@@ -194,10 +190,6 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
         this.sortEntries();
         this.updateDisplayedColumns();
         this.updateCounterPlan();
-        if (this.isChoirAdmin) {
-          console.log('Plan timestamps:',
-            this.entries.map(e => ({ id: e.id, date: e.date, ts: this.timestamp(e.date) })));
-        }
       },
       error: () => {
         this.plan = null;


### PR DESCRIPTION
## Summary
- use central Winston logger throughout backend scripts and controllers
- drop ad-hoc console logging in Angular components
- clean up noisy console logs in tests

## Testing
- `npm run check-backend`
- `npm test` *(fails: ChromeHeadless missing libXdamage.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b0c97da88320af47dba1c7f280fa