### PR TITLE
feat: export events as ICS with calendar links

### DIFF
--- a/choir-app-backend/src/routes/event.routes.js
+++ b/choir-app-backend/src/routes/event.routes.js
@@ -6,6 +6,8 @@ const validate = require("../validators/validate");
 const { handler: wrap } = require("../utils/async");
 const router = require("express").Router();
 
+router.get("/ics", wrap(controller.ics));
+
 router.use(authJwt.verifyToken);
 
 router.get("/last", wrap(controller.findLast));

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -1,5 +1,9 @@
 <div class="calendar-wrapper">
   <h2>Meine Termine</h2>
+  <div class="calendar-actions">
+    <button mat-stroked-button (click)="downloadIcs()">ICS herunterladen</button>
+    <a mat-stroked-button *ngIf="googleCalendarUrl" [href]="googleCalendarUrl" target="_blank" rel="noopener">Google Kalender</a>
+  </div>
   <mat-calendar class="compact"
                 [selected]="selectedDate"
                 (selectedChange)="onSelectedChange($event)"

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
@@ -30,6 +30,12 @@
     overflow-y: auto;
   }
 
+  .calendar-actions {
+    margin-bottom: 8px;
+    display: flex;
+    gap: 8px;
+  }
+
   ::ng-deep mat-calendar.compact {
     width: 100%;
     max-width: 360px;

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -15,6 +15,7 @@ import { Event } from '@core/models/event';
 import { PlanEntry } from '@core/models/plan-entry';
 import { AuthService } from '@core/services/auth.service';
 import { DateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
+import { environment } from 'src/environments/environment';
 
 interface HolidayEvent {
     type: 'HOLIDAY';
@@ -188,5 +189,19 @@ export class MyCalendarComponent implements OnInit {
             entries.push({ type: 'HOLIDAY', name: holiday, date: key });
         }
         return entries;
+    }
+
+    downloadIcs(): void {
+        const token = this.auth.getToken();
+        if (!token) return;
+        const url = `${environment.apiUrl}/events/ics?token=${token}`;
+        window.open(url, '_blank');
+    }
+
+    get googleCalendarUrl(): string | null {
+        const token = this.auth.getToken();
+        if (!token) return null;
+        const icsUrl = encodeURIComponent(`${environment.apiUrl}/events/ics?token=${token}`);
+        return `https://calendar.google.com/calendar/r?cid=${icsUrl}`;
     }
 }

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
@@ -26,6 +26,14 @@
       </div>
     </mat-step>
     <mat-step>
+      <ng-template matStepLabel>Kalender</ng-template>
+      <p>Unter &bdquo;Meine Termine&ldquo; kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
+      <div>
+        <button mat-button matStepperPrevious>Zur&uuml;ck</button>
+        <button mat-flat-button color="primary" matStepperNext>Weiter</button>
+      </div>
+    </mat-step>
+    <mat-step>
       <ng-template matStepLabel>Spenden</ng-template>
       <p>Die Nutzung des Chorleiters ist f&uuml;r dich vollkommen kostenlos. Wir freuen uns jedoch &uuml;ber jede Spende, um die Weiterentwicklung zu unterst&uuml;tzen.</p>
       <div>


### PR DESCRIPTION
## Summary
- add `/events/ics` endpoint to export choir events in ICS format
- allow calendar download and Google Calendar integration from "Meine Termine"
- document calendar export in help wizard

## Testing
- `npm test --prefix choir-app-backend`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b4c07f608320b64dc3c80b2300be