### PR TITLE
fix: narrow duration input field

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -3,6 +3,10 @@
   margin-top: 16px;
 }
 
+.program-table .mat-column-duration {
+  width: 5em;
+}
+
 .table-container {
   overflow-x: auto;
 }


### PR DESCRIPTION
## Summary
- limit program editor duration column to 5em for more title space

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68ad98ed2c808320a3e39d7e5cbf0946