### PR TITLE
feat: introduce program data models

### DIFF
--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -44,6 +44,8 @@ db.post = require("./post.model.js")(sequelize, Sequelize);
 db.library_item = require("./library_item.model.js")(sequelize, Sequelize);
 db.loan_request = require("./loan_request.model.js")(sequelize, Sequelize);
 db.loan_request_item = require("./loan_request_item.model.js")(sequelize, Sequelize);
+db.program = require("./program.model.js")(sequelize, Sequelize);
+db.program_element = require("./program_element.model.js")(sequelize, Sequelize);
 
 // --- Define Associations ---
 // A Choir has many Users
@@ -77,6 +79,15 @@ db.monthly_plan.hasMany(db.plan_entry, { as: "entries" });
 db.plan_entry.belongsTo(db.monthly_plan, { foreignKey: "monthlyPlanId", as: "monthlyPlan" });
 db.choir.hasMany(db.plan_rule, { as: "planRules" });
 db.plan_rule.belongsTo(db.choir, { foreignKey: "choirId", as: "choir" });
+
+db.choir.hasMany(db.program, { as: 'programs' });
+db.program.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
+
+db.program.hasMany(db.program_element, { as: 'elements' });
+db.program_element.belongsTo(db.program, { foreignKey: 'programId', as: 'program' });
+
+db.piece.hasMany(db.program_element, { as: 'programElements' });
+db.program_element.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
 
 db.user.hasMany(db.user_availability, { as: 'availabilities' });
 db.user_availability.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });

--- a/choir-app-backend/src/models/program.model.js
+++ b/choir-app-backend/src/models/program.model.js
@@ -1,0 +1,22 @@
+module.exports = (sequelize, DataTypes) => {
+  const Program = sequelize.define('program', {
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    status: {
+      type: DataTypes.ENUM('DRAFT', 'PUBLISHED', 'ARCHIVED'),
+      allowNull: false,
+      defaultValue: 'DRAFT'
+    },
+    startTime: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  });
+  return Program;
+};

--- a/choir-app-backend/src/models/program_element.model.js
+++ b/choir-app-backend/src/models/program_element.model.js
@@ -1,0 +1,49 @@
+module.exports = (sequelize, DataTypes) => {
+  const ProgramElement = sequelize.define('program_element', {
+    type: {
+      type: DataTypes.ENUM('PIECE', 'BREAK', 'SPEECH'),
+      allowNull: false
+    },
+    position: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    duration: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
+    pieceId: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    composer: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    instrument: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    note: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    source: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    speaker: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    text: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    }
+  });
+  return ProgramElement;
+};

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -33,6 +33,8 @@ const db = require('../src/models');
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
     checkFields(db.post, ['title', 'text', 'pieceId', 'expiresAt']);
+    checkFields(db.program, ['title', 'description', 'status', 'startTime']);
+    checkFields(db.program_element, ['type', 'position', 'duration']);
 
     // Basic association checks
     assert(db.user.associations.choirs, 'User should have choirs association');
@@ -40,6 +42,8 @@ const db = require('../src/models');
     assert(db.choir.associations.events, 'Choir should have events association');
     assert(db.choir.associations.monthlyPlans, 'Choir should have monthlyPlans association');
     assert(db.choir.associations.planRules, 'Choir should have planRules association');
+    assert(db.choir.associations.programs, 'Choir should have programs association');
+    assert(db.program.associations.elements, 'Program should have elements association');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- add `program` and `program_element` Sequelize models to represent concert/service programs
- wire up associations between choirs, programs, and program elements
- cover new models with existing model tests

## Testing
- `npm test --prefix choir-app-backend`
- `npm run check-backend`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac03e55d988320891f12e494d973d2