### PR TITLE
feat: persist program item duration

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -347,3 +347,26 @@ exports.reorderItems = async (req, res) => {
     res.status(500).send({ message: err.message });
   }
 };
+
+// Update attributes of a program item
+exports.updateItem = async (req, res) => {
+  let { id, itemId } = req.params;
+  const { durationSec, note } = req.body;
+  try {
+    const program = await ensureEditableProgram(id, req.userId);
+    if (!program) return res.status(404).send({ message: 'program not found' });
+    id = program.id;
+
+    const item = await db.program_item.findOne({ where: { id: itemId, programId: id } });
+    if (!item) return res.status(404).send({ message: 'item not found' });
+
+    await item.update({
+      durationSec: typeof durationSec === 'number' ? durationSec : null,
+      note: typeof note === 'string' ? note : item.note,
+    });
+
+    res.status(200).send(item);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -9,6 +9,7 @@ const {
   programItemSpeechValidation,
   programItemSlotValidation,
   programItemsReorderValidation,
+  programItemUpdateValidation,
 } = require('../validators/program.validation');
 const controller = require('../controllers/program.controller');
 const { handler: wrap } = require('../utils/async');
@@ -32,6 +33,13 @@ router.put(
   programItemsReorderValidation,
   validate,
   wrap(controller.reorderItems)
+);
+router.put(
+  '/:id/items/:itemId',
+  role.requireDirector,
+  programItemUpdateValidation,
+  validate,
+  wrap(controller.updateItem)
 );
 
 module.exports = router;

--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -60,3 +60,9 @@ exports.programItemsReorderValidation = [
   body('order').isArray(),
   body('order.*').isUUID(),
 ];
+
+// Validation rules for updating a program item
+exports.programItemUpdateValidation = [
+  body('durationSec').optional({ nullable: true }).isInt({ min: 0 }),
+  body('note').optional({ nullable: true }).isString(),
+];

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -46,6 +46,17 @@ const controller = require('../src/controllers/program.controller');
     assert.strictEqual(pieceItem.pieceTitleSnapshot, 'Song');
     assert.strictEqual(pieceItem.durationSec, 120);
 
+    // update duration of piece item
+    const updReq = {
+      params: { id: res.data.id, itemId: pieceItem.id },
+      body: { durationSec: 180 },
+      userId: user.id,
+    };
+    const updRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.updateItem(updReq, updRes);
+    assert.strictEqual(updRes.statusCode, 200);
+    assert.strictEqual(updRes.data.durationSec, 180);
+
     // add a free piece
     const freeReq = {
       params: { id: res.data.id },

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -69,14 +69,22 @@ export class ProgramService {
     return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/break`, data);
   }
 
-  addSlotItem(
-    programId: string,
-    data: { label: string; note?: string }
-  ): Observable<ProgramItem> {
-    return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/slot`, data);
-  }
+    addSlotItem(
+      programId: string,
+      data: { label: string; note?: string }
+    ): Observable<ProgramItem> {
+      return this.http.post<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/slot`, data);
+    }
 
-  reorderItems(programId: string, order: string[]): Observable<ProgramItem[]> {
-    return this.http.put<ProgramItem[]>(`${this.apiUrl}/programs/${programId}/items/reorder`, { order });
+    reorderItems(programId: string, order: string[]): Observable<ProgramItem[]> {
+      return this.http.put<ProgramItem[]>(`${this.apiUrl}/programs/${programId}/items/reorder`, { order });
+    }
+
+    updateItem(
+      programId: string,
+      itemId: string,
+      data: { durationSec?: number | null; note?: string | null }
+    ): Observable<ProgramItem> {
+      return this.http.put<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/${itemId}`, data);
+    }
   }
-}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -175,6 +175,13 @@ export class ProgramEditorComponent implements OnInit {
 
   onDurationChange(item: ProgramItem) {
     item.durationSec = this.parseDuration(item.durationStr);
+    if (item.durationStr === '' || item.durationSec !== null) {
+      this.programService
+        .updateItem(this.programId, item.id, { durationSec: item.durationSec ?? null })
+        .subscribe(updated => {
+          Object.assign(item, this.enhanceItem(updated));
+        });
+    }
   }
 
   private enhanceItem(item: ProgramItem): ProgramItem {


### PR DESCRIPTION
## Summary
- allow updating program item duration via new backend route
- persist duration changes from program editor
- cover item duration updates with tests

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: libatk-1.0.so.0: cannot open shared object file)


------
https://chatgpt.com/codex/tasks/task_e_68ad832262c083209483c9f5c998ba2c