### PR TITLE
feat(program): allow adding pieces to concerts

### DIFF
--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -83,12 +83,6 @@ db.choir.hasMany(db.plan_rule, { as: "planRules" });
 db.plan_rule.belongsTo(db.choir, { foreignKey: "choirId", as: "choir" });
 
 
-db.program.hasMany(db.program_element, { as: 'elements' });
-db.program_element.belongsTo(db.program, { foreignKey: 'programId', as: 'program' });
-
-db.piece.hasMany(db.program_element, { as: 'programElements' });
-db.program_element.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
-
 db.user.hasMany(db.user_availability, { as: 'availabilities' });
 db.user_availability.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
 db.choir.hasMany(db.user_availability, { as: 'availabilities' });

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -1,7 +1,7 @@
 const authJwt = require('../middleware/auth.middleware');
 const role = require('../middleware/role.middleware');
 const validate = require('../validators/validate');
-const { programValidation } = require('../validators/program.validation');
+const { programValidation, programItemPieceValidation } = require('../validators/program.validation');
 const controller = require('../controllers/program.controller');
 const { handler: wrap } = require('../utils/async');
 const router = require('express').Router();
@@ -9,5 +9,6 @@ const router = require('express').Router();
 router.use(authJwt.verifyToken);
 
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
+router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));
 
 module.exports = router;

--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -5,3 +5,12 @@ exports.programValidation = [
   body('description').optional().isString(),
   body('startTime').optional().isISO8601(),
 ];
+
+// Validation rules for adding a piece item to a program
+exports.programItemPieceValidation = [
+  body('pieceId').isUUID(),
+  body('title').isString().notEmpty(),
+  body('composer').optional().isString(),
+  body('durationSec').optional().isInt({ min: 0 }),
+  body('note').optional().isString(),
+];

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -33,8 +33,9 @@ const db = require('../src/models');
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
     checkFields(db.post, ['title', 'text', 'pieceId', 'expiresAt']);
-    checkFields(db.program, ['title', 'description', 'status', 'startAt']);
+    checkFields(db.program, ['title', 'description', 'status', 'startTime']);
     checkFields(db.program_element, ['type', 'position', 'duration']);
+    checkFields(db.program_item, ['type', 'sortIndex']);
 
     // Basic association checks
     assert(db.user.associations.choirs, 'User should have choirs association');
@@ -43,6 +44,7 @@ const db = require('../src/models');
     assert(db.choir.associations.monthlyPlans, 'Choir should have monthlyPlans association');
     assert(db.choir.associations.planRules, 'Choir should have planRules association');
     assert(db.choir.associations.programs, 'Choir should have programs association');
