### PR TITLE
Fix program association alias and test field

### DIFF
--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -82,9 +82,6 @@ db.plan_entry.belongsTo(db.monthly_plan, { foreignKey: "monthlyPlanId", as: "mon
 db.choir.hasMany(db.plan_rule, { as: "planRules" });
 db.plan_rule.belongsTo(db.choir, { foreignKey: "choirId", as: "choir" });
 
-db.choir.hasMany(db.program, { as: 'programs' });
-db.program.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
-
 db.program.hasMany(db.program_element, { as: 'elements' });
 db.program_element.belongsTo(db.program, { foreignKey: 'programId', as: 'program' });
 

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -33,7 +33,7 @@ const db = require('../src/models');
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
     checkFields(db.post, ['title', 'text', 'pieceId', 'expiresAt']);
-    checkFields(db.program, ['title', 'description', 'status', 'startTime']);
+    checkFields(db.program, ['title', 'description', 'status', 'startAt']);
     checkFields(db.program_element, ['type', 'position', 'duration']);
 
     // Basic association checks


### PR DESCRIPTION
## Summary
- remove duplicate program association to avoid alias conflict
- expect `startAt` in program model test

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68ac128d2b68832093be60f3c2d03331