### PR TITLE
Add per-choir piece ratings

### DIFF
--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -120,7 +120,7 @@ exports.findMyRepertoire = async (req, res) => {
 
         // Erstellen Sie eine Liste aller Stück-IDs im Repertoire und eine Map für den Status.
         const pieceIdsInRepertoire = repertoireLinks.map(link => link.pieceId);
-        const linkMap = new Map(repertoireLinks.map(link => [link.pieceId, { status: link.status, notes: link.notes }]));
+        const linkMap = new Map(repertoireLinks.map(link => [link.pieceId, { status: link.status, notes: link.notes, rating: link.rating }]));
 
 
         // --- SCHRITT 2: Bauen Sie die finale Abfrage auf der Piece-Tabelle ---
@@ -364,7 +364,7 @@ exports.findMyRepertoire = async (req, res) => {
         // Konvertieren Sie die Sequelize-Instanzen in einfache Objekte für die Bearbeitung.
         const results = pieces.map(piece => {
             const plainPiece = piece.get({ plain: true });
-            const info = linkMap.get(plainPiece.id) || { status: 'NOT_READY', notes: null };
+            const info = linkMap.get(plainPiece.id) || { status: 'NOT_READY', notes: null, rating: null };
             plainPiece.choir_repertoire = info;
             return plainPiece;
         });
@@ -404,6 +404,19 @@ exports.updateNotes = async (req, res) => {
             { where: { choirId: req.activeChoirId, pieceId: pieceId } }
         );
         res.status(200).send({ message: "Notes updated successfully." });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.updateRating = async (req, res) => {
+    const { pieceId, rating } = req.body;
+    try {
+        await db.choir_repertoire.update(
+            { rating: rating },
+            { where: { choirId: req.activeChoirId, pieceId: pieceId } }
+        );
+        res.status(200).send({ message: "Rating updated successfully." });
     } catch (err) {
         res.status(500).send({ message: err.message });
     }
@@ -454,7 +467,7 @@ exports.findOne = async (req, res) => {
 
         const result = piece.get({ plain: true });
         if (link) {
-            result.choir_repertoire = { status: link.status, notes: link.notes };
+            result.choir_repertoire = { status: link.status, notes: link.notes, rating: link.rating };
         }
         result.notes = notes.map(n => n.get({ plain: true }));
 

--- a/choir-app-backend/src/middleware/role.middleware.js
+++ b/choir-app-backend/src/middleware/role.middleware.js
@@ -53,4 +53,10 @@ function requireLibrarian(req, res, next) {
     }
     return res.status(403).send({ message: 'Require Librarian Role!' });
 }
-module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector, requireLibrarian };
+function requireDirectorOrHigher(req, res, next) {
+    if (['director', 'choir_admin', 'admin'].some(r => req.userRoles.includes(r))) {
+        return next();
+    }
+    return res.status(403).send({ message: 'Require Director Role!' });
+}
+module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector, requireLibrarian, requireDirectorOrHigher };

--- a/choir-app-backend/src/models/choir_repertoire.model.js
+++ b/choir-app-backend/src/models/choir_repertoire.model.js
@@ -13,6 +13,11 @@ module.exports = (sequelize, DataTypes) => {
         notes: {
             type: DataTypes.TEXT,
             allowNull: true
+        },
+        rating: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            validate: { min: 1, max: 5 }
         }
     });
     return ChoirRepertoire;

--- a/choir-app-backend/src/routes/repertoire.routes.js
+++ b/choir-app-backend/src/routes/repertoire.routes.js
@@ -1,4 +1,5 @@
 const authJwt = require("../middleware/auth.middleware");
+const role = require("../middleware/role.middleware");
 const controller = require("../controllers/repertoire.controller");
 const noteController = require("../controllers/piece-note.controller");
 const router = require("express").Router();
@@ -9,6 +10,7 @@ router.use(authJwt.verifyToken);
 router.get("/", wrap(controller.findMyRepertoire));
 router.put("/status", wrap(controller.updateStatus));
 router.put("/notes", wrap(controller.updateNotes));
+router.put("/rating", role.requireDirectorOrHigher, wrap(controller.updateRating));
 router.post("/add-piece", wrap(controller.addPieceToRepertoire));
 router.get("/lookup", wrap(controller.lookup));
 router.get("/:id", wrap(controller.findOne));

