### PR TITLE
Add missing mock for available choirs

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -23,6 +23,7 @@ describe('MainLayoutComponent', () => {
       isAdmin$: of(false),
       currentUser$: new BehaviorSubject<any>({ roles: ['singer'] }),
       activeChoir$: new BehaviorSubject<any>({ modules: { singerMenu: { events: false } } }),
+      availableChoirs$: of([]),
       setCurrentUser: () => {},
       logout: () => {}
     };


### PR DESCRIPTION
## Summary
- mock available choirs observable in MainLayoutComponent tests to prevent undefined errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63763be088320a84718f299b775c0