### PR TITLE
Add singer role to admin user management

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -34,6 +34,7 @@
         >
           <mat-option value="director">Dirigent</mat-option>
           <mat-option value="choir_admin">Chor-Admin</mat-option>
+          <mat-option value="singer">Sänger</mat-option>
           <mat-option value="admin">Admin</mat-option>
           <mat-option value="librarian">Bibliothekar</mat-option>
         </mat-select>
@@ -88,6 +89,7 @@
           >
             <mat-option value="director">Dirigent</mat-option>
             <mat-option value="choir_admin">Chor-Admin</mat-option>
+            <mat-option value="singer">Sänger</mat-option>
             <mat-option value="admin">Admin</mat-option>
             <mat-option value="librarian">Bibliothekar</mat-option>
           </mat-select>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -102,7 +102,7 @@ export class ManageUsersComponent implements OnInit {
     this.applyFilter(value);
   }
 
-  onRolesChange(user: User, roles: ('director' | 'choir_admin' | 'admin' | 'librarian')[]): void {
+  onRolesChange(user: User, roles: ('director' | 'choir_admin' | 'admin' | 'librarian' | 'singer')[]): void {
     this.api.updateUser(user.id, { roles }).subscribe(() => {
       user.roles = roles;
       this.snack.open('Rollen aktualisiert', 'OK', { duration: 3000 });

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -45,6 +45,7 @@
       <mat-select formControlName="roles" multiple>
         <mat-option value="director">Dirigent</mat-option>
         <mat-option value="choir_admin">Chor-Admin</mat-option>
+        <mat-option value="singer">Sänger</mat-option>
         <mat-option value="admin">Admin</mat-option>
         <mat-option value="librarian">Bibliothekar</mat-option>
       </mat-select>


### PR DESCRIPTION
## Summary
- include "Sänger" role in admin user dialog
- allow selecting "Sänger" in manage users view
- update role change handler to support "singer"

## Testing
- `npm test` *(fails: ChromeHeadless error: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a63c578060832099ceea85203cfda8