### PR TITLE
feat: add speech contribution items to program

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -85,3 +85,30 @@ exports.addFreePieceItem = async (req, res) => {
     res.status(500).send({ message: err.message });
   }
 };
+
+// Add a speech item to an existing program
+exports.addSpeechItem = async (req, res) => {
+  const { id } = req.params;
+  const { title, source, speaker, text, durationSec, note } = req.body;
+  try {
+    const program = await Program.findByPk(id);
+    if (!program) return res.status(404).send({ message: 'program not found' });
+
+    const sortIndex = await db.program_item.count({ where: { programId: id } });
+
+    const item = await db.program_item.create({
+      programId: id,
+      sortIndex,
+      type: 'speech',
+      durationSec: typeof durationSec === 'number' ? durationSec : null,
+      note: note || null,
+      speechTitle: title,
+      speechSource: source || null,
+      speechSpeaker: speaker || null,
+      speechText: text || null,
+    });
+    res.status(201).send(item);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -1,7 +1,7 @@
 const authJwt = require('../middleware/auth.middleware');
 const role = require('../middleware/role.middleware');
 const validate = require('../validators/validate');
-const { programValidation, programItemPieceValidation, programItemFreePieceValidation } = require('../validators/program.validation');
+const { programValidation, programItemPieceValidation, programItemFreePieceValidation, programItemSpeechValidation } = require('../validators/program.validation');
 const controller = require('../controllers/program.controller');
 const { handler: wrap } = require('../utils/async');
 const router = require('express').Router();
@@ -11,5 +11,6 @@ router.use(authJwt.verifyToken);
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));
 router.post('/:id/items/free', role.requireDirector, programItemFreePieceValidation, validate, wrap(controller.addFreePieceItem));
+router.post('/:id/items/speech', role.requireDirector, programItemSpeechValidation, validate, wrap(controller.addSpeechItem));
 
 module.exports = router;

--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -24,3 +24,13 @@ exports.programItemFreePieceValidation = [
   body('durationSec').optional().isInt({ min: 0 }),
   body('note').optional().isString(),
 ];
+
+// Validation rules for adding a speech item to a program
+exports.programItemSpeechValidation = [
+  body('title').isString().notEmpty(),
+  body('source').optional().isString(),
+  body('speaker').optional().isString(),
+  body('text').optional().isString(),
+  body('durationSec').optional().isInt({ min: 0 }),
+  body('note').optional().isString(),
+];

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -66,6 +66,24 @@ const controller = require('../src/controllers/program.controller');
     assert.strictEqual(freeRes.data.performerNames, 'Alice');
     assert.strictEqual(freeRes.data.durationSec, 150);
 
+    // add a speech item
+    const speechReq = {
+      params: { id: res.data.id },
+      body: {
+        title: 'Welcome',
+        source: 'Author',
+        speaker: 'Bob',
+        text: 'Welcome everyone',
+        durationSec: 30,
+      },
+    };
+    const speechRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.addSpeechItem(speechReq, speechRes);
+    assert.strictEqual(speechRes.statusCode, 201);
+    assert.strictEqual(speechRes.data.speechTitle, 'Welcome');
+    assert.strictEqual(speechRes.data.speechSpeaker, 'Bob');
+    assert.strictEqual(speechRes.data.durationSec, 30);
+
     console.log('program.controller tests passed');
     await db.sequelize.close();
   } catch (err) {

--- a/choir-app-frontend/src/app/core/models/program.ts
+++ b/choir-app-frontend/src/app/core/models/program.ts
@@ -11,6 +11,10 @@ export interface ProgramItem {
   pieceDurationSecSnapshot?: number | null;
   instrument?: string | null;
   performerNames?: string | null;
+  speechTitle?: string | null;
+  speechSource?: string | null;
+  speechSpeaker?: string | null;
+  speechText?: string | null;
 }
 
 export interface Program {

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -31,4 +31,11 @@ export class ProgramService {
   ): Observable<ProgramItem> {
     return this.http.post<ProgramItem>(`/api/programs/${programId}/items/free`, data);
   }
+
+  addSpeechItem(
+    programId: string,
+    data: { title: string; source?: string; speaker?: string; text?: string; durationSec?: number; note?: string }
+  ): Observable<ProgramItem> {
+    return this.http.post<ProgramItem>(`/api/programs/${programId}/items/speech`, data);
+  }
 }

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -1,14 +1,25 @@
-<button mat-raised-button color="primary" (click)="addPiece()">+ Element</button>
+<button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>
+<button mat-raised-button color="accent" class="add-speech" (click)="addSpeech()">+ Sprachbeitrag</button>
 
 <table mat-table [dataSource]="items" *ngIf="items.length" class="program-table">
   <ng-container matColumnDef="title">
     <th mat-header-cell *matHeaderCellDef> Titel </th>
-    <td mat-cell *matCellDef="let item"> {{ item.pieceTitleSnapshot }} </td>
+    <td mat-cell *matCellDef="let item">
+      <ng-container [ngSwitch]="item.type">
+        <span *ngSwitchCase="'piece'">{{ item.pieceTitleSnapshot }}</span>
+        <span *ngSwitchCase="'speech'">{{ item.speechTitle }}</span>
+      </ng-container>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="composer">
-    <th mat-header-cell *matHeaderCellDef> Komponist </th>
-    <td mat-cell *matCellDef="let item"> {{ item.pieceComposerSnapshot }} </td>
+    <th mat-header-cell *matHeaderCellDef> Komponist / Sprecher </th>
+    <td mat-cell *matCellDef="let item">
+      <ng-container [ngSwitch]="item.type">
+        <span *ngSwitchCase="'piece'">{{ item.pieceComposerSnapshot }}</span>
+        <span *ngSwitchCase="'speech'">{{ item.speechSpeaker }}</span>
+      </ng-container>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="duration">

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -2,3 +2,7 @@
   width: 100%;
   margin-top: 16px;
 }
