### PR TITLE
Fix disappearing choir switcher by syncing choir state

### DIFF
--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -160,8 +160,16 @@ export class AuthService {
     );
   }
 
-  setCurrentUser(user: User) {
+  setCurrentUser(user: User): void {
+    console.debug('AuthService.setCurrentUser called', user);
     localStorage.setItem(USER_KEY, JSON.stringify(user));
     this.currentUserSubject.next(user);
+    this.activeChoir$.next(user.activeChoir || null);
+    const choirs = user.availableChoirs || [];
+    console.debug('AuthService.setCurrentUser updated choirs', {
+      active: user.activeChoir,
+      available: choirs
+    });
+    this.availableChoirs$.next(choirs);
   }
 }

--- a/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.ts
+++ b/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { MaterialModule } from '@modules/material.module';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { Choir } from 'src/app/core/models/choir';
@@ -17,11 +18,16 @@ export class ChoirSwitcherComponent {
   activeChoir$: Observable<Choir | null>;
 
   constructor(private authService: AuthService) {
-    this.availableChoirs$ = this.authService.availableChoirs$;
-    this.activeChoir$ = this.authService.activeChoir$;
+    this.availableChoirs$ = this.authService.availableChoirs$.pipe(
+      tap(choirs => console.debug('ChoirSwitcher available choirs', choirs))
+    );
+    this.activeChoir$ = this.authService.activeChoir$.pipe(
+      tap(choir => console.debug('ChoirSwitcher active choir', choir))
+    );
   }
 
   onChoirChange(choirId: number): void {
+    console.debug('ChoirSwitcher onChoirChange', choirId);
     this.authService.switchChoir(choirId).subscribe();
   }
 }


### PR DESCRIPTION
## Summary
- update AuthService.setCurrentUser to sync active and available choirs and add debug logs
- add debug logging in choir switcher component for analysis

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a63301bfbc8320aba0a6bce8dea702