### PR TITLE
Ensure collection sync adds new pieces

### DIFF
--- a/choir-app-backend/src/controllers/collection.controller.js
+++ b/choir-app-backend/src/controllers/collection.controller.js
@@ -191,7 +191,10 @@ exports.addToChoir = async (req, res, next) => {
         const missingPieces = pieces.filter(p => !choirPieceIds.has(p.id));
 
         if (missingPieces.length) {
-            await choir.addPieces(missingPieces).catch(() => {});
+            for (const piece of missingPieces) {
+                // add individually so one failure does not abort the entire batch
+                await choir.addPiece(piece).catch(() => {});
+            }
         }
 
         res.status(200).send({ message: `Collection '${collection.title}' synced with your repertoire.` });
@@ -225,8 +228,10 @@ exports.bulkAddToChoir = async (req, res, next) => {
             const pieces = await collection.getPieces({ attributes: ['id'] });
             const missingPieces = pieces.filter(p => !choirPieceIds.has(p.id));
             if (missingPieces.length) {
-                await choir.addPieces(missingPieces).catch(() => {});
-                missingPieces.forEach(p => choirPieceIds.add(p.id));
+                for (const piece of missingPieces) {
+                    await choir.addPiece(piece).catch(() => {});
+                    choirPieceIds.add(piece.id);
+                }
             }
         }
 

--- a/choir-app-backend/tests/collection.sync.test.js
+++ b/choir-app-backend/tests/collection.sync.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+
+const db = require('../src/models');
+const controller = require('../src/controllers/collection.controller');
+
+(async () => {
+  try {
+    await db.sequelize.sync({ force: true });
+
+    const choir = await db.choir.create({ name: 'Test Choir' });
+    const collection = await db.collection.create({ title: 'Test Collection' });
+
+    // initial 50 pieces
+    for (let i = 1; i <= 50; i++) {
+      const piece = await db.piece.create({ title: `P${i}` });
+      await collection.addPiece(piece, { through: { numberInCollection: String(i) } });
+    }
+
+    const req = { body: { collectionIds: [collection.id] }, activeChoirId: choir.id };
+    const res = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+
+    await controller.bulkAddToChoir(req, res);
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(await choir.countPieces(), 50);
+
+    // add 3 new pieces to collection
+    for (let i = 51; i <= 53; i++) {
+      const piece = await db.piece.create({ title: `P${i}` });
+      await collection.addPiece(piece, { through: { numberInCollection: String(i) } });
+    }
+
+    await controller.bulkAddToChoir(req, res);
+    assert.strictEqual(await choir.countPieces(), 53);
+
+    await db.sequelize.close();
+  } catch (err) {
+    console.error(err);
+    await db.sequelize.close();
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- Prevent collection sync from aborting when adding multiple pieces by adding each piece individually
- Add regression test to verify that newly added collection pieces are synchronized to a choir's repertoire

## Testing
- `node choir-app-backend/tests/collection.sync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa98a2ee3883208b6e211f54f8a701