### PR TITLE
chore: remove unused dialog component import

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -10,7 +10,7 @@ import { ProgramPieceDialogComponent } from './program-piece-dialog.component';
 @Component({
   selector: 'app-program-editor',
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule, ProgramPieceDialogComponent],
+  imports: [CommonModule, FormsModule, MaterialModule],
   templateUrl: './program-editor.component.html',
   styleUrls: ['./program-editor.component.scss'],
 })


### PR DESCRIPTION
## Summary
- drop ProgramPieceDialogComponent from ProgramEditorComponent imports

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac31f0d9ac8320b527ecf462e10cef