### PR TITLE
feat: run collection updates asynchronously

### DIFF
--- a/choir-app-backend/src/routes/collection.routes.js
+++ b/choir-app-backend/src/routes/collection.routes.js
@@ -14,6 +14,7 @@ router.get("/:id/cover", wrap(controller.getCover));
 router.use(authJwt.verifyToken);
 router.post("/", role.requireNonDemo, role.requireChoirAdmin, createCollectionValidation, validate, wrap(controller.create));
 router.get("/", wrap(controller.findAll));
+router.get("/status/:jobId", wrap(controller.getUpdateStatus));
 router.get("/:id", wrap(controller.findOne));
 router.put("/:id", role.requireNonDemo, role.requireChoirAdmin, updateCollectionValidation, validate, wrap(controller.update));
 router.post("/:id/cover", role.requireNonDemo, role.requireChoirAdmin, upload.single('cover'), wrap(controller.uploadCover));

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -299,8 +299,12 @@ export class ApiService {
   }
 
   // Updates an existing collection
-  updateCollection(id: number, data: any): Observable<any> {
+  updateCollection(id: number, data: any): Observable<{ jobId: string }> {
     return this.collectionService.updateCollection(id, data);
+  }
+
+  getCollectionUpdateStatus(jobId: string): Observable<any> {
+    return this.collectionService.getUpdateStatus(jobId);
   }
 
   uploadCollectionCover(id: number, file: File): Observable<any> {

--- a/choir-app-frontend/src/app/core/services/collection.service.ts
+++ b/choir-app-frontend/src/app/core/services/collection.service.ts
@@ -23,8 +23,12 @@ export class CollectionService {
     return this.http.post<Collection>(`${this.apiUrl}/collections`, data);
   }
 
-  updateCollection(id: number, data: any): Observable<any> {
-    return this.http.put(`${this.apiUrl}/collections/${id}`, data);
+  updateCollection(id: number, data: any): Observable<{ jobId: string }> {
+    return this.http.put<{ jobId: string }>(`${this.apiUrl}/collections/${id}`, data);
+  }
+
+  getUpdateStatus(jobId: string): Observable<any> {
+    return this.http.get(`${this.apiUrl}/collections/status/${jobId}`);
   }
 
   uploadCollectionCover(id: number, file: File): Observable<any> {

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -1,3 +1,6 @@
+<div class="spinner-overlay" *ngIf="isSaving">
+  <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
+</div>
 <div class="form-container">
   <div class="header-actions">
     <button

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -101,3 +101,16 @@ mat-card-actions button mat-icon {
     }
   }
 }
+
+.spinner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- process collection updates as background jobs and expose status endpoint
- show spinner while polling collection update status in the UI
- add client helpers for job-based collection updates

## Testing
- `npm test` (backend)
- `npm test` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68a8c93da3a483209e88a087a791d3d8