### PR TITLE
Allow nullable duration in program item validation

### DIFF
--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -3,7 +3,7 @@ const { body, oneOf } = require('express-validator');
 exports.programValidation = [
   body('title').isString().notEmpty(),
   body('description').optional().isString(),
-  body('startTime').optional().isISO8601(),
+  body('startTime').optional({ nullable: true }).isISO8601(),
 ];
 
 // Validation rules for adding a piece item to a program
@@ -14,7 +14,7 @@ exports.programItemPieceValidation = [
   ),
   body('title').isString().notEmpty(),
   body('composer').optional().isString(),
-  body('durationSec').optional().isInt({ min: 0 }),
+  body('durationSec').optional({ nullable: true }).isInt({ min: 0 }),
   body('note').optional().isString(),
   body('slotId').optional().isUUID(),
 ];
@@ -25,7 +25,7 @@ exports.programItemFreePieceValidation = [
   body('composer').optional().isString(),
   body('instrument').optional().isString(),
   body('performerNames').optional().isString(),
-  body('durationSec').optional().isInt({ min: 0 }),
+  body('durationSec').optional({ nullable: true }).isInt({ min: 0 }),
   body('note').optional().isString(),
   body('slotId').optional().isUUID(),
 ];
@@ -37,7 +37,7 @@ exports.programItemSpeechValidation = [
   body('source').optional().isString(),
   body('speaker').optional().isString(),
   body('text').optional().isString(),
-  body('durationSec').optional().isInt({ min: 0 }),
+  body('durationSec').optional({ nullable: true }).isInt({ min: 0 }),
   body('note').optional().isString(),
   body('slotId').optional().isUUID(),
 ];


### PR DESCRIPTION
## Summary
- accept `null` values for `durationSec` across program item validators
- prevent 400 errors when adding speech contributions without a duration

## Testing
- `npm run test:backend`
- `npm test --prefix choir-app-frontend` *(fails: ChromeHeadless cannot start)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3f7a91f88320b234c968f91b36c8