### PR TITLE
feat: add deep links for program pieces

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -18,6 +18,13 @@
     </td>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="['title', 'composer', 'duration']"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['title', 'composer', 'duration'];"></tr>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef> Aktionen </th>
+    <td mat-cell *matCellDef="let item">
+      <a *ngIf="item.pieceId" [routerLink]="['/pieces', item.pieceId]" target="_blank">Details</a>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="['title', 'composer', 'duration', 'actions']"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['title', 'composer', 'duration', 'actions'];"></tr>
 </table>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { ProgramService } from '@core/services/program.service';
@@ -10,7 +11,7 @@ import { ProgramPieceDialogComponent } from './program-piece-dialog.component';
 @Component({
   selector: 'app-program-editor',
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule],
+  imports: [CommonModule, FormsModule, MaterialModule, RouterModule],
   templateUrl: './program-editor.component.html',
   styleUrls: ['./program-editor.component.scss'],
 })

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.html
@@ -22,6 +22,7 @@
   <mat-list>
     <mat-list-item *ngFor="let piece of pieces" (click)="selectPiece(piece)">
       {{ piece.title }} – {{ piece.composerName }}
+      <a mat-button [routerLink]="['/pieces', piece.id]" target="_blank" (click)="$event.stopPropagation()">Details</a>
     </mat-list-item>
   </mat-list>
 </mat-dialog-content>

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
@@ -16,7 +17,7 @@ interface PieceLookup {
 @Component({
   selector: 'app-program-piece-dialog',
   standalone: true,
-  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule, RouterModule],
   templateUrl: './program-piece-dialog.component.html',
   styleUrls: ['./program-piece-dialog.component.scss'],
 })


### PR DESCRIPTION
## Summary
- link program items with database references to piece detail pages in new tabs
- allow viewing piece details from the program piece dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4773ab7c83208dfa639af62cf98c