### PR TITLE
Notify admins on backend errors

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -7,6 +7,7 @@ const RateLimit = require("express-rate-limit");
 const path = require('path');
 
 const logger = require("./config/logger");
+const emailService = require('./services/email.service');
 
 app.set("trust proxy", 1);
 
@@ -120,6 +121,10 @@ app.use((err, req, res, next) => {
         } - ${req.ip}`
     );
     logger.error(err.stack);
+    emailService.notifyAdminsOnCrash(err, req).catch(e => {
+        logger.error(`Error notifying admins of crash: ${e.message}`);
+        logger.error(e.stack);
+    });
     res.status(err.status || 500).send({
         message: "An internal server error occurred. Please try again later.",
     });


### PR DESCRIPTION
## Summary
- send crash report emails to all admins and system admin address
- include request context and stack trace in crash notifications
- trigger notifications from global error handler

## Testing
- `npm test --prefix choir-app-backend` *(fails: command produced excessive output and didn't finish within the time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c71991648320931bb4ca05f0a0a5