### PR TITLE
feat: add dynamic singer help

### DIFF
--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
@@ -10,7 +10,12 @@
     </mat-step>
     <mat-step>
       <ng-template matStepLabel>Rollen</ng-template>
-      <p>Je nachdem in welcher Rolle du den Chorleiter benutzt, siehst du unterschiedliche Menüpunkte und kannst Funktionen nutzen. In der Rolle <strong>Chorleiter</strong> verwaltest du das Repertoire und kannst Ereignisse einsehen und anlegen. Als <strong>Choradministrator</strong> verwaltest du zusätzlich die Sammlungen und die Benutzer des Chores, also besitzt du fast alle Rechte au&szlig;erhalb des musikalischen Bereichs.</p>
+      <ng-container *ngIf="isSingerOnly$ | async; else otherRoles">
+        <p>Du nutzt den Chorleiter als <strong>Sänger</strong>. Dein Chorleiter kann dir je nach Bedarf verschiedene Bereiche freischalten.</p>
+      </ng-container>
+      <ng-template #otherRoles>
+        <p>Je nachdem in welcher Rolle du den Chorleiter benutzt, siehst du unterschiedliche Menüpunkte und kannst Funktionen nutzen. In der Rolle <strong>Chorleiter</strong> verwaltest du das Repertoire und kannst Ereignisse einsehen und anlegen. Als <strong>Choradministrator</strong> verwaltest du zusätzlich die Sammlungen und die Benutzer des Chores, also besitzt du fast alle Rechte au&szlig;erhalb des musikalischen Bereichs.</p>
+      </ng-template>
       <div>
         <button mat-button matStepperPrevious>Zur&uuml;ck</button>
         <button mat-flat-button color="primary" matStepperNext>Weiter</button>
@@ -18,14 +23,36 @@
     </mat-step>
     <mat-step>
       <ng-template matStepLabel>Navigation</ng-template>
-      <p>Im linken Men&uuml; findest du Dashboard, Ereignisse, Statistik, Mein Chor, Repertoire und Sammlungen.</p>
-      <p>Dort gelangst du zu allen wichtigen Funktionen der Anwendung. Die wichtigsten Funktionen sind die Ereignisse, um Daten zu Gottesdiensten und Proben einzugeben.</p>
+      <ng-container *ngIf="isSingerOnly$ | async; else otherNavigation">
+        <p>Im linken Men&uuml; findest du folgende Bereiche:</p>
+        <ul>
+          <li *ngIf="menuVisible('dashboard') | async">Dashboard</li>
+          <li *ngIf="menuVisible('dienstplan') | async">Dienstplan</li>
+          <li *ngIf="menuVisible('termine') | async">Meine Termine</li>
+          <li *ngIf="menuVisible('posts') | async">Beiträge</li>
+          <li *ngIf="menuVisible('repertoire') | async">Repertoire</li>
+          <li *ngIf="menuVisible('collections') | async">Sammlungen</li>
+          <li *ngIf="menuVisible('library') | async">Bibliothek</li>
+        </ul>
+      </ng-container>
+      <ng-template #otherNavigation>
+        <p>Im linken Men&uuml; findest du Dashboard, Ereignisse, Statistik, Mein Chor, Repertoire und Sammlungen.</p>
+        <p>Dort gelangst du zu allen wichtigen Funktionen der Anwendung. Die wichtigsten Funktionen sind die Ereignisse, um Daten zu Gottesdiensten und Proben einzugeben.</p>
+      </ng-template>
       <div>
         <button mat-button matStepperPrevious>Zur&uuml;ck</button>
         <button mat-flat-button color="primary" matStepperNext>Weiter</button>
       </div>
     </mat-step>
-    <mat-step>
+    <mat-step *ngIf="(isSingerOnly$ | async) && (menuVisible('termine') | async)">
+      <ng-template matStepLabel>Kalender</ng-template>
+      <p>Unter &bdquo;Meine Termine&ldquo; kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
+      <div>
+        <button mat-button matStepperPrevious>Zur&uuml;ck</button>
+        <button mat-flat-button color="primary" matStepperNext>Weiter</button>
+      </div>
+    </mat-step>
+    <mat-step *ngIf="!(isSingerOnly$ | async)">
       <ng-template matStepLabel>Kalender</ng-template>
       <p>Unter &bdquo;Meine Termine&ldquo; kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
       <div>

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HelpWizardComponent } from './help-wizard.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { AuthService } from '@core/services/auth.service';
+import { BehaviorSubject } from 'rxjs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('HelpWizardComponent', () => {
+  let component: HelpWizardComponent;
+  let fixture: ComponentFixture<HelpWizardComponent>;
+
+  beforeEach(async () => {
+    const authServiceMock = {
+      currentUser$: new BehaviorSubject<any>({ roles: ['singer'] }),
+      activeChoir$: new BehaviorSubject<any>({ modules: { singerMenu: { events: false } } })
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HelpWizardComponent, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: AuthService, useValue: authServiceMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HelpWizardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('hides menu items disabled for singers', (done) => {
+    component.menuVisible('events').subscribe(visible => {
+      expect(visible).toBeFalse();
+      done();
+    });
+  });
+});

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
@@ -3,6 +3,9 @@ import { CommonModule } from '@angular/common';
 import { MatDialogRef, MatDialogContent } from '@angular/material/dialog';
 import { MatStepperModule, MatStepper } from '@angular/material/stepper';
 import { MaterialModule } from '@modules/material.module';
+import { Observable, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { AuthService } from '@core/services/auth.service';
 
 @Component({
   selector: 'app-help-wizard',
@@ -14,7 +17,45 @@ import { MaterialModule } from '@modules/material.module';
 export class HelpWizardComponent {
   @ViewChild('content', { read: MatDialogContent }) content!: MatDialogContent;
   @ViewChild('stepper') stepper!: MatStepper;
-  constructor(public dialogRef: MatDialogRef<HelpWizardComponent>) {}
+
+  /**
+   * Emits true when the current user has only the singer role
+   * (no additional administrative roles).
+   */
+  isSingerOnly$: Observable<boolean>;
+
+  constructor(
+    public dialogRef: MatDialogRef<HelpWizardComponent>,
+    private auth: AuthService
+  ) {
+    this.isSingerOnly$ = combineLatest([
+      this.auth.currentUser$,
+      this.auth.activeChoir$
+    ]).pipe(
+      map(([user]) => {
+        const roles = Array.isArray(user?.roles) ? user!.roles : [];
+        return (
+          roles.includes('singer') &&
+          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r))
+        );
+      })
+    );
+  }
+
+  /**
+   * Returns whether a specific menu item is visible for singers based on choir configuration.
+   */
+  menuVisible(key: string): Observable<boolean> {
+    return combineLatest([this.isSingerOnly$, this.auth.activeChoir$]).pipe(
+      map(([isSingerOnly, choir]) => {
+        if (!isSingerOnly) {
+          return true;
+        }
+        const menu = choir?.modules?.singerMenu || {};
+        return menu[key] !== false;
+      })
+    );
+  }
 
   close(): void {
     this.dialogRef.close();


### PR DESCRIPTION
## Summary
- add role-aware help wizard that adapts to singer menu
- document available singer menu sections in help wizard
- test singer menu visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a625b2359883209a9688ff643d4da4