### PR TITLE
feat(programs): allow deleting programs

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -84,6 +84,21 @@ exports.findOne = async (req, res) => {
   }
 };
 
+exports.delete = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const program = await Program.findByPk(id);
+    if (!program) return res.status(404).send({ message: 'program not found' });
+    await db.program_item.destroy({ where: { programId: id } });
+    await db.program_element.destroy({ where: { programId: id } });
+    await program.destroy();
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+
 // Publish a program so that choir members can view it
 exports.publish = async (req, res) => {
   const { id } = req.params;

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -18,6 +18,7 @@ router.use(authJwt.verifyToken);
 
 router.get('/', role.requireDirector, wrap(controller.findAll));
 router.get('/:id', role.requireDirector, wrap(controller.findOne));
+router.delete('/:id', role.requireDirector, wrap(controller.delete));
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));
 router.post('/:id/publish', role.requireDirector, wrap(controller.publish));
 router.post('/:id/items', role.requireDirector, programItemPieceValidation, validate, wrap(controller.addPieceItem));

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -135,6 +135,16 @@ const controller = require('../src/controllers/program.controller');
       assert.strictEqual(newProgram.publishedFromId, publishRes.data.id);
       assert.strictEqual(newProgram.status, 'draft');
 
+      // delete program
+      const delReq = { params: { id: afterRes.data.programId } };
+      const delRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+      await controller.delete(delReq, delRes);
+      assert.strictEqual(delRes.statusCode, 204);
+      const deleted = await db.program.findByPk(afterRes.data.programId);
+      assert.strictEqual(deleted, null);
+      const itemsAfterDelete = await db.program_item.findAll({ where: { programId: afterRes.data.programId } });
+      assert.strictEqual(itemsAfterDelete.length, 0);
+
       console.log('program.controller tests passed');
       await db.sequelize.close();
     } catch (err) {

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -21,6 +21,9 @@ export class ProgramService {
   getProgram(id: string): Observable<Program> {
     return this.http.get<Program>(`${this.apiUrl}/programs/${id}`);
   }
+  deleteProgram(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/programs/${id}`);
+  }
 
   addPieceItem(
     programId: string,

--- a/choir-app-frontend/src/app/features/programs/program-list.component.html
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.html
@@ -8,9 +8,10 @@
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
     <td mat-cell *matCellDef="let program">
       <button mat-button [routerLink]="['/programs', program.id]">Bearbeiten</button>
+      <button mat-button color="warn" (click)="delete(program)">Löschen</button>
     </td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/programs/program-list.component.ts
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.ts
@@ -20,5 +20,11 @@ export class ProgramListComponent implements OnInit {
   ngOnInit(): void {
     this.programService.getPrograms().subscribe(programs => (this.programs = programs));
   }
+  delete(program: Program): void {
+    this.programService.deleteProgram(program.id).subscribe(() => {
+      this.programs = this.programs.filter(p => p.id !== program.id);
+    });
+  }
+
 }
 


### PR DESCRIPTION
## Summary
- allow deleting programs via API and UI
- add delete button to program list and service
- cover program deletion with tests

## Testing
- `node tests/program.controller.test.js`
- `npm test` *(fails: bash: mise: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3e23607083208addb311676a5708