+    assert(db.program.associations.items, 'Program should have items association');
     assert(db.program.associations.elements, 'Program should have elements association');
     await db.sequelize.close();
   } catch (err) {

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -26,6 +26,25 @@ const controller = require('../src/controllers/program.controller');
     assert.ok(Array.isArray(res.data.items));
     assert.strictEqual(res.data.items.length, 0);
 
+    // create a piece to add
+    const piece = await db.piece.create({ title: 'Song' });
+
+    const addReq = {
+      params: { id: res.data.id },
+      body: {
+        pieceId: piece.id,
+        title: piece.title,
+        composer: 'Anon',
+        durationSec: 120,
+      },
+    };
+    const addRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.addPieceItem(addReq, addRes);
+    assert.strictEqual(addRes.statusCode, 201);
+    assert.strictEqual(addRes.data.pieceId, piece.id);
+    assert.strictEqual(addRes.data.pieceTitleSnapshot, 'Song');
+    assert.strictEqual(addRes.data.durationSec, 120);
+
     console.log('program.controller tests passed');
     await db.sequelize.close();
   } catch (err) {

--- a/choir-app-frontend/src/app/core/models/program.ts
+++ b/choir-app-frontend/src/app/core/models/program.ts
@@ -1,3 +1,16 @@
+export interface ProgramItem {
+  id: string;
+  programId: string;
+  sortIndex: number;
+  type: 'piece' | 'break' | 'speech' | 'slot';
+  durationSec?: number | null;
+  note?: string | null;
+  pieceId?: string;
+  pieceTitleSnapshot?: string;
+  pieceComposerSnapshot?: string;
+  pieceDurationSecSnapshot?: number | null;
+}
+
 export interface Program {
   id: string;
   choirId: string;
@@ -5,5 +18,5 @@ export interface Program {
   description?: string;
   startTime?: string;
   status: string;
-  items: any[];
+  items: ProgramItem[];
 }

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { Program } from '../models/program';
+import { Program, ProgramItem } from '../models/program';
 
 @Injectable({ providedIn: 'root' })
 export class ProgramService {
@@ -9,5 +9,12 @@ export class ProgramService {
 
   createProgram(data: { title: string; description?: string; startTime?: string }): Observable<Program> {
     return this.http.post<Program>('/api/programs', data);
+  }
+
+  addPieceItem(
+    programId: string,
+    data: { pieceId: string; title: string; composer?: string; durationSec?: number; note?: string }
+  ): Observable<ProgramItem> {
+    return this.http.post<ProgramItem>(`/api/programs/${programId}/items`, data);
   }
 }

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -1,0 +1,23 @@
+<button mat-raised-button color="primary" (click)="addPiece()">+ Element</button>
+
+<table mat-table [dataSource]="items" *ngIf="items.length" class="program-table">
+  <ng-container matColumnDef="title">
+    <th mat-header-cell *matHeaderCellDef> Titel </th>
+    <td mat-cell *matCellDef="let item"> {{ item.pieceTitleSnapshot }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="composer">
+    <th mat-header-cell *matHeaderCellDef> Komponist </th>
+    <td mat-cell *matCellDef="let item"> {{ item.pieceComposerSnapshot }} </td>
+  </ng-container>
+
+  <ng-container matColumnDef="duration">
+    <th mat-header-cell *matHeaderCellDef> Dauer (s) </th>
+    <td mat-cell *matCellDef="let item">
+      <input matInput type="number" [(ngModel)]="item.durationSec" />
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="['title', 'composer', 'duration']"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['title', 'composer', 'duration'];"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -1,0 +1,4 @@
+.program-table {
+  width: 100%;
+  margin-top: 16px;
+}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { ProgramService } from '@core/services/program.service';
+import { ProgramItem } from '@core/models/program';
+import { ProgramPieceDialogComponent } from './program-piece-dialog.component';
+
+@Component({
+  selector: 'app-program-editor',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MaterialModule, ProgramPieceDialogComponent],
+  templateUrl: './program-editor.component.html',
+  styleUrls: ['./program-editor.component.scss'],
+})
+export class ProgramEditorComponent {
+  programId = '';
+  items: ProgramItem[] = [];
+
+  constructor(private dialog: MatDialog, private programService: ProgramService) {}
+
+  addPiece() {
+    const dialogRef = this.dialog.open(ProgramPieceDialogComponent, {
+      width: '600px',
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService.addPieceItem(this.programId, result).subscribe(item => {
+          this.items = [...this.items, item];
+        });
+      }
+    });
+  }
+}

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.html
@@ -1,0 +1,30 @@
+<h1 mat-dialog-title>Musikstück</h1>
+<mat-dialog-content>
+  <mat-slide-toggle [(ngModel)]="repertoireOnly" (change)="toggleSource()">
+    Nur Repertoire dieses Chors
+  </mat-slide-toggle>
+  <form [formGroup]="searchForm" (ngSubmit)="onSearch()" class="search-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Titel</mat-label>
+      <input matInput formControlName="title" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Komponist</mat-label>
+      <input matInput formControlName="composer" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Tags</mat-label>
+      <input matInput formControlName="tags" />
+    </mat-form-field>
+    <mat-checkbox formControlName="hasDuration">Dauer vorhanden?</mat-checkbox>
+    <button mat-raised-button color="primary" type="submit">Suchen</button>
+  </form>
+  <mat-list>
+    <mat-list-item *ngFor="let piece of pieces" (click)="selectPiece(piece)">
+      {{ piece.title }} – {{ piece.composerName }}
+    </mat-list-item>
+  </mat-list>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+</mat-dialog-actions>

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.scss
@@ -1,0 +1,6 @@
+.search-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.ts
@@ -1,0 +1,101 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { SearchService } from '@core/services/search.service';
+
+interface PieceLookup {
+  id: string | number;
+  title: string;
+  composerName?: string;
+  durationSec?: number;
+}
+
+@Component({
+  selector: 'app-program-piece-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule],
+  templateUrl: './program-piece-dialog.component.html',
+  styleUrls: ['./program-piece-dialog.component.scss'],
+})
+export class ProgramPieceDialogComponent implements OnInit {
+  searchForm: FormGroup;
+  repertoireOnly = true;
+  pieces: PieceLookup[] = [];
+
+  constructor(
+    private fb: FormBuilder,
+    private api: ApiService,
+    private search: SearchService,
+    private dialogRef: MatDialogRef<ProgramPieceDialogComponent>
+  ) {
+    this.searchForm = this.fb.group({
+      title: [''],
+      composer: [''],
+      tags: [''],
+      hasDuration: [false],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadPieces();
+  }
+
+  toggleSource() {
+    this.repertoireOnly = !this.repertoireOnly;
+    this.loadPieces();
+  }
+
+  onSearch() {
+    this.loadPieces();
+  }
+
+  private loadPieces() {
+    if (this.repertoireOnly) {
+      this.api.getRepertoireForLookup().subscribe(pieces => {
+        const mapped: PieceLookup[] = pieces.map(p => ({
+          id: p.id,
+          title: p.title,
+          composerName: p.composerName,
+        }));
+        this.pieces = this.applyFilters(mapped);
+      });
+    } else {
+      const term = this.searchForm.value.title || '';
+      this.search.searchAll(term).subscribe(res => {
+        const mapped: PieceLookup[] = (res.pieces || []).map(p => ({
+          id: p.id,
+          title: p.title,
+          composerName: p.composer?.name || p.origin || '',
+          durationSec: (p as any).durationSec || (p as any).pieceDurationSecSnapshot,
+        }));
+        this.pieces = this.applyFilters(mapped);
+      });
+    }
+  }
+
+  private applyFilters(pieces: PieceLookup[]): PieceLookup[] {
+    const { title, composer, hasDuration } = this.searchForm.value;
+    return pieces.filter(p => {
+      const titleMatch = title ? p.title.toLowerCase().includes(title.toLowerCase()) : true;
+      const compMatch = composer ? (p.composerName || '').toLowerCase().includes(composer.toLowerCase()) : true;
+      const durationMatch = hasDuration ? typeof p.durationSec === 'number' : true;
+      return titleMatch && compMatch && durationMatch;
+    });
+  }
+
+  selectPiece(piece: PieceLookup) {
+    this.dialogRef.close({
+      pieceId: piece.id,
+      title: piece.title,
+      composer: piece.composerName,
+      durationSec: piece.durationSec,
+    });
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add backend endpoint to append piece items to programs with snapshots
- expose program item addition via frontend service and new program editor/dialog
- cover program piece addition with new tests and model updates

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: libatk-1.0.so.0 missing)


------
https://chatgpt.com/codex/tasks/task_e_68ac23cecde88320ba3446112df94710