--- a/choir-app-frontend/src/app/core/models/piece.ts
+++ b/choir-app-frontend/src/app/core/models/piece.ts
@@ -37,6 +37,7 @@ export interface Piece {
   choir_repertoire?: {
     status: 'CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY';
     notes?: string | null;
+    rating?: number | null;
   };
   collections?: CollectionReference[];
   collectionPrefix?: string | null;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -139,6 +139,10 @@ export class ApiService {
     return this.pieceService.updatePieceNotes(pieceId, notes);
   }
 
+  updatePieceRating(pieceId: number, rating: number | null): Observable<any> {
+    return this.pieceService.updatePieceRating(pieceId, rating);
+  }
+
   getPieceNotes(pieceId: number) {
     return this.pieceService.getPieceNotes(pieceId);
   }

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -60,6 +60,10 @@ export class PieceService {
     return this.http.put(`${this.apiUrl}/repertoire/notes`, { pieceId, notes });
   }
 
+  updatePieceRating(pieceId: number, rating: number | null): Observable<any> {
+    return this.http.put(`${this.apiUrl}/repertoire/rating`, { pieceId, rating });
+  }
+
   getPieceNotes(pieceId: number) {
     return this.http.get(`${this.apiUrl}/repertoire/${pieceId}/notes`);
   }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -141,6 +141,20 @@
             </ng-container>
 
             <!-- Status Column (Not sortable in this example) -->
+            <!-- Rating Column -->
+            <ng-container matColumnDef="rating">
+              <th mat-header-cell *matHeaderCellDef> Bewertung </th>
+              <td mat-cell *matCellDef="let piece">
+                <mat-select [value]="piece.choir_repertoire?.rating"
+                            (selectionChange)="onRatingChange($event.value, piece.id)"
+                            (click)="$event.stopPropagation()" [disabled]="!canRate">
+                  <mat-option [value]="null">-</mat-option>
+                  <mat-option *ngFor="let r of [1,2,3,4,5]" [value]="r">{{ r }}</mat-option>
+                </mat-select>
+              </td>
+            </ng-container>
+
+            <!-- Status Column (Not sortable in this example) -->
             <ng-container matColumnDef="status">
               <th mat-header-cell *matHeaderCellDef> Status </th>
               <td mat-cell *matCellDef="let piece">

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.html
@@ -69,6 +69,14 @@
     </mat-select>
   </p>
 
+  <p>
+    <strong>Bewertung:</strong>
+    <mat-select [value]="piece.choir_repertoire?.rating" (selectionChange)="onRatingChange($event.value)" [disabled]="!canRate">
+      <mat-option [value]="null">-</mat-option>
+      <mat-option *ngFor="let r of [1,2,3,4,5]" [value]="r">{{ r }}</mat-option>
+    </mat-select>
+  </p>
+
   <h3>Notizen</h3>
   <div class="note" *ngFor="let n of piece.notes">
     <mat-card>

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -37,6 +37,7 @@ export class PieceDetailComponent implements OnInit {
   editState: { [id: number]: string } = {};
   userId: number | null = null;
   isAdmin = false;
+  canRate = false;
   pieceImage: string | null = null;
   fileLinks: (PieceLink & { isPdf: boolean; size?: number })[] = [];
   externalLinks: PieceLink[] = [];
@@ -59,6 +60,10 @@ export class PieceDetailComponent implements OnInit {
     });
     this.auth.currentUser$.subscribe(u => this.userId = u?.id || null);
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
+    this.auth.currentUser$.subscribe(u => {
+      const roles = u?.roles || [];
+      this.canRate = roles.includes('director') || roles.includes('choir_admin') || roles.includes('admin');
+    });
     this.loadLibraryItems();
   }
 
@@ -95,6 +100,15 @@ export class PieceDetailComponent implements OnInit {
       if (!this.piece) return;
       this.piece.choir_repertoire = this.piece.choir_repertoire || { status: 'CAN_BE_SUNG' };
       this.piece.choir_repertoire.status = newStatus as any;
+    });
+  }
+
+  onRatingChange(newRating: number | null): void {
+    if (!this.piece) return;
+    this.apiService.updatePieceRating(this.piece.id, newRating).subscribe(() => {
+      if (!this.piece) return;
+      this.piece.choir_repertoire = this.piece.choir_repertoire || { status: 'CAN_BE_SUNG' };
+      this.piece.choir_repertoire.rating = newRating ?? null;
     });
   }
 

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.html
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.html
@@ -5,6 +5,7 @@
   <ul>
     <li *ngFor="let p of results.pieces">
       <a [routerLink]="['/pieces', p.id]">{{ p.title }}</a>
+      <span *ngIf="p.choir_repertoire?.rating"> (Bewertung: {{ p.choir_repertoire.rating }})</span>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
## Summary
- allow choirs to store a 1-5 rating for each piece and expose update endpoint for directors and above
- show and edit ratings in repertoire lists, piece detail pages, and search results
- include rating support in search and enforce director-or-higher permissions

## Testing
- `npm test` (backend)
- `npm test` *(frontend: missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a38ac8d1fc8320a7dea8c8f10ad84b