### PR TITLE
feat: add backend crash and error logging

### DIFF
--- a/choir-app-backend/server.js
+++ b/choir-app-backend/server.js
@@ -27,6 +27,17 @@ async function handleFatal(error) {
 
 process.on('uncaughtException', handleFatal);
 process.on('unhandledRejection', handleFatal);
+process.on('SIGTERM', () => {
+    logger.warn('SIGTERM received. Shutting down.');
+    process.exit(0);
+});
+process.on('SIGINT', () => {
+    logger.warn('SIGINT received. Shutting down.');
+    process.exit(0);
+});
+process.on('exit', (code) => {
+    logger.info(`Process exited with code ${code}`);
+});
 
 
 const PORT = process.env.PORT || 8088;

--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -31,6 +31,12 @@ const limiter = RateLimit({
     max: 100, // Erhöhen Sie das Limit auf einen vernünftigeren Wert
     standardHeaders: true,
     legacyHeaders: false,
+    handler: (req, res, _next) => {
+        logger.warn(`429 - Too Many Requests - ${req.originalUrl} - ${req.method} - ${req.ip}`);
+        res.status(429).send({
+            message: "Too many requests, please try again later.",
+        });
+    },
 });
 // Apply rate limiter to all requests
 app.use(limiter);
@@ -100,6 +106,12 @@ app.use("/api/availabilities", availabilityRoutes);
 app.use("/api/client-errors", clientErrorRoutes);
 app.use("/api/posts", postRoutes);
 app.use("/api/library", libraryRoutes);
+
+// Handle 404 for unknown routes
+app.use((req, res, _next) => {
+    logger.warn(`404 - Not Found - ${req.originalUrl} - ${req.method} - ${req.ip}`);
+    res.status(404).send({ message: "Not Found" });
+});
 
 app.use((err, req, res, next) => {
     logger.error(


### PR DESCRIPTION
## Summary
- log SIGTERM/SIGINT and process exit events in server startup
- log rate limit and 404 errors to trace backend issues

## Testing
- `cd choir-app-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3876141c48320bc33b5f60c44798d