### PR TITLE
fix: improve program editor mobile layout

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -11,14 +11,14 @@
   Es existieren Elemente ohne Dauerangabe.
 </div>
 
-<table
-  mat-table
-  [dataSource]="items"
-  *ngIf="items.length"
-  class="program-table"
-  cdkDropList
-  (cdkDropListDropped)="drop($event)"
->
+<div *ngIf="items.length" class="table-container">
+  <table
+    mat-table
+    [dataSource]="items"
+    class="program-table"
+    cdkDropList
+    (cdkDropListDropped)="drop($event)"
+  >
   <ng-container matColumnDef="move">
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let item; let i = index">
@@ -112,7 +112,8 @@
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns" cdkDrag></tr>
-</table>
+  </table>
+</div>
 
 <div *ngIf="items.length" class="total-duration">
   Gesamtdauer: {{ getTotalDuration() }}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -3,6 +3,10 @@
   margin-top: 16px;
 }
 
+.table-container {
+  overflow-x: auto;
+}
+
 .add-speech {
   margin-left: 8px;
 }
@@ -25,4 +29,28 @@
 .duration-warning {
   margin-top: 8px;
   color: #b00020;
+}
+
+@media (max-width: 600px) {
+  .program-table {
+    display: table;
+    width: 100%;
+  }
+
+  .program-table .mat-mdc-header-row {
+    display: table-row;
+  }
+
+  .program-table .mat-mdc-row {
+    display: table-row;
+    border-bottom: none;
+    padding: 0;
+  }
+
+  .program-table .mat-mdc-row .mat-mdc-cell {
+    display: table-cell;
+    width: auto;
+    padding: 4px 8px;
+    box-sizing: border-box;
+  }
 }


### PR DESCRIPTION
## Summary
- keep program editor table layout on small screens
- enable horizontal scrolling when content overflows

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project.)*


------
https://chatgpt.com/codex/tasks/task_e_68acbe6fc4c0832089c289df10e079c8