### PR TITLE
feat(admin): allow assigning users to choirs

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.html
@@ -1,0 +1,26 @@
+<h1 mat-dialog-title>Benutzer zu Chor hinzufügen</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Chor</mat-label>
+      <mat-select formControlName="choir" required>
+        <mat-option *ngFor="let choir of choirs" [value]="choir.id">{{ choir.name }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Rollen</mat-label>
+      <mat-select formControlName="roles" multiple>
+        <mat-option value="director">Dirigent</mat-option>
+        <mat-option value="choir_admin">Chor-Admin</mat-option>
+        <mat-option value="singer">Sänger</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-checkbox formControlName="isOrganist">Organist</mat-checkbox>
+  </form>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()">Abbrechen</button>
+  <button mat-raised-button color="primary" (click)="onAdd()" [disabled]="form.invalid">Hinzufügen</button>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.scss
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.ts
@@ -1,0 +1,53 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from 'src/app/core/services/api.service';
+import { Choir } from 'src/app/core/models/choir';
+
+@Component({
+  selector: 'app-add-to-choir-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './add-to-choir-dialog.component.html',
+})
+export class AddToChoirDialogComponent implements OnInit {
+  form: FormGroup;
+  choirs: Choir[] = [];
+
+  constructor(
+    private fb: FormBuilder,
+    private api: ApiService,
+    public dialogRef: MatDialogRef<AddToChoirDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any
+  ) {
+    this.form = this.fb.group({
+      choir: [null, Validators.required],
+      roles: [['singer'], Validators.required],
+      isOrganist: [false],
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.getAdminChoirs().subscribe(choirs => {
+      this.choirs = choirs;
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onAdd(): void {
+    if (this.form.valid) {
+      const choirId = this.form.value.choir;
+      const roles = this.form.value.roles as string[];
+      const isOrg = this.form.value.isOrganist;
+      const finalRoles = isOrg && !roles.includes('organist')
+        ? [...roles, 'organist']
+        : (!isOrg ? roles.filter(r => r !== 'organist') : roles);
+      this.dialogRef.close({ choirId, roles: finalRoles });
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -58,6 +58,9 @@
       <button mat-icon-button color="primary" (click)="editUser(element)">
         <mat-icon>edit</mat-icon>
       </button>
+      <button mat-icon-button (click)="addToChoir(element)">
+        <mat-icon>group_add</mat-icon>
+      </button>
       <button mat-icon-button (click)="sendReset(element)">
         <mat-icon>mail</mat-icon>
       </button>
@@ -101,6 +104,9 @@
     <div class="mobile-actions">
       <button mat-icon-button color="primary" (click)="editUser(element)">
         <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button (click)="addToChoir(element)">
+        <mat-icon>group_add</mat-icon>
       </button>
       <button mat-icon-button (click)="sendReset(element)">
         <mat-icon>mail</mat-icon>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -8,6 +8,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { UserDialogComponent } from './user-dialog/user-dialog.component';
+import { AddToChoirDialogComponent } from './add-to-choir-dialog/add-to-choir-dialog.component';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -77,6 +78,15 @@ export class ManageUsersComponent implements OnInit {
     if (confirm('Benutzer löschen?')) {
       this.api.deleteUser(user.id).subscribe(() => this.loadUsers());
     }
+  }
+
+  addToChoir(user: User): void {
+    const ref = this.dialog.open(AddToChoirDialogComponent, { width: '400px' });
+    ref.afterClosed().subscribe(result => {
+      if (result) {
+        this.api.inviteUserToChoirAdmin(result.choirId, user.email, result.roles).subscribe(() => this.loadUsers());
+      }
+    });
   }
 
   sendReset(user: User): void {


### PR DESCRIPTION
## Summary
- add dialog to select choir and roles for user
- enable adding existing users to choirs from admin user management

## Testing
- `npm test --silent` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8daaf90188320a439bec4c90ee245