### PR TITLE
feat: link latest post from dashboard

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -18,7 +18,12 @@
   </app-event-card>
 </div>
 
-<div class="latest-post" *ngIf="latestPost$ | async as post">
+<div
+  class="latest-post"
+  *ngIf="latestPost$ | async as post"
+  (click)="openLatestPost(post)"
+  tabindex="0"
+  role="link">
   <h2>Neuster Beitrag</h2>
   <h3>{{ post.title }}</h3>
   <p>{{ post.text }}</p>

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
@@ -27,4 +27,13 @@ mat-card-content h3 {
   color: #999;
 }
 
-.latest-post{margin-top:1rem;}
+.latest-post {
+  margin-top: 1rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  &:hover {
+    background-color: #f5f5f5;
+  }
+}

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { map, switchMap, tap, take } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
@@ -57,7 +57,8 @@ export class DashboardComponent implements OnInit {
     private dialog: MatDialog, // Zum Öffnen von Dialogen
     private snackBar: MatSnackBar, // Zum Anzeigen von Benachrichtigungen
     private help: HelpService,
-    private prefs: UserPreferencesService
+    private prefs: UserPreferencesService,
+    private router: Router
   ) {
     this.activeChoir$ = this.authService.activeChoir$;
     this.isAdmin$ = this.authService.isAdmin$;
@@ -193,6 +194,10 @@ export class DashboardComponent implements OnInit {
 
   onToggleMine(): void {
     this.refresh$.next();
+  }
+
+  openLatestPost(post: Post): void {
+    this.router.navigate(['/posts'], { fragment: `post-${post.id}` });
   }
 
 }

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -4,7 +4,7 @@
 
 <ng-container *ngIf="posts.length; else noPosts">
   <div class="post-list">
-    <mat-card *ngFor="let p of posts" class="post">
+    <mat-card *ngFor="let p of posts" class="post" id="post-{{ p.id }}">
       <mat-card-header>
         <mat-card-title>{{ p.title }}</mat-card-title>
         <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }}</mat-card-subtitle>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { RouterModule, ActivatedRoute } from '@angular/router';
 import { MaterialModule } from '@modules/material.module';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -22,7 +22,13 @@ export class PostListComponent implements OnInit {
   currentUserId: number | null = null;
   isChoirAdmin = false;
   isSingerOnly = false;
-  constructor(private api: ApiService, private auth: AuthService, private dialog: MatDialog, private snackBar: MatSnackBar) {
+  constructor(
+    private api: ApiService,
+    private auth: AuthService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+    private route: ActivatedRoute
+  ) {
   }
 
   ngOnInit(): void {
@@ -37,7 +43,13 @@ export class PostListComponent implements OnInit {
   }
 
   loadPosts(): void {
-    this.api.getPosts().subscribe(p => this.posts = p);
+    this.api.getPosts().subscribe(p => {
+      this.posts = p;
+      const fragment = this.route.snapshot.fragment;
+      if (fragment) {
+        setTimeout(() => document.getElementById(fragment)?.scrollIntoView({ behavior: 'smooth' }), 0);
+      }
+    });
   }
 
   canEdit(post: Post): boolean {


### PR DESCRIPTION
## Summary
- make latest dashboard post open full posts page when clicked
- add visual hover/pointer cues for latest post section
- allow deep linking to posts by id with fragment scrolling

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm run check-backend`

------
https://chatgpt.com/codex/tasks/task_e_68a63f3ae590832092abe7bd336ae369