### PR TITLE
chore: add root scripts for lint build and tests

### DIFF
--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "startwithtimestamp": "node ./scripts/serve-with-timestamp.js",
     "build": "ng build",
+    "lint": "ng lint",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false",
     "pretest": "npm run generate-build-info",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "chorleiter-root",
   "private": true,
   "scripts": {
+    "lint": "npm run lint --prefix choir-app-frontend && npm run check --prefix choir-app-backend",
+    "build": "npm run build --prefix choir-app-frontend",
     "test": "npm test --prefix choir-app-frontend",
+    "test:backend": "npm test --prefix choir-app-backend",
     "check-backend": "npm run check --prefix choir-app-backend"
   }
 }


### PR DESCRIPTION
## Summary
- expose lint, build, and backend test scripts at repo root
- add lint script to the Angular frontend

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npm run build`
- `npm test`
- `timeout 60 npm run test:backend`


------
https://chatgpt.com/codex/tasks/task_e_68a2b0abad0c83208cce4057853c0eb1