### PR TITLE
feat(admin): show changed fields in leave warning

### DIFF
--- a/choir-app-frontend/src/app/core/guards/pending-changes.guard.ts
+++ b/choir-app-frontend/src/app/core/guards/pending-changes.guard.ts
@@ -6,6 +6,7 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/co
 
 export interface PendingChanges {
   hasPendingChanges(): boolean;
+  getChangedFields(): string[];
 }
 
 @Injectable({ providedIn: 'root' })
@@ -14,9 +15,13 @@ export class PendingChangesGuard implements CanDeactivate<PendingChanges> {
 
   canDeactivate(component: PendingChanges): boolean | Observable<boolean> {
     if (component.hasPendingChanges()) {
+      const fields = component.getChangedFields();
+      const message = fields.length
+        ? `Sie haben ungespeicherte Änderungen an folgenden Feldern: ${fields.join(', ')}. Wirklich verlassen?`
+        : 'Sie haben ungespeicherte Änderungen. Wirklich verlassen?';
       const dialogData: ConfirmDialogData = {
         title: 'Änderungen verwerfen?',
-        message: 'Sie haben ungespeicherte Änderungen. Wirklich verlassen?'
+        message
       };
       const dialogRef = this.dialog.open(ConfirmDialogComponent, { data: dialogData });
       return dialogRef.afterClosed();

--- a/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/admin-email-settings/admin-email-settings.component.ts
@@ -43,6 +43,10 @@ export class AdminEmailSettingsComponent implements OnInit, PendingChanges {
     return this.form.dirty;
   }
 
+  getChangedFields(): string[] {
+    return Object.keys(this.form.controls).filter(key => this.form.get(key)?.dirty);
+  }
+
   @HostListener('window:beforeunload', ['$event'])
   confirmUnload(event: BeforeUnloadEvent): void {
     if (this.hasPendingChanges()) {

--- a/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/frontend-url-settings/frontend-url-settings.component.ts
@@ -43,6 +43,10 @@ export class FrontendUrlSettingsComponent implements OnInit, PendingChanges {
     return this.form.dirty;
   }
 
+  getChangedFields(): string[] {
+    return Object.keys(this.form.controls).filter(key => this.form.get(key)?.dirty);
+  }
+
   @HostListener('window:beforeunload', ['$event'])
   confirmUnload(event: BeforeUnloadEvent): void {
     if (this.hasPendingChanges()) {

--- a/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/general/general-settings.component.ts
@@ -27,4 +27,13 @@ export class GeneralSettingsComponent implements PendingChanges {
            (this.mailSettings?.hasPendingChanges() ?? false) ||
            (this.mailTemplates?.hasPendingChanges() ?? false);
   }
+
+  getChangedFields(): string[] {
+    return [
+      ...(this.frontendUrl?.getChangedFields() ?? []),
+      ...(this.adminEmail?.getChangedFields() ?? []),
+      ...(this.mailSettings?.getChangedFields() ?? []),
+      ...(this.mailTemplates?.getChangedFields() ?? [])
+    ];
+  }
 }

--- a/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-settings/mail-settings.component.ts
@@ -80,6 +80,10 @@ export class MailSettingsComponent implements OnInit, PendingChanges {
     return this.form.dirty;
   }
 
+  getChangedFields(): string[] {
+    return Object.keys(this.form.controls).filter(key => this.form.get(key)?.dirty);
+  }
+
   @HostListener('window:beforeunload', ['$event'])
   confirmUnload(event: BeforeUnloadEvent): void {
     if (this.hasPendingChanges()) {

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
@@ -236,6 +236,10 @@ export class MailTemplatesComponent implements OnInit, AfterViewInit, PendingCha
     return this.form.dirty;
   }
 
+  getChangedFields(): string[] {
+    return Object.keys(this.form.controls).filter(key => this.form.get(key)?.dirty);
+  }
+
   @HostListener('window:beforeunload', ['$event'])
   confirmUnload(event: BeforeUnloadEvent): void {
     if (this.hasPendingChanges()) {


### PR DESCRIPTION
## Summary
- list field names with unsaved changes when leaving admin/general
- track dirty fields in each general settings subcomponent

## Testing
- `npm test --prefix choir-app-frontend` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run lint --prefix choir-app-frontend` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bbb0f0988320b12abe2cc8515b9c