### PR TITLE
Add voice field to user profiles

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -88,7 +88,7 @@ exports.getAllUsers = async (req, res) => {
     try {
         const users = await db.user.findAll({
             order: [['name', 'ASC']],
-            attributes: ['id', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'shareWithChoir', 'lastDonation', 'lastLogin'],
+            attributes: ['id', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
             include: [{
                 model: db.choir,
                 as: 'choirs',
@@ -105,7 +105,7 @@ exports.getAllUsers = async (req, res) => {
 const bcrypt = require('bcryptjs');
 
 exports.createUser = async (req, res) => {
-    const { name, email, password, roles, street, postalCode, city, shareWithChoir } = req.body;
+    const { name, email, password, roles, street, postalCode, city, voice, shareWithChoir } = req.body;
     try {
         const user = await db.user.create({
             name,
@@ -115,6 +115,7 @@ exports.createUser = async (req, res) => {
             street,
             postalCode,
             city,
+            voice,
             shareWithChoir: !!shareWithChoir
         });
         res.status(201).send(user);
@@ -129,7 +130,7 @@ exports.createUser = async (req, res) => {
 
 exports.updateUser = async (req, res) => {
     const { id } = req.params;
-    const { name, email, password, roles, street, postalCode, city, shareWithChoir } = req.body;
+    const { name, email, password, roles, street, postalCode, city, voice, shareWithChoir } = req.body;
     try {
         const user = await db.user.findByPk(id);
         if (!user) return res.status(404).send({ message: 'Not found' });
@@ -140,6 +141,7 @@ exports.updateUser = async (req, res) => {
             street: street ?? user.street,
             postalCode: postalCode ?? user.postalCode,
             city: city ?? user.city,
+            voice: voice ?? user.voice,
             shareWithChoir: shareWithChoir !== undefined ? !!shareWithChoir : user.shareWithChoir,
             ...(password ? { password: bcrypt.hashSync(password, 8) } : {})
         });
@@ -168,7 +170,7 @@ exports.getUserByEmail = async (req, res) => {
     try {
         const user = await db.user.findOne({
             where: { email },
-            attributes: ['id', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'shareWithChoir', 'lastDonation', 'lastLogin'],
+            attributes: ['id', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
             include: [{
                 model: db.choir,
                 as: 'choirs',
@@ -254,7 +256,7 @@ exports.getChoirMembers = async (req, res) => {
             include: [{
                 model: db.user,
                 as: 'users',
-                attributes: ['id', 'name', 'email', 'street', 'postalCode', 'city', 'shareWithChoir'],
+                attributes: ['id', 'name', 'email', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir'],
                 through: { model: db.user_choir, attributes: ['rolesInChoir', 'registrationStatus'] }
             }],
             order: [[db.user, 'name', 'ASC']]
@@ -269,6 +271,7 @@ exports.getChoirMembers = async (req, res) => {
             street: u.street,
             postalCode: u.postalCode,
             city: u.city,
+            voice: u.voice,
             shareWithChoir: u.shareWithChoir,
             membership: {
                 rolesInChoir: u.user_choir.rolesInChoir,

--- a/choir-app-backend/src/controllers/auth.controller.js
+++ b/choir-app-backend/src/controllers/auth.controller.js
@@ -121,6 +121,7 @@ exports.signin = async (req, res) => {
       id: user.id,
       name: user.name,
       email: user.email,
+      voice: user.voice,
       roles: user.roles,
       accessToken: token,
       // Senden Sie die Liste aller Chöre und den aktuell aktiven

--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -94,7 +94,7 @@ exports.getChoirMembers = async (req, res, next) => {
             include: [{
                 model: db.user,
                 as: 'users',
-                attributes: ['id', 'name', 'email', 'street', 'postalCode', 'city', 'shareWithChoir'],
+                attributes: ['id', 'name', 'email', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir'],
                 // Wichtig: Holen Sie die Daten aus der Zwischentabelle.
                 through: {
                     model: db.user_choir,
@@ -115,6 +115,7 @@ exports.getChoirMembers = async (req, res, next) => {
                 id: user.id,
                 name: user.name,
                 email: user.email,
+                voice: user.voice,
                 membership: {
                     rolesInChoir: user.user_choir.rolesInChoir,
                     registrationStatus: user.user_choir.registrationStatus

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -6,7 +6,7 @@ const bcrypt = require("bcryptjs");
 exports.getMe = async (req, res) => {
     try {
         const user = await User.findByPk(req.userId, {
-            attributes: ['id', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'shareWithChoir'],
+            attributes: ['id', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir'],
             include: [{
                 model: Choir,
                 as: 'choirs', // Use the plural alias 'choirs' defined in the association
@@ -28,7 +28,7 @@ exports.getMe = async (req, res) => {
  * @description Update the profile of the currently logged-in user.
  */
 exports.updateMe = async (req, res) => {
-     const { name, email, street, postalCode, city, shareWithChoir, oldPassword, newPassword, roles } = req.body;
+     const { name, email, street, postalCode, city, voice, shareWithChoir, oldPassword, newPassword, roles } = req.body;
 
     try {
         const user = await User.findByPk(req.userId);
@@ -52,6 +52,9 @@ exports.updateMe = async (req, res) => {
         }
         if (city !== undefined) {
             updateData.city = city;
+        }
+        if (voice !== undefined) {
+            updateData.voice = voice;
         }
         if (shareWithChoir !== undefined) {
             updateData.shareWithChoir = !!shareWithChoir;

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -45,6 +45,10 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: true
       },
+      voice: {
+        type: DataTypes.ENUM('Sopran I', 'Sopran II', 'Alt I', 'Alt II', 'Tenor I', 'Tenor II', 'Bass I', 'Bass II'),
+        allowNull: true
+      },
       shareWithChoir: {
         type: DataTypes.BOOLEAN,
         allowNull: false,

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -17,7 +17,7 @@ const db = require('../src/models');
       }
     }
 
-    checkFields(db.user, ['email', 'roles', 'lastDonation', 'preferences', 'street', 'postalCode', 'city', 'shareWithChoir']);
+    checkFields(db.user, ['email', 'roles', 'lastDonation', 'preferences', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir']);
     checkFields(db.choir, ['name', 'modules', 'joinHash']);
     checkFields(db.piece, ['title']);
     checkFields(db.event, ['date', 'type', 'organistId', 'finalized', 'version', 'monthlyPlanId']);

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -23,6 +23,7 @@ export interface User {
   street?: string;
   postalCode?: string;
   city?: string;
+  voice?: string;
   shareWithChoir?: boolean;
 
 

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -460,7 +460,7 @@ export class ApiService {
     return this.userService.getCurrentUser();
   }
 
-  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.userService.updateCurrentUser(profileData);
   }
 

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -21,6 +21,20 @@
       <mat-label>Ort</mat-label>
       <input matInput formControlName="city">
     </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Stimmlage</mat-label>
+      <mat-select formControlName="voice">
+        <mat-option value="">-</mat-option>
+        <mat-option value="Sopran I">Sopran I</mat-option>
+        <mat-option value="Sopran II">Sopran II</mat-option>
+        <mat-option value="Alt I">Alt I</mat-option>
+        <mat-option value="Alt II">Alt II</mat-option>
+        <mat-option value="Tenor I">Tenor I</mat-option>
+        <mat-option value="Tenor II">Tenor II</mat-option>
+        <mat-option value="Bass I">Bass I</mat-option>
+        <mat-option value="Bass II">Bass II</mat-option>
+      </mat-select>
+    </mat-form-field>
     <mat-checkbox formControlName="shareWithChoir">Daten für Chorleiter freigeben</mat-checkbox>
     <mat-form-field appearance="outline">
       <mat-label>Passwort</mat-label>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -28,6 +28,7 @@ export class UserDialogComponent {
       street: [data?.street || ''],
       postalCode: [data?.postalCode || ''],
       city: [data?.city || ''],
+      voice: [data?.voice || ''],
       shareWithChoir: [data?.shareWithChoir || false],
       roles: [data?.roles || ['director'], Validators.required],
       password: ['', data ? [] : [Validators.required]]

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -7,7 +7,7 @@
 
     <ng-container matColumnDef="voice">
       <th mat-header-cell *matHeaderCellDef>Stimme</th>
-      <td mat-cell *matCellDef="let m">{{ m.membership?.rolesInChoir?.join(', ') || '-' }}</td>
+      <td mat-cell *matCellDef="let m">{{ m.voice || '-' }}</td>
     </ng-container>
 
     <ng-container matColumnDef="email">

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -41,6 +41,21 @@
             <input matInput formControlName="city">
           </mat-form-field>
 
+          <mat-form-field appearance="outline">
+            <mat-label>Stimmlage</mat-label>
+            <mat-select formControlName="voice">
+              <mat-option value="">-</mat-option>
+              <mat-option value="Sopran I">Sopran I</mat-option>
+              <mat-option value="Sopran II">Sopran II</mat-option>
+              <mat-option value="Alt I">Alt I</mat-option>
+              <mat-option value="Alt II">Alt II</mat-option>
+              <mat-option value="Tenor I">Tenor I</mat-option>
+              <mat-option value="Tenor II">Tenor II</mat-option>
+              <mat-option value="Bass I">Bass I</mat-option>
+              <mat-option value="Bass II">Bass II</mat-option>
+            </mat-select>
+          </mat-form-field>
+
           <mat-checkbox formControlName="shareWithChoir">Erlaube Nutzung meiner Daten für Chorleiter</mat-checkbox>
         </mat-card-content>
       </mat-card>

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -48,6 +48,7 @@ export class ProfileComponent implements OnInit {
       street: [''],
       postalCode: [''],
       city: [''],
+      voice: [''],
       shareWithChoir: [false],
       roles: [{ value: [], disabled: true }],
       passwords: this.fb.group({
@@ -69,6 +70,7 @@ export class ProfileComponent implements OnInit {
           street: user.street || '',
           postalCode: user.postalCode || '',
           city: user.city || '',
+          voice: user.voice || '',
           shareWithChoir: !!user.shareWithChoir,
           roles: user.roles || []
         });
@@ -90,12 +92,13 @@ export class ProfileComponent implements OnInit {
     }
 
     const formValue = this.profileForm.value;
-    const updatePayload: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] } = {
+    const updatePayload: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] } = {
       name: formValue.name,
       email: formValue.email,
       street: formValue.street,
       postalCode: formValue.postalCode,
       city: formValue.city,
+      voice: formValue.voice,
       shareWithChoir: formValue.shareWithChoir
     };
 


### PR DESCRIPTION
## Summary
- extend user model with `voice` and expose it in auth, user and admin endpoints
- allow directors and admins to edit a singer's voice in profile and user dialog
- display selected voice in choir member lists

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a6268c3fd8832086965cba242f7ba3