### PR TITLE
Allow numeric piece IDs when adding program items

### DIFF
--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -1,4 +1,4 @@
-const { body } = require('express-validator');
+const { body, oneOf } = require('express-validator');
 
 exports.programValidation = [
   body('title').isString().notEmpty(),
@@ -8,7 +8,10 @@ exports.programValidation = [
 
 // Validation rules for adding a piece item to a program
 exports.programItemPieceValidation = [
-  body('pieceId').isUUID(),
+  oneOf(
+    [body('pieceId').isUUID(), body('pieceId').isInt()],
+    'pieceId must be a valid UUID or integer'
+  ),
   body('title').isString().notEmpty(),
   body('composer').optional().isString(),
   body('durationSec').optional().isInt({ min: 0 }),


### PR DESCRIPTION
## Summary
- accept numeric or UUID `pieceId` values when adding a piece to a program

## Testing
- `node -e "const { programItemPieceValidation } = require('./choir-app-backend/src/validators/program.validation'); const { validationResult } = require('express-validator'); const req = { body: { pieceId: 123, title: 'Song' } }; Promise.all(programItemPieceValidation.map(v => v.run(req))).then(() => { console.log(validationResult(req).array()); });"`


------
https://chatgpt.com/codex/tasks/task_e_68aca91ba6148320a787331b1acd8b6c