### PR TITLE
Ignore .gitkeep in upload listing

### DIFF
--- a/choir-app-backend/src/services/file.service.js
+++ b/choir-app-backend/src/services/file.service.js
@@ -12,7 +12,8 @@ const DIRS = {
 
 async function safeReaddir(sub) {
   try {
-    return await fs.readdir(path.join(BASE_DIR, sub));
+    const entries = await fs.readdir(path.join(BASE_DIR, sub));
+    return entries.filter(name => name !== '.gitkeep');
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- skip `.gitkeep` files when scanning upload directories so they aren't flagged as unlinked

## Testing
- `npm run check --prefix choir-app-backend`
- `npm test --prefix choir-app-backend` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a31f795684832082272074e72c2a97