### PR TITLE
feat: add markdown help and preview to post dialog

### DIFF
--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.html
@@ -16,6 +16,19 @@
       <mat-label>Text</mat-label>
       <textarea matInput rows="5" formControlName="text" placeholder="Markdown möglich"></textarea>
     </mat-form-field>
+    <mat-expansion-panel>
+      <mat-expansion-panel-header>
+        <mat-panel-title>Markdown-Hilfe</mat-panel-title>
+      </mat-expansion-panel-header>
+      <p><code># Überschrift</code> → <strong>Überschrift</strong></p>
+      <p><code>**fett**</code> → <strong>fett</strong></p>
+      <p><code>*kursiv*</code> → <em>kursiv</em></p>
+      <p><code>`Code`</code> → <code>Code</code></p>
+      <p><code>[Link](https://beispiel.de)</code></p>
+      <p><code>- Liste</code></p>
+    </mat-expansion-panel>
+    <h3>Vorschau</h3>
+    <div class="preview" [innerHTML]="form.get('text')?.value | markdown"></div>
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Ablaufdatum</mat-label>
       <input matInput [matDatepicker]="picker" formControlName="expiresAt">

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
@@ -8,11 +8,12 @@ import { ApiService } from '@core/services/api.service';
 import { LookupPiece } from '@core/models/lookup-piece';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { MarkdownPipe } from '@shared/pipes/markdown.pipe';
 
 @Component({
   selector: 'app-post-dialog',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MaterialModule],
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MaterialModule, MarkdownPipe],
   templateUrl: './post-dialog.component.html'
 })
 export class PostDialogComponent {


### PR DESCRIPTION
## Summary
- show markdown syntax help in post dialog
- add live markdown preview for posts

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68a83b4c23808320a63b8f3d1887219c