### PR TITLE
feat: add pause items to concert programs

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -85,3 +85,26 @@ exports.addFreePieceItem = async (req, res) => {
     res.status(500).send({ message: err.message });
   }
 };
+
+// Add a break item to an existing program
+exports.addBreakItem = async (req, res) => {
+  const { id } = req.params;
+  const { durationSec, note } = req.body;
+  try {
+    const program = await Program.findByPk(id);
+    if (!program) return res.status(404).send({ message: 'program not found' });
+
+    const sortIndex = await db.program_item.count({ where: { programId: id } });
+
+    const item = await db.program_item.create({
+      programId: id,
+      sortIndex,
+      type: 'break',
+      durationSec: typeof durationSec === 'number' ? durationSec : null,
+      note: note || null,
+    });
+    res.status(201).send(item);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -1,7 +1,7 @@
 const authJwt = require('../middleware/auth.middleware');
 const role = require('../middleware/role.middleware');
 const validate = require('../validators/validate');
-const { programValidation, programItemPieceValidation, programItemFreePieceValidation } = require('../validators/program.validation');
+const { programValidation, programItemPieceValidation, programItemFreePieceValidation, programItemBreakValidation } = require('../validators/program.validation');
 const controller = require('../controllers/program.controller');
 const { handler: wrap } = require('../utils/async');
 const router = require('express').Router();
@@ -11,5 +11,6 @@ router.use(authJwt.verifyToken);
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));
 router.post('/:id/items/free', role.requireDirector, programItemFreePieceValidation, validate, wrap(controller.addFreePieceItem));
+router.post('/:id/items/break', role.requireDirector, programItemBreakValidation, validate, wrap(controller.addBreakItem));
 
 module.exports = router;

--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -24,3 +24,9 @@ exports.programItemFreePieceValidation = [
   body('durationSec').optional().isInt({ min: 0 }),
   body('note').optional().isString(),
 ];
+
+// Validation rules for adding a break item to a program
+exports.programItemBreakValidation = [
+  body('durationSec').isInt({ min: 0 }),
+  body('note').optional().isString(),
+];

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -66,6 +66,21 @@ const controller = require('../src/controllers/program.controller');
     assert.strictEqual(freeRes.data.performerNames, 'Alice');
     assert.strictEqual(freeRes.data.durationSec, 150);
 
+    // add a break
+    const breakReq = {
+      params: { id: res.data.id },
+      body: {
+        durationSec: 300,
+        note: 'Umbau Bühne',
+      },
+    };
+    const breakRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.addBreakItem(breakReq, breakRes);
+    assert.strictEqual(breakRes.statusCode, 201);
+    assert.strictEqual(breakRes.data.type, 'break');
+    assert.strictEqual(breakRes.data.durationSec, 300);
+    assert.strictEqual(breakRes.data.note, 'Umbau Bühne');
+
     console.log('program.controller tests passed');
     await db.sequelize.close();
   } catch (err) {

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -31,4 +31,11 @@ export class ProgramService {
   ): Observable<ProgramItem> {
     return this.http.post<ProgramItem>(`/api/programs/${programId}/items/free`, data);
   }
+
+  addBreakItem(
+    programId: string,
+    data: { durationSec: number; note?: string }
+  ): Observable<ProgramItem> {
+    return this.http.post<ProgramItem>(`/api/programs/${programId}/items/break`, data);
+  }
 }

--- a/choir-app-frontend/src/app/features/program/program-break-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-break-dialog.component.html
@@ -1,0 +1,17 @@
+<h1 mat-dialog-title>Pause</h1>
+<mat-dialog-content>
+  <form [formGroup]="breakForm" class="break-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Dauer (mm:ss)</mat-label>
+      <input matInput formControlName="duration" placeholder="05:00" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Notiz</mat-label>
+      <input matInput formControlName="note" />
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-raised-button color="primary" (click)="save()" [disabled]="breakForm.invalid">Speichern</button>
+</mat-dialog-actions>

--- a/choir-app-frontend/src/app/features/program/program-break-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-break-dialog.component.scss
@@ -1,0 +1,5 @@
+.break-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/choir-app-frontend/src/app/features/program/program-break-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-break-dialog.component.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+
+@Component({
+  selector: 'app-program-break-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, ReactiveFormsModule],
+  templateUrl: './program-break-dialog.component.html',
+  styleUrls: ['./program-break-dialog.component.scss'],
+})
+export class ProgramBreakDialogComponent {
+  breakForm: FormGroup;
+
+  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<ProgramBreakDialogComponent>) {
+    this.breakForm = this.fb.group({
+      duration: ['', Validators.required],
+      note: [''],
+    });
+  }
+
+  save() {
+    const { duration, note } = this.breakForm.value;
+    const match = /^\d{1,2}:\d{2}$/.test(duration);
+    if (!match) {
+      return;
+    }
+    const [m, s] = duration.split(':').map((v: string) => parseInt(v, 10));
+    const durationSec = m * 60 + s;
+    this.dialogRef.close({ durationSec, note });
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -1,9 +1,10 @@
-<button mat-raised-button color="primary" (click)="addPiece()">+ Element</button>
+<button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>
+<button mat-raised-button color="accent" (click)="addBreak()">+ Pause</button>
 
 <table mat-table [dataSource]="items" *ngIf="items.length" class="program-table">
   <ng-container matColumnDef="title">
     <th mat-header-cell *matHeaderCellDef> Titel </th>
-    <td mat-cell *matCellDef="let item"> {{ item.pieceTitleSnapshot }} </td>
+    <td mat-cell *matCellDef="let item"> {{ item.type === 'break' ? 'Pause' : item.pieceTitleSnapshot }} </td>
   </ng-container>
 
   <ng-container matColumnDef="composer">
@@ -18,6 +19,13 @@
     </td>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="['title', 'composer', 'duration']"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['title', 'composer', 'duration'];"></tr>
+  <ng-container matColumnDef="note">
+    <th mat-header-cell *matHeaderCellDef> Notiz </th>
+    <td mat-cell *matCellDef="let item">
+      <input matInput [(ngModel)]="item.note" />
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="['title', 'composer', 'duration', 'note']"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['title', 'composer', 'duration', 'note'];"></tr>
 </table>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -6,6 +6,7 @@ import { MaterialModule } from '@modules/material.module';
 import { ProgramService } from '@core/services/program.service';
 import { ProgramItem } from '@core/models/program';
 import { ProgramPieceDialogComponent } from './program-piece-dialog.component';
+import { ProgramBreakDialogComponent } from './program-break-dialog.component';
 
 @Component({
   selector: 'app-program-editor',
@@ -27,6 +28,19 @@ export class ProgramEditorComponent {
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         this.programService.addPieceItem(this.programId, result).subscribe(item => {
+          this.items = [...this.items, item];
+        });
+      }
+    });
+  }
+
+  addBreak() {
+    const dialogRef = this.dialog.open(ProgramBreakDialogComponent, {
+      width: '400px',
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService.addBreakItem(this.programId, result).subscribe(item => {
           this.items = [...this.items, item];
         });
       }


### PR DESCRIPTION
## Summary
- allow adding break items with duration and note to programs
- expose `/items/break` endpoint and validator
- add break dialog and button in program editor UI

## Testing
- `node tests/program.controller.test.js`
- `npm test --prefix choir-app-frontend` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac474f12b48320bc6be9d3ed15a4e2