### PR TITLE
Add program management views

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -57,6 +57,33 @@ exports.create = async (req, res) => {
   }
 };
 
+// Retrieve all programs for the active choir
+exports.findAll = async (req, res) => {
+  try {
+    const programs = await Program.findAll({
+      where: { choirId: req.activeChoirId },
+      order: [['createdAt', 'DESC']],
+    });
+    res.status(200).send(programs);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+// Retrieve a single program with its items
+exports.findOne = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const program = await Program.findByPk(id, {
+      include: [{ model: db.program_item, as: 'items', separate: true, order: [['sortIndex', 'ASC']] }],
+    });
+    if (!program) return res.status(404).send({ message: 'program not found' });
+    res.status(200).send(program);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
 // Publish a program so that choir members can view it
 exports.publish = async (req, res) => {
   const { id } = req.params;

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -16,6 +16,8 @@ const router = require('express').Router();
 
 router.use(authJwt.verifyToken);
 
+router.get('/', role.requireDirector, wrap(controller.findAll));
+router.get('/:id', role.requireDirector, wrap(controller.findOne));
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
 router.post('/:id/publish', role.requireDirector, wrap(controller.publish));
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -146,10 +146,22 @@ export const routes: Routes = [
                 data: { title: 'Beiträge', showChoirName: true }
             },
             {
+                path: 'programs',
+                loadComponent: () => import('./features/programs/program-list.component').then(m => m.ProgramListComponent),
+                canActivate: [AuthGuard, ProgramGuard],
+                data: { title: 'Programme' }
+            },
+            {
                 path: 'programs/create',
                 loadComponent: () => import('./features/programs/program-create.component').then(m => m.ProgramCreateComponent),
                 canActivate: [AuthGuard, ProgramGuard],
                 data: { title: 'Programm erstellen' }
+            },
+            {
+                path: 'programs/:id',
+                loadComponent: () => import('./features/program/program-editor.component').then(m => m.ProgramEditorComponent),
+                canActivate: [AuthGuard, ProgramGuard],
+                data: { title: 'Programm bearbeiten' }
             },
             {
                 path: 'stats',

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -14,6 +14,14 @@ export class ProgramService {
     return this.http.post<Program>(`${this.apiUrl}/programs`, data);
   }
 
+  getPrograms(): Observable<Program[]> {
+    return this.http.get<Program[]>(`${this.apiUrl}/programs`);
+  }
+
+  getProgram(id: string): Observable<Program> {
+    return this.http.get<Program>(`${this.apiUrl}/programs/${id}`);
+  }
+
   addPieceItem(
     programId: string,
     data: { pieceId: string; title: string; composer?: string; durationSec?: number; note?: string; slotId?: string }

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -1,8 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { ProgramService } from '@core/services/program.service';
@@ -18,7 +18,7 @@ import { ProgramBreakDialogComponent } from './program-break-dialog.component';
   templateUrl: './program-editor.component.html',
   styleUrls: ['./program-editor.component.scss'],
 })
-export class ProgramEditorComponent {
+export class ProgramEditorComponent implements OnInit {
   programId = '';
   startTime: string | null = null;
   items: ProgramItem[] = [];
@@ -26,7 +26,21 @@ export class ProgramEditorComponent {
   private readonly baseColumns = ['move', 'title', 'composer', 'duration', 'note', 'sum', 'actions'];
   private readonly columnsWithTime = ['move', 'title', 'composer', 'duration', 'note', 'time', 'sum', 'actions'];
 
-  constructor(private dialog: MatDialog, private programService: ProgramService) {}
+  constructor(
+    private dialog: MatDialog,
+    private programService: ProgramService,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    this.programId = this.route.snapshot.paramMap.get('id') ?? '';
+    if (this.programId) {
+      this.programService.getProgram(this.programId).subscribe(program => {
+        this.startTime = program.startTime ?? null;
+        this.items = program.items;
+      });
+    }
+  }
 
   get displayedColumns(): string[] {
     return this.startTime ? this.columnsWithTime : this.baseColumns;

--- a/choir-app-frontend/src/app/features/programs/program-list.component.html
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.html
@@ -1,0 +1,22 @@
+<h2>Programme</h2>
+<button mat-raised-button color="primary" routerLink="/programs/create">Neues Programm</button>
+
+<table mat-table [dataSource]="programs" *ngIf="programs.length > 0">
+  <ng-container matColumnDef="title">
+    <th mat-header-cell *matHeaderCellDef>Titel</th>
+    <td mat-cell *matCellDef="let program">{{ program.title }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+    <td mat-cell *matCellDef="let program">
+      <button mat-button [routerLink]="['/programs', program.id]">Bearbeiten</button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="['title', 'actions']"></tr>
+  <tr mat-row *matRowDef="let row; columns: ['title', 'actions']"></tr>
+</table>
+
+<p *ngIf="programs.length === 0">Keine Programme vorhanden.</p>
+

--- a/choir-app-frontend/src/app/features/programs/program-list.component.scss
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.scss
@@ -1,0 +1,9 @@
+table {
+  width: 100%;
+  margin-top: 16px;
+}
+
+button {
+  margin-bottom: 16px;
+}
+

--- a/choir-app-frontend/src/app/features/programs/program-list.component.ts
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MaterialModule } from '@modules/material.module';
+import { Program } from '@core/models/program';
+import { ProgramService } from '@core/services/program.service';
+
+@Component({
+  selector: 'app-program-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule, MaterialModule],
+  templateUrl: './program-list.component.html',
+  styleUrls: ['./program-list.component.scss'],
+})
+export class ProgramListComponent implements OnInit {
+  programs: Program[] = [];
+
+  constructor(private programService: ProgramService) {}
+
+  ngOnInit(): void {
+    this.programService.getPrograms().subscribe(programs => (this.programs = programs));
+  }
+}
+

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -303,7 +303,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
       {
         key: 'programs',
         displayName: 'Programm',
-        route: '/programs/create',
+        route: '/programs',
         visibleSubject: this.canCreateProgram$,
       },
       {


### PR DESCRIPTION
## Summary
- add backend endpoints to list and fetch programs
- create program list component and editor loading
- update routes and navigation to manage programs

## Testing
- `npm test` (frontend) *(fails: libatk-1.0.so.0 missing)*
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68ac7fd468008320832c1865b2015844