### PR TITLE
Add license filtering and usage hints

### DIFF
--- a/choir-app-backend/src/controllers/piece.controller.js
+++ b/choir-app-backend/src/controllers/piece.controller.js
@@ -3,6 +3,7 @@ const Piece = db.piece;
 const Composer = db.composer;
 const Category = db.category;
 const Author = db.author;
+const { Op } = require('sequelize');
 const path = require('path');
 const fs = require('fs/promises');
 const fileService = require('../services/file.service');
@@ -93,10 +94,14 @@ exports.create = async (req, res) => {
  * when adding pieces to a collection.
  */
 exports.findAll = async (req, res) => {
-    const { composerId, authorId } = req.query;
+    const { composerId, authorId, license } = req.query;
     const where = {};
     if (composerId) where.composerId = composerId;
     if (authorId) where.authorId = authorId;
+    if (license) {
+        const licenses = Array.isArray(license) ? license : String(license).split(',');
+        where.license = { [Op.in]: licenses };
+    }
 
     const pieces = await base.service.findAll({
             where,

--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -79,7 +79,7 @@ exports.lookup = async (req, res) => {
 
 
 exports.findMyRepertoire = async (req, res) => {
-    const { composerId, categoryId, categoryIds, collectionId, collectionIds, sortBy, sortDir = 'ASC', status, page = 1, limit = 25, voicing, key, search } = req.query;
+    const { composerId, categoryId, categoryIds, collectionId, collectionIds, sortBy, sortDir = 'ASC', status, page = 1, limit = 25, voicing, key, search, license } = req.query;
     let parsedStatuses = [];
     if (status) {
         parsedStatuses = Array.isArray(status) ? status : String(status).split(',');
@@ -99,6 +99,11 @@ exports.findMyRepertoire = async (req, res) => {
         parsedCollectionIds = [collectionId];
     }
     parsedCollectionIds = parsedCollectionIds.map(id => parseInt(id, 10)).filter(id => !isNaN(id));
+
+    let parsedLicenses = [];
+    if (license) {
+        parsedLicenses = Array.isArray(license) ? license : String(license).split(',');
+    }
     const pageNum = parseInt(page, 10) || 1;
     const limitNum = parseInt(limit, 10) || 25;
     const offset = (pageNum - 1) * limitNum;
@@ -132,6 +137,7 @@ exports.findMyRepertoire = async (req, res) => {
             ...(parsedCategoryIds.length && { categoryId: { [Op.in]: parsedCategoryIds } }),
             ...(voicing && { voicing: { [Op.iLike]: `%${voicing}%` } }), // Case-insensitive search
             ...(key && { key }),
+            ...(parsedLicenses.length && { license: { [Op.in]: parsedLicenses } }),
         };
 
         if (search) {

--- a/choir-app-frontend/src/app/core/models/repertoire-filter.ts
+++ b/choir-app-frontend/src/app/core/models/repertoire-filter.ts
@@ -22,5 +22,6 @@ export interface RepertoireFilter {
      */
     statuses?: ('CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY')[];
     search?: string;
+    licenses?: string[];
   };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -106,7 +106,8 @@ export class ApiService {
     limit: number = 25,
     statuses?: string[],
     sortDir: 'ASC' | 'DESC' = 'ASC',
-    search?: string
+    search?: string,
+    licenses?: string[]
   ): Observable<{ data: Piece[]; total: number }> {
     // composerId not yet supported by PieceService, pass as part of search/filter when implemented
     return this.pieceService.getMyRepertoire(
@@ -117,7 +118,8 @@ export class ApiService {
       limit,
       statuses,
       sortDir,
-      search
+      search,
+      licenses
     );
   }
 
@@ -164,7 +166,7 @@ export class ApiService {
    * Gets the master list of all pieces in the system, independent of any choir.
    * Useful for lookups when creating collections.
    */
-  getGlobalPieces(filters?: { composerId?: number; authorId?: number }): Observable<Piece[]> {
+  getGlobalPieces(filters?: { composerId?: number; authorId?: number; license?: string[] }): Observable<Piece[]> {
     return this.pieceService.getGlobalPieces(filters);
   }
 

--- a/choir-app-frontend/src/app/core/services/piece.service.ts
+++ b/choir-app-frontend/src/app/core/services/piece.service.ts
@@ -32,7 +32,8 @@ export class PieceService {
     limit = 25,
     statuses?: string[],
     sortDir: 'ASC' | 'DESC' = 'ASC',
-    search?: string
+    search?: string,
+    licenses?: string[]
   ): Observable<{ data: Piece[]; total: number }> {
     let params = new HttpParams();
     if (categoryIds && categoryIds.length > 0) {
@@ -48,6 +49,7 @@ export class PieceService {
     params = params.set('sortDir', sortDir || 'ASC');
     if (statuses && statuses.length) params = params.set('status', statuses.join(','));
     if (search) params = params.set('search', search);
+    if (licenses && licenses.length) params = params.set('license', licenses.join(','));
 
     return this.http.get<{ data: Piece[]; total: number }>(`${this.apiUrl}/repertoire`, { params });
   }
@@ -76,13 +78,16 @@ export class PieceService {
     return this.http.delete(`${this.apiUrl}/repertoire/notes/${noteId}`);
   }
 
-  getGlobalPieces(filters?: { composerId?: number; authorId?: number }): Observable<Piece[]> {
+  getGlobalPieces(filters?: { composerId?: number; authorId?: number; license?: string[] }): Observable<Piece[]> {
     let params = new HttpParams();
     if (filters?.composerId) {
       params = params.set('composerId', filters.composerId.toString());
     }
     if (filters?.authorId) {
       params = params.set('authorId', filters.authorId.toString());
+    }
+    if (filters?.license && filters.license.length) {
+      params = params.set('license', filters.license.join(','));
     }
     return this.http.get<Piece[]>(`${this.apiUrl}/pieces`, { params });
   }

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -24,6 +24,13 @@
         </mat-select>
       </mat-form-field>
       <mat-form-field appearance="outline">
+        <mat-label>Lizenz</mat-label>
+        <mat-select multiple [value]="filterByLicense$.value" (selectionChange)="onLicenseFilterChange($event.value)">
+          <mat-option *ngFor="let lic of licenseOptions" [value]="lic.type">{{lic.label}}</mat-option>
+        </mat-select>
+        <mat-hint *ngIf="filterByLicense$.value.length === 1">{{licenseHintMap[filterByLicense$.value[0]]}}</mat-hint>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
         <mat-label>Status</mat-label>
         <mat-select multiple [value]="status$.value" (selectionChange)="onStatusFilterChange($event.value)">
           <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -38,6 +38,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   private refresh$ = new BehaviorSubject<void>(undefined);
   public filterByCollectionIds$ = new BehaviorSubject<number[]>([]);
   public filterByCategoryIds$ = new BehaviorSubject<number[]>([]);
+  public filterByLicense$ = new BehaviorSubject<string[]>([]);
   public status$ = new BehaviorSubject<('CAN_BE_SUNG' | 'IN_REHEARSAL' | 'NOT_READY')[]>([]);
   public searchControl = new FormControl('');
   public filtersExpanded = false;
@@ -46,6 +47,20 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
   // --- Observables for filter display ---
   public collections$!: Observable<Collection[]>;
   public categories$!: Observable<Category[]>;
+  public licenseOptions = [
+    { type: 'CC0', label: 'CC0' },
+    { type: 'CC-BY', label: 'CC BY' },
+    { type: 'CC-BY-SA', label: 'CC BY-SA' },
+    { type: 'CC-BY-NC', label: 'CC BY-NC' },
+    { type: 'CC-BY-ND', label: 'CC BY-ND' }
+  ];
+  public licenseHintMap: Record<string, string> = {
+    'CC0': 'Keine Rechte vorbehalten',
+    'CC-BY': 'Namensnennung erforderlich',
+    'CC-BY-SA': 'Weitergabe unter gleichen Bedingungen',
+    'CC-BY-NC': 'Keine kommerzielle Nutzung',
+    'CC-BY-ND': 'Keine Bearbeitungen'
+  };
 
   // --- Table, Paginator, and Sort Logic ---
   public displayedColumns: string[] = [];
@@ -138,6 +153,9 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         } else if (s.status !== undefined && s.status !== null) {
           this.status$.next([s.status]);
         }
+        if (s.licenses !== undefined) {
+          this.filterByLicense$.next(s.licenses);
+        }
         if (s.search !== undefined) this.searchControl.setValue(s.search, { emitEvent: false });
         if (
           (s.collectionIds && s.collectionIds.length) ||
@@ -145,7 +163,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
           (s.categoryIds && s.categoryIds.length) ||
           (s as any).categoryId ||
           (Array.isArray(s.statuses) && s.statuses.length) ||
-          s.status
+          s.status ||
+          (s.licenses && s.licenses.length)
         ) {
           this.filtersExpanded = true;
         }
@@ -171,7 +190,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     const page$ = this._paginator.page.pipe(tap(e => this.paginatorService.setPageSize('literature-list', e.pageSize)));
     const search$ = this.searchControl.valueChanges.pipe(startWith(this.searchControl.value || ''));
 
-    merge(this.refresh$, this.filterByCollectionIds$, this.filterByCategoryIds$, this.status$, sort$, page$, search$)
+    merge(this.refresh$, this.filterByCollectionIds$, this.filterByCategoryIds$, this.status$, this.filterByLicense$, sort$, page$, search$)
       .pipe(
         startWith({}),
         tap(() => {
@@ -200,7 +219,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
             this._paginator.pageSize,
             statuses,
             dir,
-            this.searchControl.value || undefined
+            this.searchControl.value || undefined,
+            this.filterByLicense$.value.length ? this.filterByLicense$.value : undefined
           ).pipe(
             catchError((err) => {
               const msg = err.error?.message || 'Could not load repertoire.';
@@ -236,6 +256,7 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
       this.filterByCollectionIds$.value.join(','),
       this.filterByCategoryIds$.value.join(','),
       this.status$.value.join(','),
+      this.filterByLicense$.value.join(','),
       this.searchControl.value,
       this._sort.active,
       this._sort.direction
@@ -327,10 +348,20 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     this.refresh$.next();
   }
 
+  onLicenseFilterChange(licenses: string[]): void {
+    if (this._paginator) {
+      this._paginator.firstPage();
+    }
+    this.filterByLicense$.next(licenses);
+    this.saveFilters();
+    this.refresh$.next();
+  }
+
   clearFilters(): void {
     this.filterByCollectionIds$.next([]);
     this.filterByCategoryIds$.next([]);
     this.status$.next([]);
+    this.filterByLicense$.next([]);
     this.searchControl.setValue('', { emitEvent: false });
     this.filtersExpanded = false;
     this.pageCache.clear();
@@ -346,13 +377,15 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
       collectionIds: this.filterByCollectionIds$.value,
       categoryIds: this.filterByCategoryIds$.value,
       statuses: this.status$.value,
-      search: this.searchControl.value
+      search: this.searchControl.value,
+      licenses: this.filterByLicense$.value
     };
     localStorage.setItem(this.FILTER_KEY, JSON.stringify(state));
     this.filtersExpanded = !!(
       (state.collectionIds && state.collectionIds.length) ||
       (state.categoryIds && state.categoryIds.length) ||
-      (state.statuses && state.statuses.length)
+      (state.statuses && state.statuses.length) ||
+      (state.licenses && state.licenses.length)
     );
   }
 
@@ -483,6 +516,11 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
     } else if (preset.data.status !== undefined && preset.data.status !== null) {
       this.status$.next([preset.data.status]);
     }
+    if (Array.isArray((preset.data as any).licenses)) {
+      this.filterByLicense$.next((preset.data as any).licenses);
+    } else {
+      this.filterByLicense$.next([]);
+    }
     this.searchControl.setValue(preset.data.search || '', { emitEvent: false });
     const singleId = (preset.data as any).categoryId;
     this.filtersExpanded = !!(
@@ -491,7 +529,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
       (preset.data.categoryIds && preset.data.categoryIds.length) ||
       singleId ||
       (Array.isArray(preset.data.statuses) && preset.data.statuses.length) ||
-      preset.data.status
+      preset.data.status ||
+      ((preset.data as any).licenses && (preset.data as any).licenses.length)
     );
     if (this._paginator) {
       this._paginator.firstPage();
@@ -511,7 +550,8 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
         collectionIds: this.filterByCollectionIds$.value,
         categoryIds: this.filterByCategoryIds$.value,
         statuses: this.status$.value,
-        search: this.searchControl.value
+        search: this.searchControl.value,
+        licenses: this.filterByLicense$.value
       };
       this.apiService.saveRepertoireFilter({ name: result.name, data, visibility: result.visibility }).subscribe(() => this.loadPresets());
     });

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -68,6 +68,15 @@
                 <input matInput formControlName="origin">
               </mat-form-field>
 
+              <mat-form-field appearance="outline">
+                <mat-label>Lizenz</mat-label>
+                <mat-select formControlName="license" (selectionChange)="onLicenseChange($event.value)">
+                  <mat-option value=""></mat-option>
+                  <mat-option *ngFor="let lic of licenseOptions" [value]="lic.type">{{lic.label}}</mat-option>
+                </mat-select>
+                <mat-hint *ngIf="licenseHint">{{licenseHint}}</mat-hint>
+              </mat-form-field>
+
             </div>
           </ng-container>
 

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -68,6 +68,22 @@ export class PieceDialogComponent implements OnInit {
     isDragOver = false;
     removedLinkPaths: string[] = [];
 
+    licenseOptions = [
+        { type: 'CC0', label: 'CC0' },
+        { type: 'CC-BY', label: 'CC BY' },
+        { type: 'CC-BY-SA', label: 'CC BY-SA' },
+        { type: 'CC-BY-NC', label: 'CC BY-NC' },
+        { type: 'CC-BY-ND', label: 'CC BY-ND' }
+    ];
+    licenseHintMap: Record<string, string> = {
+        'CC0': 'Keine Rechte vorbehalten',
+        'CC-BY': 'Namensnennung erforderlich',
+        'CC-BY-SA': 'Weitergabe unter gleichen Bedingungen',
+        'CC-BY-NC': 'Keine kommerzielle Nutzung',
+        'CC-BY-ND': 'Keine Bearbeitungen'
+    };
+    licenseHint: string | null = null;
+
     composerCtrl = new FormControl<string | Composer>('');
     filteredComposers$!: Observable<(Composer & { isNew?: boolean })[]>;
     allComposers: Composer[] = [];
@@ -158,6 +174,7 @@ export class PieceDialogComponent implements OnInit {
                 .getPieceById(this.data.pieceId)
                 .subscribe((piece) => {
                     this.populateForm(piece);
+                    this.onLicenseChange(this.pieceForm.get('license')?.value);
                 });
         }
     }
@@ -434,6 +451,7 @@ export class PieceDialogComponent implements OnInit {
             lyrics: piece.lyrics,
             lyricsSource: piece.lyricsSource,
         });
+        this.onLicenseChange(piece.license || '');
 
         if (piece.composer) {
             const found = this.allComposers.find(c => c.id === piece.composer!.id);
@@ -460,6 +478,10 @@ export class PieceDialogComponent implements OnInit {
                 })
             );
         });
+    }
+
+    onLicenseChange(license: string): void {
+        this.licenseHint = this.licenseHintMap[license] || null;
     }
 
     onCancel(): void {


### PR DESCRIPTION
## Summary
- allow filtering repertoire and pieces by license on the backend
- expose license filters and hints in front-end services and UI
- provide license selection with usage guidance when editing pieces

## Testing
- `npm test` (backend)
- `npm test` *(failed: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f1ba9a883208a793fe973d1aff9