### PR TITLE
fix: ignore future events in dashboard

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -113,8 +113,9 @@ exports.create = async (req, res) => {
 
 
 /**
- * @description Findet das letzte Event eines bestimmten Typs für den eingeloggten Chor.
- * Dies ist die korrigierte Funktion für das Dashboard.
+ * @description Findet das letzte bereits stattgefundene Event eines bestimmten Typs
+ * für den eingeloggten Chor. Zukünftige Termine werden ignoriert, damit das
+ * Dashboard nicht versehentlich kommende Ereignisse als "letzten" Termin anzeigt.
  */
 exports.findLast = async (req, res) => {
     const { type } = req.query;
@@ -123,10 +124,14 @@ exports.findLast = async (req, res) => {
         return res.status(400).send({ message: "Event type is required." });
     }
 
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+
     const lastEvent = await Event.findOne({
             where: {
                 choirId: req.activeChoirId,
-                type: type.toUpperCase()
+                type: type.toUpperCase(),
+                date: { [Op.lt]: startOfToday }
             },
             order: [['date', 'DESC']],
             // --- DIE ANPASSUNG IST HIER ---

--- a/choir-app-backend/tests/event.controller.test.js
+++ b/choir-app-backend/tests/event.controller.test.js
@@ -75,6 +75,11 @@ const controller = require('../src/controllers/event.controller');
     const ids = res.data.map(e => e.id);
     assert.ok(ids.includes(futureId));
     assert.ok(!ids.includes(res.data.find(e => e.id !== futureId)?.id || false));
+
+    // --- Last event tests ---
+    await controller.findLast({ ...baseReq, query: { type: 'SERVICE' } }, res);
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.data.id, updateId);
     await db.sequelize.close();
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- ignore upcoming events when fetching last event for dashboard
- add regression test for last event handling

## Testing
- `npm run check-backend`
- `node tests/event.controller.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a630e16b14832099f59deb0156513c