### PR TITLE
feat: reorder program items and show live duration

### DIFF
--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -1,7 +1,13 @@
 const authJwt = require('../middleware/auth.middleware');
 const role = require('../middleware/role.middleware');
 const validate = require('../validators/validate');
-const { programValidation, programItemPieceValidation, programItemFreePieceValidation, programItemBreakValidation } = require('../validators/program.validation');
+const {
+  programValidation,
+  programItemPieceValidation,
+  programItemFreePieceValidation,
+  programItemBreakValidation,
+  programItemsReorderValidation,
+} = require('../validators/program.validation');
 const controller = require('../controllers/program.controller');
 const { handler: wrap } = require('../utils/async');
 const router = require('express').Router();
@@ -12,5 +18,12 @@ router.post('/', role.requireDirector, programValidation, validate, wrap(control
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));
 router.post('/:id/items/free', role.requireDirector, programItemFreePieceValidation, validate, wrap(controller.addFreePieceItem));
 router.post('/:id/items/break', role.requireDirector, programItemBreakValidation, validate, wrap(controller.addBreakItem));
+router.put(
+  '/:id/items/reorder',
+  role.requireDirector,
+  programItemsReorderValidation,
+  validate,
+  wrap(controller.reorderItems)
+);
 
 module.exports = router;

--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -30,3 +30,9 @@ exports.programItemBreakValidation = [
   body('durationSec').isInt({ min: 0 }),
   body('note').optional().isString(),
 ];
+
+// Validation rules for reordering program items
+exports.programItemsReorderValidation = [
+  body('order').isArray(),
+  body('order.*').isUUID(),
+];

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -40,10 +40,11 @@ const controller = require('../src/controllers/program.controller');
     };
     const addRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
     await controller.addPieceItem(addReq, addRes);
+    const pieceItem = addRes.data;
     assert.strictEqual(addRes.statusCode, 201);
-    assert.strictEqual(addRes.data.pieceId, piece.id);
-    assert.strictEqual(addRes.data.pieceTitleSnapshot, 'Song');
-    assert.strictEqual(addRes.data.durationSec, 120);
+    assert.strictEqual(pieceItem.pieceId, piece.id);
+    assert.strictEqual(pieceItem.pieceTitleSnapshot, 'Song');
+    assert.strictEqual(pieceItem.durationSec, 120);
 
     // add a free piece
     const freeReq = {
@@ -59,12 +60,13 @@ const controller = require('../src/controllers/program.controller');
     };
     const freeRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
     await controller.addFreePieceItem(freeReq, freeRes);
+    const freeItem = freeRes.data;
     assert.strictEqual(freeRes.statusCode, 201);
-    assert.strictEqual(freeRes.data.pieceId, null);
-    assert.strictEqual(freeRes.data.pieceTitleSnapshot, 'Free Song');
-    assert.strictEqual(freeRes.data.instrument, 'Piano');
-    assert.strictEqual(freeRes.data.performerNames, 'Alice');
-    assert.strictEqual(freeRes.data.durationSec, 150);
+    assert.strictEqual(freeItem.pieceId, null);
+    assert.strictEqual(freeItem.pieceTitleSnapshot, 'Free Song');
+    assert.strictEqual(freeItem.instrument, 'Piano');
+    assert.strictEqual(freeItem.performerNames, 'Alice');
+    assert.strictEqual(freeItem.durationSec, 150);
 
     // add a break
     const breakReq = {
@@ -76,10 +78,22 @@ const controller = require('../src/controllers/program.controller');
     };
     const breakRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
     await controller.addBreakItem(breakReq, breakRes);
+    const breakItem = breakRes.data;
     assert.strictEqual(breakRes.statusCode, 201);
-    assert.strictEqual(breakRes.data.type, 'break');
-    assert.strictEqual(breakRes.data.durationSec, 300);
-    assert.strictEqual(breakRes.data.note, 'Umbau Bühne');
+    assert.strictEqual(breakItem.type, 'break');
+    assert.strictEqual(breakItem.durationSec, 300);
+    assert.strictEqual(breakItem.note, 'Umbau Bühne');
+
+    // reorder items
+    const orderReq = {
+      params: { id: res.data.id },
+      body: { order: [breakItem.id, pieceItem.id, freeItem.id] },
+    };
+    const orderRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.reorderItems(orderReq, orderRes);
+    assert.strictEqual(orderRes.statusCode, 200);
+    assert.deepStrictEqual(orderRes.data.map(i => i.id), [breakItem.id, pieceItem.id, freeItem.id]);
+    assert.strictEqual(orderRes.data[0].sortIndex, 0);
 
     console.log('program.controller tests passed');
     await db.sequelize.close();

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -38,4 +38,8 @@ export class ProgramService {
   ): Observable<ProgramItem> {
     return this.http.post<ProgramItem>(`/api/programs/${programId}/items/break`, data);
   }
+
+  reorderItems(programId: string, order: string[]): Observable<ProgramItem[]> {
+    return this.http.put<ProgramItem[]>(`/api/programs/${programId}/items/reorder`, { order });
+  }
 }

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -1,10 +1,44 @@
 <button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>
 <button mat-raised-button color="accent" (click)="addBreak()">+ Pause</button>
 