+
+.add-speech {
+  margin-left: 8px;
+}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -6,6 +6,7 @@ import { MaterialModule } from '@modules/material.module';
 import { ProgramService } from '@core/services/program.service';
 import { ProgramItem } from '@core/models/program';
 import { ProgramPieceDialogComponent } from './program-piece-dialog.component';
+import { ProgramSpeechDialogComponent } from './program-speech-dialog.component';
 
 @Component({
   selector: 'app-program-editor',
@@ -27,6 +28,19 @@ export class ProgramEditorComponent {
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         this.programService.addPieceItem(this.programId, result).subscribe(item => {
+          this.items = [...this.items, item];
+        });
+      }
+    });
+  }
+
+  addSpeech() {
+    const dialogRef = this.dialog.open(ProgramSpeechDialogComponent, {
+      width: '600px',
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService.addSpeechItem(this.programId, result).subscribe(item => {
           this.items = [...this.items, item];
         });
       }

--- a/choir-app-frontend/src/app/features/program/program-speech-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-speech-dialog.component.html
@@ -1,0 +1,29 @@
+<h1 mat-dialog-title>Sprachbeitrag</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" class="speech-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Titel</mat-label>
+      <input matInput formControlName="title" required />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Quelle</mat-label>
+      <input matInput formControlName="source" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Sprecher:in</mat-label>
+      <input matInput formControlName="speaker" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Kurztext / Anriss</mat-label>
+      <textarea matInput formControlName="text"></textarea>
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Dauer (s)</mat-label>
+      <input matInput type="number" formControlName="durationSec" />
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-raised-button color="primary" (click)="save()" [disabled]="form.invalid">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/program/program-speech-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-speech-dialog.component.scss
@@ -1,0 +1,9 @@
+.speech-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.mat-form-field {
+  width: 100%;
+  margin-top: 8px;
+}

--- a/choir-app-frontend/src/app/features/program/program-speech-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-speech-dialog.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+
+@Component({
+  selector: 'app-program-speech-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule],
+  templateUrl: './program-speech-dialog.component.html',
+  styleUrls: ['./program-speech-dialog.component.scss'],
+})
+export class ProgramSpeechDialogComponent {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<ProgramSpeechDialogComponent>) {
+    this.form = this.fb.group({
+      title: ['', Validators.required],
+      source: [''],
+      speaker: [''],
+      text: [''],
+      durationSec: [null],
+    });
+  }
+
+  save() {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add backend endpoint and validation for speech items
- support speech contributions in program editor with dedicated dialog
- cover speech item creation in controller tests

## Testing
- `npm test` *(fails: error while loading shared libraries: libcups.so.2)*
- `npm run test:backend`


------
https://chatgpt.com/codex/tasks/task_e_68ac476210288320bfdd299944f77581