### PR TITLE
fix: mobile piece edit dialog scroll

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
@@ -31,12 +31,12 @@
 
 mat-sidenav-container.dialog-container {
   max-width: 1000px;
-  height: 100%;
+  height: auto;
 }
 
 div[mat-dialog-content] {
-  height: 80vh;
-  overflow: hidden;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 mat-sidenav {


### PR DESCRIPTION
## Summary
- allow piece edit dialog to scroll so all fields are reachable on small screens

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68acbeabcb78832092f9f2a16bdbabd5