### PR TITLE
fix(frontend): include API base url for program service

### DIFF
--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -2,20 +2,23 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Program, ProgramItem } from '../models/program';
+import { environment } from 'src/environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ProgramService {
+  private apiUrl = environment.apiUrl;
+
   constructor(private http: HttpClient) {}
 
   createProgram(data: { title: string; description?: string; startTime?: string }): Observable<Program> {
-    return this.http.post<Program>('/api/programs', data);
+    return this.http.post<Program>(`${this.apiUrl}/programs`, data);
   }
 
   addPieceItem(
     programId: string,
     data: { pieceId: string; title: string; composer?: string; durationSec?: number; note?: string }
   ): Observable<ProgramItem> {
-    return this.http.post<ProgramItem>(`/api/programs/${programId}/items`, data);
+    return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items`, data);
   }
 
   addFreePieceItem(
@@ -29,13 +32,13 @@ export class ProgramService {
       note?: string;
     }
   ): Observable<ProgramItem> {
-    return this.http.post<ProgramItem>(`/api/programs/${programId}/items/free`, data);
+    return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/free`, data);
   }
 
   addBreakItem(
     programId: string,
     data: { durationSec: number; note?: string }
   ): Observable<ProgramItem> {
-    return this.http.post<ProgramItem>(`/api/programs/${programId}/items/break`, data);
+    return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/break`, data);
   }
 }


### PR DESCRIPTION
## Summary
- ensure program service uses environment.apiUrl so auth token is attached

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5d0029f88320be117b7f9d829b60