### PR TITLE
feat: allow adding free pieces to programs

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -56,3 +56,32 @@ exports.addPieceItem = async (req, res) => {
     res.status(500).send({ message: err.message });
   }
 };
+
+// Add a free piece item to an existing program
+exports.addFreePieceItem = async (req, res) => {
+  const { id } = req.params;
+  const { title, composer, instrument, performerNames, durationSec, note } = req.body;
+  try {
+    const program = await Program.findByPk(id);
+    if (!program) return res.status(404).send({ message: 'program not found' });
+
+    const sortIndex = await db.program_item.count({ where: { programId: id } });
+
+    const item = await db.program_item.create({
+      programId: id,
+      sortIndex,
+      type: 'piece',
+      durationSec: typeof durationSec === 'number' ? durationSec : null,
+      note: note || null,
+      pieceId: null,
+      pieceTitleSnapshot: title,
+      pieceComposerSnapshot: composer || null,
+      pieceDurationSecSnapshot: typeof durationSec === 'number' ? durationSec : null,
+      instrument: instrument || null,
+      performerNames: performerNames || null,
+    });
+    res.status(201).send(item);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -1,7 +1,7 @@
 const authJwt = require('../middleware/auth.middleware');
 const role = require('../middleware/role.middleware');
 const validate = require('../validators/validate');
-const { programValidation, programItemPieceValidation } = require('../validators/program.validation');
+const { programValidation, programItemPieceValidation, programItemFreePieceValidation } = require('../validators/program.validation');
 const controller = require('../controllers/program.controller');
 const { handler: wrap } = require('../utils/async');
 const router = require('express').Router();
@@ -10,5 +10,6 @@ router.use(authJwt.verifyToken);
 
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));
+router.post('/:id/items/free', role.requireDirector, programItemFreePieceValidation, validate, wrap(controller.addFreePieceItem));
 
 module.exports = router;

--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -14,3 +14,13 @@ exports.programItemPieceValidation = [
   body('durationSec').optional().isInt({ min: 0 }),
   body('note').optional().isString(),
 ];
+
+// Validation rules for adding a free piece item to a program
+exports.programItemFreePieceValidation = [
+  body('title').isString().notEmpty(),
+  body('composer').optional().isString(),
+  body('instrument').optional().isString(),
+  body('performerNames').optional().isString(),
+  body('durationSec').optional().isInt({ min: 0 }),
+  body('note').optional().isString(),
+];

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -45,6 +45,27 @@ const controller = require('../src/controllers/program.controller');
     assert.strictEqual(addRes.data.pieceTitleSnapshot, 'Song');
     assert.strictEqual(addRes.data.durationSec, 120);
 
+    // add a free piece
+    const freeReq = {
+      params: { id: res.data.id },
+      body: {
+        title: 'Free Song',
+        composer: 'Anon',
+        instrument: 'Piano',
+        performerNames: 'Alice',
+        durationSec: 150,
+        note: 'Solo',
+      },
+    };
+    const freeRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.addFreePieceItem(freeReq, freeRes);
+    assert.strictEqual(freeRes.statusCode, 201);
+    assert.strictEqual(freeRes.data.pieceId, null);
+    assert.strictEqual(freeRes.data.pieceTitleSnapshot, 'Free Song');
+    assert.strictEqual(freeRes.data.instrument, 'Piano');
+    assert.strictEqual(freeRes.data.performerNames, 'Alice');
+    assert.strictEqual(freeRes.data.durationSec, 150);
+
     console.log('program.controller tests passed');
     await db.sequelize.close();
   } catch (err) {

--- a/choir-app-frontend/src/app/core/models/program.ts
+++ b/choir-app-frontend/src/app/core/models/program.ts
@@ -9,6 +9,8 @@ export interface ProgramItem {
   pieceTitleSnapshot?: string;
   pieceComposerSnapshot?: string;
   pieceDurationSecSnapshot?: number | null;
+  instrument?: string | null;
+  performerNames?: string | null;
 }
 
 export interface Program {

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -17,4 +17,18 @@ export class ProgramService {
   ): Observable<ProgramItem> {
     return this.http.post<ProgramItem>(`/api/programs/${programId}/items`, data);
   }
+
+  addFreePieceItem(
+    programId: string,
+    data: {
+      title: string;
+      composer?: string;
+      instrument?: string;
+      performerNames?: string;
+      durationSec?: number;
+      note?: string;
+    }
+  ): Observable<ProgramItem> {
+    return this.http.post<ProgramItem>(`/api/programs/${programId}/items/free`, data);
+  }
 }


### PR DESCRIPTION
## Summary
- allow adding ad-hoc pieces to concert programs
- support optional composer, instrument, performers and notes for free pieces
- expose API and frontend service for free piece items

## Testing
- `npm test` (backend)
- `node tests/program.controller.test.js`
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac309635f083208d02609976a18e6f