### PR TITLE
feat(program): add time calculation

### DIFF
--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -35,23 +35,18 @@ export class ProgramService {
     return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/free`, data);
   }
 
-
   addSpeechItem(
     programId: string,
     data: { title: string; source?: string; speaker?: string; text?: string; durationSec?: number; note?: string }
   ): Observable<ProgramItem> {
-    return this.http.post<ProgramItem>(`/api/programs/${programId}/items/speech`, data);
-  }
+    return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/speech`, data);
   }
 
-  addBreakItem(
-    programId: string,
-    data: { durationSec: number; note?: string }
-  ): Observable<ProgramItem> {
+  addBreakItem(programId: string, data: { durationSec: number; note?: string }): Observable<ProgramItem> {
     return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/break`, data);
   }
 
   reorderItems(programId: string, order: string[]): Observable<ProgramItem[]> {
-    return this.http.put<ProgramItem[]>(`/api/programs/${programId}/items/reorder`, { order });
+    return this.http.put<ProgramItem[]>(`${this.apiUrl}/programs/${programId}/items/reorder`, { order });
   }
 }

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -1,7 +1,15 @@
-<button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>
+<mat-form-field appearance="fill">
+  <mat-label>Startzeit</mat-label>
+  <input matInput type="datetime-local" [(ngModel)]="startTime" />
+</mat-form-field>
 
+<button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>
 <button mat-raised-button color="accent" class="add-speech" (click)="addSpeech()">+ Sprachbeitrag</button>
 <button mat-raised-button color="accent" (click)="addBreak()">+ Pause</button>
+
+<div *ngIf="hasMissingDurations()" class="duration-warning">
+  Es existieren Elemente ohne Dauerangabe.
+</div>
 
 <table
   mat-table
@@ -71,6 +79,13 @@
     </td>
   </ng-container>
 
+  <ng-container matColumnDef="time">
+    <th mat-header-cell *matHeaderCellDef> Uhrzeit </th>
+    <td mat-cell *matCellDef="let item; let i = index">
+      {{ getPlannedTime(i) }}
+    </td>
+  </ng-container>
+
   <ng-container matColumnDef="sum">
     <th mat-header-cell *matHeaderCellDef> Summe </th>
     <td mat-cell *matCellDef="let item; let i = index">
@@ -81,9 +96,7 @@
   <ng-container matColumnDef="actions">
     <th mat-header-cell *matHeaderCellDef> Aktionen </th>
     <td mat-cell *matCellDef="let item">
-      <a *ngIf="item.pieceId" [routerLink]="['/pieces', item.pieceId]" target="_blank"
-        >Details</a
-      >
+      <a *ngIf="item.pieceId" [routerLink]="['/pieces', item.pieceId]" target="_blank">Details</a>
     </td>
   </ng-container>
 
@@ -94,4 +107,3 @@
 <div *ngIf="items.length" class="total-duration">
   Gesamtdauer: {{ getTotalDuration() }}
 </div>
-

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -3,9 +3,9 @@
   margin-top: 16px;
 }
 
-
 .add-speech {
   margin-left: 8px;
+}
 
 .drag-handle {
   cursor: move;
@@ -16,4 +16,13 @@
 .total-duration {
   margin-top: 8px;
   font-weight: bold;
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  padding: 8px 0;
+}
+
+.duration-warning {
+  margin-top: 8px;
+  color: #b00020;
 }


### PR DESCRIPTION
## Summary
- calculate planned start times for program items if a start time is given
- warn when program items have no duration and keep total duration sticky
- clean up ProgramService to support program item operations

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac73d8f0b4832098d24167c3232a24