### PR TITLE
Restrict collection edits to choir admins

### DIFF
--- a/choir-app-backend/src/routes/collection.routes.js
+++ b/choir-app-backend/src/routes/collection.routes.js
@@ -12,11 +12,11 @@ const { handler: wrap } = require("../utils/async");
 router.get("/:id/cover", wrap(controller.getCover));
 
 router.use(authJwt.verifyToken);
-router.post("/", role.requireNonDemo, createCollectionValidation, validate, wrap(controller.create));
+router.post("/", role.requireNonDemo, role.requireChoirAdmin, createCollectionValidation, validate, wrap(controller.create));
 router.get("/", wrap(controller.findAll));
 router.get("/:id", wrap(controller.findOne));
-router.put("/:id", role.requireNonDemo, updateCollectionValidation, validate, wrap(controller.update));
-router.post("/:id/cover", role.requireNonDemo, upload.single('cover'), wrap(controller.uploadCover));
+router.put("/:id", role.requireNonDemo, role.requireChoirAdmin, updateCollectionValidation, validate, wrap(controller.update));
+router.post("/:id/cover", role.requireNonDemo, role.requireChoirAdmin, upload.single('cover'), wrap(controller.uploadCover));
 router.post("/:id/addToChoir", wrap(controller.addToChoir)); // Crucial endpoint
 router.post("/bulkAddToChoir", wrap(controller.bulkAddToChoir));
 module.exports = router;

