### PR TITLE
feat: add program and program item models

### DIFF
--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -44,6 +44,8 @@ db.post = require("./post.model.js")(sequelize, Sequelize);
 db.library_item = require("./library_item.model.js")(sequelize, Sequelize);
 db.loan_request = require("./loan_request.model.js")(sequelize, Sequelize);
 db.loan_request_item = require("./loan_request_item.model.js")(sequelize, Sequelize);
+db.program = require("./program.model.js")(sequelize, Sequelize);
+db.program_item = require("./program_item.model.js")(sequelize, Sequelize);
 
 // --- Define Associations ---
 // A Choir has many Users
@@ -159,6 +161,21 @@ db.loan_request.belongsTo(db.user, { foreignKey: 'userId', as: 'requester' });
 db.loan_request.hasMany(db.loan_request_item, { as: 'items', foreignKey: 'loanRequestId' });
 db.loan_request_item.belongsTo(db.loan_request, { foreignKey: 'loanRequestId', as: 'loanRequest' });
 db.loan_request_item.belongsTo(db.library_item, { foreignKey: 'libraryItemId', as: 'libraryItem' });
+
+// Programs and items
+db.choir.hasMany(db.program, { as: 'programs' });
+db.program.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
+
+db.user.hasMany(db.program, { as: 'createdPrograms', foreignKey: 'createdBy' });
+db.user.hasMany(db.program, { as: 'updatedPrograms', foreignKey: 'updatedBy' });
+db.program.belongsTo(db.user, { foreignKey: 'createdBy', as: 'creator' });
+db.program.belongsTo(db.user, { foreignKey: 'updatedBy', as: 'updater' });
+
+db.program.hasMany(db.program_item, { as: 'items', foreignKey: 'programId' });
+db.program_item.belongsTo(db.program, { foreignKey: 'programId', as: 'program' });
+
+db.piece.hasMany(db.program_item, { as: 'programItems', foreignKey: 'pieceId' });
+db.program_item.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
 
 
 module.exports = db;

--- a/choir-app-backend/src/models/program.model.js
+++ b/choir-app-backend/src/models/program.model.js
@@ -1,0 +1,54 @@
+module.exports = (sequelize, DataTypes) => {
+  const Program = sequelize.define('program', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    choirId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'choir_id',
+    },
+    title: {
+      type: DataTypes.STRING(200),
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+    },
+    startAt: {
+      type: DataTypes.DATE,
+      field: 'start_at',
+    },
+    status: {
+      type: DataTypes.ENUM('draft', 'published', 'archived'),
+      defaultValue: 'draft',
+      allowNull: false,
+    },
+    publishedAt: {
+      type: DataTypes.DATE,
+      field: 'published_at',
+    },
+    publishedFromId: {
+      type: DataTypes.UUID,
+      field: 'published_from_id',
+    },
+    createdBy: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'created_by',
+    },
+    updatedBy: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'updated_by',
+    },
+  }, {
+    tableName: 'programs',
+    underscored: true,
+    paranoid: true,
+  });
+
+  return Program;
+};

--- a/choir-app-backend/src/models/program_item.model.js
+++ b/choir-app-backend/src/models/program_item.model.js
@@ -1,0 +1,83 @@
+module.exports = (sequelize, DataTypes) => {
+  const ProgramItem = sequelize.define('program_item', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    programId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'program_id',
+    },
+    sortIndex: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: 'sort_index',
+    },
+    type: {
+      type: DataTypes.ENUM('piece', 'break', 'speech', 'slot'),
+      allowNull: false,
+    },
+    durationSec: {
+      type: DataTypes.INTEGER,
+      field: 'duration_sec',
+    },
+    note: {
+      type: DataTypes.STRING(1000),
+    },
+    pieceId: {
+      type: DataTypes.UUID,
+      field: 'piece_id',
+    },
+    pieceTitleSnapshot: {
+      type: DataTypes.STRING(300),
+      field: 'piece_title_snapshot',
+    },
+    pieceComposerSnapshot: {
+      type: DataTypes.STRING(300),
+      field: 'piece_composer_snapshot',
+    },
+    pieceDurationSecSnapshot: {
+      type: DataTypes.INTEGER,
+      field: 'piece_duration_sec_snapshot',
+    },
+    instrument: {
+      type: DataTypes.STRING(120),
+    },
+    performerNames: {
+      type: DataTypes.STRING(300),
+      field: 'performer_names',
+    },
+    speechTitle: {
+      type: DataTypes.STRING(200),
+      field: 'speech_title',
+    },
+    speechSource: {
+      type: DataTypes.STRING(200),
+      field: 'speech_source',
+    },
+    speechSpeaker: {
+      type: DataTypes.STRING(120),
+      field: 'speech_speaker',
+    },
+    speechText: {
+      type: DataTypes.TEXT,
+      field: 'speech_text',
+    },
+    breakTitle: {
+      type: DataTypes.STRING(200),
+      field: 'break_title',
+    },
+    slotLabel: {
+      type: DataTypes.STRING(120),
+      field: 'slot_label',
+    },
+  }, {
+    tableName: 'program_items',
+    underscored: true,
+    paranoid: true,
+  });
+
+  return ProgramItem;
+};


### PR DESCRIPTION
## Summary
- add Sequelize models for programs and program items
- wire up associations between choirs, users, pieces and new models

## Testing
- `npm test` *(fails: command terminated without output)*

------
https://chatgpt.com/codex/tasks/task_e_68abff76611083208f37831af72923e9