### PR TITLE
Add global statistics mode

### DIFF
--- a/choir-app-frontend/src/app/core/models/stats-summary.ts
+++ b/choir-app-frontend/src/app/core/models/stats-summary.ts
@@ -10,4 +10,6 @@ export interface StatsSummary {
   leastUsedPieces: PieceStat[];
   singableCount: number;
   rehearsalCount: number;
+  globalAvailable: boolean;
+  isGlobal: boolean;
 }

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -118,7 +118,7 @@ export class AdminService {
     return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
   }
 
-  getStatistics(startDate?: Date | string, endDate?: Date | string, activeMonths?: number): Observable<StatsSummary> {
+  getStatistics(startDate?: Date | string, endDate?: Date | string, activeMonths?: number, global?: boolean): Observable<StatsSummary> {
     const params: any = {};
     if (startDate) {
       params.startDate = startDate instanceof Date ? startDate.toISOString() : startDate;
@@ -128,6 +128,9 @@ export class AdminService {
     }
     if (activeMonths !== undefined) {
       params.activeMonths = activeMonths;
+    }
+    if (global) {
+      params.global = true;
     }
     return this.http.get<StatsSummary>(`${this.apiUrl}/stats`, { params });
   }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -739,8 +739,8 @@ export class ApiService {
     return this.adminService.checkChoirAdminStatus();
   }
 
-  getStatistics(startDate?: Date, endDate?: Date, activeMonths?: number): Observable<StatsSummary> {
-    return this.adminService.getStatistics(startDate, endDate, activeMonths);
+  getStatistics(startDate?: Date, endDate?: Date, activeMonths?: number, global?: boolean): Observable<StatsSummary> {
+    return this.adminService.getStatistics(startDate, endDate, activeMonths, global);
   }
 
   pingBackend(): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -23,9 +23,13 @@
     <button mat-raised-button color="primary" (click)="loadStats()">Statistik laden</button>
   </div>
 
+  <div class="mode-toggle" *ngIf="stats?.globalAvailable">
+    <mat-slide-toggle [(ngModel)]="globalMode" (change)="onModeChange()">Global</mat-slide-toggle>
+  </div>
+
   <ng-container *ngIf="stats">
     <mat-card>
-      <h3>Top 3 Gottesdienst-Stücke</h3>
+      <h3>Top 3 Gottesdienst-Stücke{{ globalMode ? ' (global)' : '' }}</h3>
       <ol>
         <li *ngFor="let item of stats.topServicePieces">
           <a [routerLink]="['/pieces', item.id]">{{ item.title }}</a> ({{ item.count }}x)
@@ -34,7 +38,7 @@
     </mat-card>
 
     <mat-card>
-      <h3>Meist geprobte Stücke</h3>
+      <h3>Meist geprobte Stücke{{ globalMode ? ' (global)' : '' }}</h3>
       <ol>
         <li *ngFor="let item of stats.topRehearsalPieces">
           <a [routerLink]="['/pieces', item.id]">{{ item.title }}</a> ({{ item.count }}x)
@@ -57,7 +61,7 @@
       <p>Probe: {{ stats.rehearsalCount }}</p>
     </mat-card>
 
-    <mat-card class="table-card">
+    <mat-card class="table-card" *ngIf="!globalMode">
       <mat-card-header>
         <mat-card-title>Probe</mat-card-title>
       </mat-card-header>

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.ts
@@ -26,21 +26,31 @@ export class StatisticsComponent implements OnInit {
   startDate?: Date;
   endDate?: Date;
   activeMonths?: number;
+  globalMode = false;
 
 
   constructor(private apiService: ApiService) {}
 
   ngOnInit(): void {
     this.loadStats();
-    this.loadRehearsalPieces();
   }
 
   loadStats(): void {
-    this.apiService.getStatistics(this.startDate, this.endDate, this.activeMonths)
+    this.apiService.getStatistics(this.startDate, this.endDate, this.activeMonths, this.globalMode)
       .subscribe(s => {
-      this.stats = s;
-      this.leastUsedPieces = s.leastUsedPieces;
-    });
+        this.stats = s;
+        this.leastUsedPieces = s.leastUsedPieces;
+        this.globalMode = s.isGlobal;
+        if (!this.globalMode) {
+          this.loadRehearsalPieces();
+        } else {
+          this.rehearsalDataSource.data = [];
+        }
+      });
+  }
+
+  onModeChange(): void {
+    this.loadStats();
   }
 
   private loadRehearsalPieces(): void {


### PR DESCRIPTION
## Summary
- allow querying statistics across all choirs when more than three exist
- expose global statistics toggle in frontend and show aggregated Top 3 lists

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f5dde2c8320b126682391683485