-<table mat-table [dataSource]="items" *ngIf="items.length" class="program-table">
+<table
+  mat-table
+  [dataSource]="items"
+  *ngIf="items.length"
+  class="program-table"
+  cdkDropList
+  (cdkDropListDropped)="drop($event)"
+>
+  <ng-container matColumnDef="move">
+    <th mat-header-cell *matHeaderCellDef></th>
+    <td mat-cell *matCellDef="let item; let i = index">
+      <button
+        mat-icon-button
+        (click)="moveUp(i)"
+        [disabled]="i === 0"
+        aria-label="Nach oben"
+      >
+        <mat-icon>arrow_upward</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        (click)="moveDown(i)"
+        [disabled]="i === items.length - 1"
+        aria-label="Nach unten"
+      >
+        <mat-icon>arrow_downward</mat-icon>
+      </button>
+      <span class="drag-handle" cdkDragHandle aria-label="Greifen">
+        <mat-icon>drag_indicator</mat-icon>
+      </span>
+    </td>
+  </ng-container>
+
   <ng-container matColumnDef="title">
     <th mat-header-cell *matHeaderCellDef> Titel </th>
-    <td mat-cell *matCellDef="let item"> {{ item.type === 'break' ? 'Pause' : item.pieceTitleSnapshot }} </td>
+    <td mat-cell *matCellDef="let item">
+      {{ item.type === 'break' ? 'Pause' : item.pieceTitleSnapshot }}
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="composer">
@@ -26,13 +60,27 @@
     </td>
   </ng-container>
 
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef> Aktionen </th>
-    <td mat-cell *matCellDef="let item">
-      <a *ngIf="item.pieceId" [routerLink]="['/pieces', item.pieceId]" target="_blank">Details</a>
+  <ng-container matColumnDef="sum">
+    <th mat-header-cell *matHeaderCellDef> Summe </th>
+    <td mat-cell *matCellDef="let item; let i = index">
+      {{ getCumulativeDuration(i) }}
     </td>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="['title', 'composer', 'duration', 'note', 'action']"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['title', 'composer', 'duration', 'note', actions];"></tr>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef> Aktionen </th>
+    <td mat-cell *matCellDef="let item">
+      <a *ngIf="item.pieceId" [routerLink]="['/pieces', item.pieceId]" target="_blank"
+        >Details</a
+      >
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns" cdkDrag></tr>
 </table>
+
+<div *ngIf="items.length" class="total-duration">
+  Gesamtdauer: {{ getTotalDuration() }}
+</div>
+

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -2,3 +2,14 @@
   width: 100%;
   margin-top: 16px;
 }
+
+.drag-handle {
+  cursor: move;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
+.total-duration {
+  margin-top: 8px;
+  font-weight: bold;
+}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -19,6 +20,7 @@ import { ProgramBreakDialogComponent } from './program-break-dialog.component';
 export class ProgramEditorComponent {
   programId = '';
   items: ProgramItem[] = [];
+  displayedColumns = ['move', 'title', 'composer', 'duration', 'note', 'sum', 'actions'];
 
   constructor(private dialog: MatDialog, private programService: ProgramService) {}
 
@@ -46,5 +48,52 @@ export class ProgramEditorComponent {
         });
       }
     });
+  }
+
+  drop(event: CdkDragDrop<ProgramItem[]>) {
+    moveItemInArray(this.items, event.previousIndex, event.currentIndex);
+    this.saveOrder();
+  }
+
+  moveUp(index: number) {
+    if (index === 0) return;
+    moveItemInArray(this.items, index, index - 1);
+    this.saveOrder();
+  }
+
+  moveDown(index: number) {
+    if (index === this.items.length - 1) return;
+    moveItemInArray(this.items, index, index + 1);
+    this.saveOrder();
+  }
+
+  saveOrder() {
+    this.programService
+      .reorderItems(this.programId, this.items.map(i => i.id))
+      .subscribe(items => {
+        this.items = items;
+      });
+  }
+
+  getCumulativeDuration(index: number): string {
+    const total = this.items
+      .slice(0, index + 1)
+      .reduce((sum, item) => sum + (item.durationSec || 0), 0);
+    return this.formatDuration(total);
+  }
+
+  getTotalDuration(): string {
+    const total = this.items.reduce((sum, item) => sum + (item.durationSec || 0), 0);
+    return this.formatDuration(total);
+  }
+
+  private formatDuration(seconds: number): string {
+    const m = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, '0');
+    const s = Math.floor(seconds % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${m}:${s}`;
   }
 }


### PR DESCRIPTION
## Summary
- add backend API and validation to reorder concert program items
- enable drag & drop/up-down reordering in program editor with live cumulative times
- cover reordering in program controller tests

## Testing
- `npm test` (backend)
- `npm test` *(fails: ChromeHeadless missing libXcomposite.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ac53cf51f4832085ebc43f79f023bf