### PR TITLE
Refactor monthly plan availability display

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -126,9 +126,9 @@
         <h3>Verfügbarkeiten aller Mitglieder</h3>
         <div *ngFor="let ev of entries">
           <h4>{{ ev.date | date:'EEE dd.MM.yyyy' }}</h4>
-          <p><strong>verfügbar:</strong> {{ membersByAvailability(ev.date, 'AVAILABLE').map(m => m.name).join(', ') || '—' }}</p>
-          <p><strong>nach Absprache:</strong> {{ membersByAvailability(ev.date, 'MAYBE').map(m => m.name).join(', ') || '—' }}</p>
-          <p><strong>nicht verfügbar:</strong> {{ membersByAvailability(ev.date, 'UNAVAILABLE').map(m => m.name).join(', ') || '—' }}</p>
+          <p><strong>verfügbar:</strong> {{ memberNamesByAvailability(ev.date, 'AVAILABLE') }}</p>
+          <p><strong>nach Absprache:</strong> {{ memberNamesByAvailability(ev.date, 'MAYBE') }}</p>
+          <p><strong>nicht verfügbar:</strong> {{ memberNamesByAvailability(ev.date, 'UNAVAILABLE') }}</p>
         </div>
       </div>
     </div>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -105,6 +105,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     return this.members.filter(m => (this.availabilityMap[m.id]?.[key] || 'AVAILABLE') === status);
   }
 
+  memberNamesByAvailability(date: string, status: string): string {
+    return this.membersByAvailability(date, status).map(m => m.name).join(', ') || '—';
+  }
+
   private updateCounterPlan(): void {
     const dateMap = new Map<string, string>();
     for (const e of this.entries) {


### PR DESCRIPTION
## Summary
- extract `memberNamesByAvailability` helper in monthly plan component
- simplify availability list template to avoid arrow functions

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d15ff108320a99f9ba021c2df46