### PR TITLE
Handle upcoming event click by role

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -32,7 +32,7 @@
   </mat-slide-toggle>
   <mat-list>
     <mat-list-item *ngFor="let ev of nextEvents$ | async">
-      <a [routerLink]="['/events', ev.id]">
+      <a href="#" (click)="openEvent(ev); $event.preventDefault()">
         {{ ev.date | date:'shortDate' }} -
         {{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}
       </a>


### PR DESCRIPTION
## Summary
- open upcoming events on dashboard for editing or availability based on role
- navigate singers to availability view for the event month
- allow admins and directors to edit events directly from dashboard

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a63f8739888320bd93b0b0f6d01948