### PR TITLE
Persist help wizard status in user profile

### DIFF
--- a/choir-app-backend/src/controllers/auth.controller.js
+++ b/choir-app-backend/src/controllers/auth.controller.js
@@ -123,6 +123,7 @@ exports.signin = async (req, res) => {
       email: user.email,
       voice: user.voice,
       roles: user.roles,
+      helpShown: user.helpShown,
       accessToken: token,
       // Senden Sie die Liste aller Chöre und den aktuell aktiven
       activeChoir: user.choirs[0],

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -6,7 +6,7 @@ const bcrypt = require("bcryptjs");
 exports.getMe = async (req, res) => {
     try {
         const user = await User.findByPk(req.userId, {
-            attributes: ['id', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir'],
+            attributes: ['id', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'helpShown'],
             include: [{
                 model: Choir,
                 as: 'choirs', // Use the plural alias 'choirs' defined in the association
@@ -27,8 +27,8 @@ exports.getMe = async (req, res) => {
 /**
  * @description Update the profile of the currently logged-in user.
  */
-exports.updateMe = async (req, res) => {
-     const { name, email, street, postalCode, city, voice, shareWithChoir, oldPassword, newPassword, roles } = req.body;
+ exports.updateMe = async (req, res) => {
+     const { name, email, street, postalCode, city, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
 
     try {
         const user = await User.findByPk(req.userId);
@@ -58,6 +58,9 @@ exports.updateMe = async (req, res) => {
         }
         if (shareWithChoir !== undefined) {
             updateData.shareWithChoir = !!shareWithChoir;
+        }
+        if (helpShown !== undefined) {
+            updateData.helpShown = !!helpShown;
         }
         if (Array.isArray(roles) && user.roles.includes('admin')) {
             const newRoles = roles.includes('admin') ? roles : [...roles, 'admin'];

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -1,64 +1,70 @@
 module.exports = (sequelize, DataTypes) => {
-    const User = sequelize.define("user", {
-      name: {
-        type: DataTypes.STRING
-      },
-      email: {
-        type: DataTypes.STRING,
-        allowNull: false,
-        unique: true
-      },
-      password: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
-      resetToken: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
-      resetTokenExpiry: {
-        type: DataTypes.DATE,
-        allowNull: true
-      },
-      roles: {
-        type: DataTypes.JSON,
-        allowNull: false,
-        defaultValue: ['director']
-      },
-      lastDonation: {
-        type: DataTypes.DATE,
-        allowNull: true
-      },
-      lastLogin: {
-        type: DataTypes.DATE,
-        allowNull: true
-      },
-      street: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
-      postalCode: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
-      city: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
-      voice: {
-        type: DataTypes.ENUM('Sopran I', 'Sopran II', 'Alt I', 'Alt II', 'Tenor I', 'Tenor II', 'Bass I', 'Bass II'),
-        allowNull: true
-      },
-      shareWithChoir: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-        defaultValue: false
-      },
-      preferences: {
-        type: DataTypes.JSON,
-        allowNull: true,
-        defaultValue: {}
-      }
-    });
-    return User;
+  const User = sequelize.define("user", {
+    name: {
+      type: DataTypes.STRING
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    password: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    resetToken: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    resetTokenExpiry: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    roles: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: ['director'],
+    },
+    lastDonation: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    lastLogin: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    street: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    postalCode: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    city: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    voice: {
+      type: DataTypes.ENUM('Sopran I', 'Sopran II', 'Alt I', 'Alt II', 'Tenor I', 'Tenor II', 'Bass I', 'Bass II'),
+      allowNull: true
+    },
+    shareWithChoir: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
+    helpShown: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
+    preferences: {
+      type: DataTypes.JSON,
+      allowNull: true,
+      defaultValue: {},
+    }
+  });
+  return User;
 };
+

--- a/choir-app-frontend/src/app/core/models/user-preferences.ts
+++ b/choir-app-frontend/src/app/core/models/user-preferences.ts
@@ -1,6 +1,5 @@
 export interface UserPreferences {
   theme?: 'light' | 'dark' | 'system';
-  helpShown?: boolean;
   pageSizes?: { [key: string]: number };
   repertoireColumns?: {
     lastSung?: boolean;

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -30,6 +30,11 @@ export interface User {
   roles?: ('director' | 'choir_admin' | 'admin' | 'demo' | 'singer' | 'librarian')[];
 
   /**
+   * Indicates whether the help wizard has been displayed for this user.
+   */
+  helpShown?: boolean;
+
+  /**
    * The JSON Web Token received upon successful login.
    * This property is only present in the response from the sign-in endpoint.
    * It is optional ('?') because the profile endpoint (/users/me) does not return it.

--- a/choir-app-frontend/src/app/core/services/help.service.spec.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { HelpService } from './help.service';
-import { UserPreferencesService } from './user-preferences.service';
+import { UserService } from './user.service';
 import { User } from '../models/user';
 
 describe('HelpService', () => {
@@ -14,7 +14,7 @@ describe('HelpService', () => {
     TestBed.configureTestingModule({
       providers: [
         HelpService,
-        { provide: UserPreferencesService, useValue: { getPreference: () => undefined, update: () => of({}) } }
+        { provide: UserService, useValue: { updateCurrentUser: () => of({}) } }
       ]
     });
     service = TestBed.inject(HelpService);

--- a/choir-app-frontend/src/app/core/services/help.service.ts
+++ b/choir-app-frontend/src/app/core/services/help.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { User } from '../models/user';
-import { UserPreferencesService } from './user-preferences.service';
+import { UserService } from './user.service';
 
 @Injectable({ providedIn: 'root' })
 export class HelpService {
-  constructor(private prefs: UserPreferencesService) {}
+  constructor(private users: UserService) {}
 
   shouldShowHelp(user: User | null): boolean {
     if (!user) {
@@ -13,19 +13,15 @@ export class HelpService {
     if (user.roles?.includes('demo')) {
       return true;
     }
-    const storageKey = `helpShown_${user.id}`;
-    if (localStorage.getItem(storageKey) === 'true') {
-      return false;
-    }
-    return !this.prefs.getPreference('helpShown');
+    return !user.helpShown;
   }
 
   markHelpShown(user: User | null): void {
     if (!user || user.roles?.includes('demo')) {
       return;
     }
-    const storageKey = `helpShown_${user.id}`;
-    localStorage.setItem(storageKey, 'true');
-    this.prefs.update({ helpShown: true }).subscribe();
+    this.users.updateCurrentUser({ helpShown: true }).subscribe(() => {
+      user.helpShown = true;
+    });
   }
 }

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.spec.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { HelpService } from '@core/services/help.service';
-import { UserPreferencesService } from '@core/services/user-preferences.service';
+import { UserService } from '@core/services/user.service';
 import { of } from 'rxjs';
 
 import { DashboardComponent } from './dashboard.component';
@@ -22,7 +22,7 @@ describe('DashboardComponent', () => {
         { provide: MatDialog, useValue: {} },
         { provide: MatSnackBar, useValue: { open: () => {} } },
         { provide: HelpService, useValue: { shouldShowHelp: () => false, markHelpShown: () => {} } },
-        { provide: UserPreferencesService, useValue: { isLoaded: () => true, load: () => of({}) } }
+        { provide: UserService, useValue: { getCurrentUser: () => of({}) } }
       ]
     })
     .compileComponents();

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -19,8 +19,7 @@ import { PieceChange } from '@core/models/piece-change';
 import { Post } from '@core/models/post';
 import { HelpService } from '@core/services/help.service';
 import { HelpWizardComponent } from '@shared/components/help-wizard/help-wizard.component';
-import { UserPreferencesService } from '@core/services/user-preferences.service';
-import { UserPreferences } from '@core/models/user-preferences';
+import { UserService } from '@core/services/user.service';
 import { LibraryItem } from '@core/models/library-item';
 
 @Component({
@@ -57,7 +56,7 @@ export class DashboardComponent implements OnInit {
     private dialog: MatDialog, // Zum Öffnen von Dialogen
     private snackBar: MatSnackBar, // Zum Anzeigen von Benachrichtigungen
     private help: HelpService,
-    private prefs: UserPreferencesService,
+    private userService: UserService,
     private router: Router
   ) {
     this.activeChoir$ = this.authService.activeChoir$;
@@ -99,17 +98,12 @@ export class DashboardComponent implements OnInit {
     );
 
     // Willkommenstext ggf. anzeigen
-    this.authService.currentUser$.pipe(take(1)).subscribe(user => {
-      if (!user) return;
-      const load$: Observable<UserPreferences | null> = this.prefs.isLoaded()
-        ? of(null)
-        : this.prefs.load();
-      load$.pipe(take(1)).subscribe(() => {
-        if (this.help.shouldShowHelp(user)) {
-          const ref = this.dialog.open(HelpWizardComponent, { width: '600px' });
-          ref.afterClosed().subscribe(() => this.help.markHelpShown(user));
-        }
-      });
+    this.userService.getCurrentUser().pipe(take(1)).subscribe(user => {
+      this.authService.setCurrentUser(user);
+      if (this.help.shouldShowHelp(user)) {
+        const ref = this.dialog.open(HelpWizardComponent, { width: '600px' });
+        ref.afterClosed().subscribe(() => this.help.markHelpShown(user));
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- persist whether a user has seen the help wizard in the database profile
- show the help wizard only after the profile is loaded and update the flag via the API

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a80602a9008320bd7eb01fdb34b466