### PR TITLE
Disable event creation for singers on dashboard

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
   <h1 *ngIf="(activeChoir$ | async)?.name as name">
     Willkommen bei {{ name }}
   </h1>
-  <button mat-icon-button color="primary" (click)="openAddEventDialog()" matTooltip="Neues Ereignis erstellen">
+  <button *ngIf="!(isSingerOnly$ | async)" mat-icon-button color="primary" (click)="openAddEventDialog()" matTooltip="Neues Ereignis erstellen">
     <mat-icon>add</mat-icon>
   </button>
   <button mat-icon-button color="accent" routerLink="/events" matTooltip="Alle Ereignisse">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -49,6 +49,7 @@ export class DashboardComponent implements OnInit {
   borrowedItems$!: Observable<LibraryItem[]>;
   showOnlyMine = false;
   isAdmin$: Observable<boolean | false>;
+  isSingerOnly$: Observable<boolean>;
 
   constructor(
     private apiService: ApiService,
@@ -60,6 +61,13 @@ export class DashboardComponent implements OnInit {
   ) {
     this.activeChoir$ = this.authService.activeChoir$;
     this.isAdmin$ = this.authService.isAdmin$;
+    this.isSingerOnly$ = this.authService.currentUser$.pipe(
+      map(user => {
+        const roles = Array.isArray(user?.roles) ? user.roles : [];
+        return roles.includes('singer') &&
+          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
+      })
+    );
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- Hide new-event button on dashboard for users with only singer role
- Derive singer-only status from user roles to match event list permissions

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6314284b08320ac6674be4b82db18