### PR TITLE
feat: show member availability overview

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -122,6 +122,15 @@
     <div>
       <h3>Meine Verfügbarkeiten</h3>
       <app-availability-table [year]="selectedYear" [month]="selectedMonth"></app-availability-table>
+      <div *ngIf="isChoirAdmin" class="member-availabilities">
+        <h3>Verfügbarkeiten aller Mitglieder</h3>
+        <div *ngFor="let ev of entries">
+          <h4>{{ ev.date | date:'EEE dd.MM.yyyy' }}</h4>
+          <p><strong>verfügbar:</strong> {{ membersByAvailability(ev.date, 'AVAILABLE').map(m => m.name).join(', ') || '—' }}</p>
+          <p><strong>nach Absprache:</strong> {{ membersByAvailability(ev.date, 'MAYBE').map(m => m.name).join(', ') || '—' }}</p>
+          <p><strong>nicht verfügbar:</strong> {{ membersByAvailability(ev.date, 'UNAVAILABLE').map(m => m.name).join(', ') || '—' }}</p>
+        </div>
+      </div>
     </div>
   </mat-tab>
 </mat-tab-group>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -100,6 +100,11 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     return list.filter(u => this.isAvailable(u.id, date));
   }
 
+  membersByAvailability(date: string, status: string): UserInChoir[] {
+    const key = this.dateKey(date);
+    return this.members.filter(m => (this.availabilityMap[m.id]?.[key] || 'AVAILABLE') === status);
+  }
+
   private updateCounterPlan(): void {
     const dateMap = new Map<string, string>();
     for (const e of this.entries) {


### PR DESCRIPTION
## Summary
- display all members' availability per plan date for choir admins
- expose helper to filter members by availability status

## Testing
- `npm test` *(fails: ChromeHeadless failed to start)*
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_68a6262c3bfc832091918c12a730e78a