--- a/choir-app-backend/tests/collection.auth.test.js
+++ b/choir-app-backend/tests/collection.auth.test.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+const express = require('express');
+const http = require('http');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+let currentContext = {};
+const authJwt = require('../src/middleware/auth.middleware');
+authJwt.verifyToken = (req, res, next) => { Object.assign(req, currentContext); next(); };
+const router = require('../src/routes/collection.routes');
+
+(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/collections', router);
+  const server = http.createServer(app);
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+
+  async function send(method, url, body, context) {
+    currentContext = context;
+    const res = await fetch(`http://localhost:${port}${url}`, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const text = await res.text();
+    let data;
+    try { data = JSON.parse(text); } catch { data = text; }
+    return { status: res.status, data };
+  }
+
+  try {
+    await db.sequelize.sync({ force: true });
+    const choir = await db.choir.create({ name: 'Test Choir' });
+    const collection = await db.collection.create({ title: 'Coll' });
+    const choirAdmin = await db.user.create({ email: 'admin@example.com', roles: ['singer'] });
+    await db.user_choir.create({ userId: choirAdmin.id, choirId: choir.id, rolesInChoir: ['choir_admin'] });
+    const singer = await db.user.create({ email: 'singer@example.com', roles: ['singer'] });
+    await db.user_choir.create({ userId: singer.id, choirId: choir.id, rolesInChoir: [] });
+
+    let res = await send('PUT', `/api/collections/${collection.id}`, { title: 'Updated' }, {
+      userRoles: ['singer'],
+      userId: choirAdmin.id,
+      activeChoirId: choir.id
+    });
+    assert.strictEqual(res.status, 200, 'choir admin should update');
+
+    res = await send('PUT', `/api/collections/${collection.id}`, { title: 'Again' }, {
+      userRoles: ['singer'],
+      userId: singer.id,
+      activeChoirId: choir.id
+    });
+    assert.strictEqual(res.status, 403, 'singer should be forbidden');
+
+    await new Promise(resolve => server.close(resolve));
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await new Promise(resolve => server.close(resolve));
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import { ImprintComponent } from '@features/legal/imprint/imprint.component';
 import { PrivacyComponent } from '@features/legal/privacy/privacy.component';
 import { AdminGuard } from '@core/guards/admin-guard';
 import { LoginGuard } from '@core/guards/login.guard';
+import { ChoirAdminGuard } from '@core/guards/choir-admin.guard';
 import { HomeComponent } from '@features/home/home.component';
 import { ManageChoirComponent } from '@features/choir-management/manage-choir/manage-choir.component';
 import { ManageChoirResolver } from '@features/choir-management/manage-choir-resolver';
@@ -99,13 +100,13 @@ export const routes: Routes = [
             {
                 path: 'collections/new',
                 component: CollectionEditComponent,
-                canActivate: [AuthGuard],
+                canActivate: [AuthGuard, ChoirAdminGuard],
                 data: { title: 'Neue Sammlung' },
             },
             {
                 path: 'collections/edit/:id',
                 component: CollectionEditComponent,
-                canActivate: [AuthGuard],
+                canActivate: [AuthGuard, ChoirAdminGuard],
                 data: { title: 'Sammlung bearbeiten' },
             },
             {

--- a/choir-app-frontend/src/app/core/guards/choir-admin.guard.ts
+++ b/choir-app-frontend/src/app/core/guards/choir-admin.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { ApiService } from '../services/api.service';
+import { Observable, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class ChoirAdminGuard implements CanActivate {
+  constructor(private auth: AuthService, private api: ApiService, private router: Router) {}
+
+  canActivate(): Observable<boolean | UrlTree> {
+    return combineLatest([this.auth.isAdmin$, this.api.checkChoirAdminStatus()]).pipe(
+      map(([isAdmin, status]) => {
+        if (isAdmin || status.isChoirAdmin) {
+          return true;
+        }
+        return this.router.createUrlTree(['/collections']);
+      })
+    );
+  }
+}

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -1,7 +1,7 @@
 <div class="form-container">
   <div class="header-actions">
     <button
-      *ngIf="isEditMode && isAdmin"
+      *ngIf="isEditMode && (isAdmin || isChoirAdmin)"
       mat-stroked-button
       color="accent"
       (click)="openImportDialog()">

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -15,8 +15,8 @@ import {
     FormControl,
 } from '@angular/forms';
 import { Router, ActivatedRoute, RouterModule } from '@angular/router';
-import { Observable, of } from 'rxjs';
-import { map, startWith, switchMap, tap } from 'rxjs/operators';
+import { Observable, of, combineLatest } from 'rxjs';
+import { map, startWith, switchMap } from 'rxjs/operators';
 import {
     MatAutocompleteModule,
     MatAutocompleteSelectedEvent,
@@ -76,6 +76,7 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     coverFile: File | null = null;
     isDragOver = false;
     isAdmin = false;
+    isChoirAdmin = false;
     readonly addNewPieceId = -1;
     @ViewChild('pieceInput') pieceInput!: ElementRef<HTMLInputElement>;
 
@@ -134,7 +135,14 @@ export class CollectionEditComponent implements OnInit, AfterViewInit {
     }
 
     ngOnInit(): void {
-        this.authService.isAdmin$.subscribe(v => (this.isAdmin = v));
+        combineLatest([this.authService.isAdmin$, this.apiService.checkChoirAdminStatus()]).subscribe(([isAdmin, s]) => {
+            this.isAdmin = isAdmin;
+            this.isChoirAdmin = s.isChoirAdmin;
+            if (!this.isAdmin && !this.isChoirAdmin) {
+                this.router.navigate(['/collections']);
+                this.snackBar.open('Keine Berechtigung Sammlungen zu bearbeiten.', 'Schließen');
+            }
+        });
         this.apiService.getPublishers().subscribe(list => {
             this.publishers = list;
             this.setupPublisherAutocomplete();

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -84,7 +84,7 @@
               matTooltip="In Notenbibliothek vorhanden">
               library_music
             </mat-icon>
-            <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
+            <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
                 <mat-icon>edit</mat-icon>
             </button>
         </td>
@@ -132,7 +132,7 @@
           matTooltip="In Notenbibliothek vorhanden">
           library_music
         </mat-icon>
-        <button mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
+        <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
             <mat-icon>edit</mat-icon>
         </button>
       </div>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -178,6 +178,7 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
   }
 
   openCollection(collection: Collection): void {
+    if (!this.isChoirAdmin && !this.isAdmin) { return; }
     const page = this.paginator ? this.paginator.pageIndex : 0;
     this.navState.saveState(this.stateKey, { page, selectedId: collection.id });
     // Create an extra history entry so the back button returns to this list with state


### PR DESCRIPTION
## Summary
- require choir-admin role on backend collection create/update and cover upload
- add ChoirAdminGuard and route protections for collection editing in frontend
- hide edit actions and redirect unauthorized users
- add backend test covering singer access denial

## Testing
- `node choir-app-backend/tests/collection.auth.test.js`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm test --prefix choir-app-backend` *(did not finish: long-running and verbose)*

------
https://chatgpt.com/codex/tasks/task_e_68a63e59a4108320991ca7594ac18cef