### PR TITLE
feat(program): enable publishing with revisions

### DIFF
--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -16,6 +16,7 @@ const router = require('express').Router();
 router.use(authJwt.verifyToken);
 
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
+router.post('/:id/publish', role.requireDirector, wrap(controller.publish));
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));
 router.post('/:id/items/free', role.requireDirector, programItemFreePieceValidation, validate, wrap(controller.addFreePieceItem));
 router.post('/:id/items/speech', role.requireDirector, programItemSpeechValidation, validate, wrap(controller.addSpeechItem));


### PR DESCRIPTION
## Summary
- allow directors to publish programs and record publish time
- automatically create a draft revision when editing a published program
- test program publishing and revision cloning

## Testing
- `cd choir-app-backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68ac740adbe883209ed7629cdd09073b