### PR TITLE
feat(program): accept mm:ss duration inputs

### DIFF
--- a/choir-app-frontend/src/app/core/models/program.ts
+++ b/choir-app-frontend/src/app/core/models/program.ts
@@ -4,6 +4,11 @@ export interface ProgramItem {
   sortIndex: number;
   type: 'piece' | 'break' | 'speech' | 'slot';
   durationSec?: number | null;
+  /**
+   * Optional helper string used in the editor to keep the mm:ss input value
+   * while editing. Converted to {@link durationSec} on save.
+   */
+  durationStr?: string;
   note?: string | null;
   pieceId?: string;
   pieceTitleSnapshot?: string;

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -68,9 +68,14 @@
   </ng-container>
 
   <ng-container matColumnDef="duration">
-    <th mat-header-cell *matHeaderCellDef> Dauer (s) </th>
+    <th mat-header-cell *matHeaderCellDef> Dauer (mm:ss) </th>
     <td mat-cell *matCellDef="let item">
-      <input matInput type="number" [(ngModel)]="item.durationSec" />
+      <input
+        matInput
+        [(ngModel)]="item.durationStr"
+        (ngModelChange)="onDurationChange(item)"
+        placeholder="mm:ss"
+      />
     </td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/program/program-speech-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-speech-dialog.component.html
@@ -18,8 +18,8 @@
       <textarea matInput formControlName="text"></textarea>
     </mat-form-field>
     <mat-form-field appearance="fill">
-      <mat-label>Dauer (s)</mat-label>
-      <input matInput type="number" formControlName="durationSec" />
+      <mat-label>Dauer (mm:ss)</mat-label>
+      <input matInput formControlName="duration" placeholder="mm:ss" />
     </mat-form-field>
   </form>
 </div>

--- a/choir-app-frontend/src/app/features/program/program-speech-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-speech-dialog.component.ts
@@ -20,13 +20,19 @@ export class ProgramSpeechDialogComponent {
       source: [''],
       speaker: [''],
       text: [''],
-      durationSec: [null],
+      duration: ['', Validators.pattern(/^\d{1,2}:\d{2}$/)],
     });
   }
 
   save() {
     if (this.form.valid) {
-      this.dialogRef.close(this.form.value);
+      const { duration, ...rest } = this.form.value;
+      let durationSec: number | undefined;
+      if (duration) {
+        const [m, s] = duration.split(':').map((v: string) => parseInt(v, 10));
+        durationSec = m * 60 + s;
+      }
+      this.dialogRef.close({ ...rest, durationSec });
     }
   }
 


### PR DESCRIPTION
## Summary
- allow editing program item durations in `mm:ss`
- parse and format speech item durations using `mm:ss`

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `npm run test:backend`


------
https://chatgpt.com/codex/tasks/task_e_68ad674b01bc8320aae9296716b3b17b