### PR TITLE
feat(program): allow adding free pieces

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -4,6 +4,7 @@
 </mat-form-field>
 
 <button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>
+<button mat-raised-button color="accent" (click)="addFreePiece()">+ Freies Stück</button>
 <button mat-raised-button color="accent" class="add-speech" (click)="addSpeech()">+ Sprachbeitrag</button>
 <button mat-raised-button color="accent" (click)="addBreak()">+ Pause</button>
 
@@ -108,6 +109,7 @@
         <a *ngSwitchCase="'piece'" [routerLink]="['/pieces', item.pieceId]" target="_blank">Details</a>
         <ng-container *ngSwitchCase="'slot'">
           <button mat-button (click)="fillSlotWithPiece(item)">Stück</button>
+          <button mat-button (click)="fillSlotWithFreePiece(item)">Freies Stück</button>
           <button mat-button (click)="fillSlotWithSpeech(item)">Text</button>
           <button mat-button (click)="fillSlotWithBreak(item)">Pause</button>
         </ng-container>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -10,6 +10,7 @@ import { ProgramItem } from '@core/models/program';
 import { ProgramPieceDialogComponent } from './program-piece-dialog.component';
 import { ProgramSpeechDialogComponent } from './program-speech-dialog.component';
 import { ProgramBreakDialogComponent } from './program-break-dialog.component';
+import { ProgramFreePieceDialogComponent } from './program-free-piece-dialog.component';
 
 @Component({
   selector: 'app-program-editor',
@@ -57,6 +58,17 @@ export class ProgramEditorComponent implements OnInit {
     });
   }
 
+  addFreePiece() {
+    const dialogRef = this.dialog.open(ProgramFreePieceDialogComponent, { width: '600px' });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService.addFreePieceItem(this.programId, result).subscribe(item => {
+          this.items = [...this.items, this.enhanceItem(item)];
+        });
+      }
+    });
+  }
+
   addSpeech() {
     const dialogRef = this.dialog.open(ProgramSpeechDialogComponent, { width: '600px' });
     dialogRef.afterClosed().subscribe(result => {
@@ -86,6 +98,20 @@ export class ProgramEditorComponent implements OnInit {
       if (result) {
         this.programService
           .addPieceItem(this.programId, { ...result, slotId: item.id })
+          .subscribe(updated => {
+            const enh = this.enhanceItem(updated);
+            this.items = this.items.map(i => (i.id === item.id ? enh : i));
+          });
+      }
+    });
+  }
+
+  fillSlotWithFreePiece(item: ProgramItem) {
+    const dialogRef = this.dialog.open(ProgramFreePieceDialogComponent, { width: '600px' });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService
+          .addFreePieceItem(this.programId, { ...result, slotId: item.id })
           .subscribe(updated => {
             const enh = this.enhanceItem(updated);
             this.items = this.items.map(i => (i.id === item.id ? enh : i));

--- a/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.html
@@ -1,0 +1,29 @@
+<h1 mat-dialog-title>Freies Stück</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form" class="free-piece-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Titel</mat-label>
+      <input matInput formControlName="title" required />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Komponist:in</mat-label>
+      <input matInput formControlName="composer" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Instrument</mat-label>
+      <input matInput formControlName="instrument" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Ausführende</mat-label>
+      <input matInput formControlName="performerNames" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Dauer (mm:ss)</mat-label>
+      <input matInput formControlName="duration" placeholder="mm:ss" />
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Abbrechen</button>
+  <button mat-raised-button color="primary" (click)="save()" [disabled]="form.invalid">Speichern</button>
+</div>

--- a/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.scss
@@ -1,0 +1,9 @@
+.free-piece-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.mat-form-field {
+  width: 100%;
+  margin-top: 8px;
+}

--- a/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '@modules/material.module';
+
+@Component({
+  selector: 'app-program-free-piece-dialog',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, FormsModule, ReactiveFormsModule],
+  templateUrl: './program-free-piece-dialog.component.html',
+  styleUrls: ['./program-free-piece-dialog.component.scss'],
+})
+export class ProgramFreePieceDialogComponent {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<ProgramFreePieceDialogComponent>) {
+    this.form = this.fb.group({
+      title: ['', Validators.required],
+      composer: [''],
+      instrument: [''],
+      performerNames: [''],
+      duration: ['', Validators.pattern(/^\d{1,2}:\d{2}$/)],
+    });
+  }
+
+  save() {
+    if (this.form.valid) {
+      const { duration, ...rest } = this.form.value;
+      let durationSec: number | undefined;
+      if (duration) {
+        const [m, s] = duration.split(':').map((v: string) => parseInt(v, 10));
+        durationSec = m * 60 + s;
+      }
+      this.dialogRef.close({ ...rest, durationSec });
+    }
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add dialog to create free pieces with title, composer, instrument and duration
- enable adding free pieces and filling slots in program editor

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project.)*


------
https://chatgpt.com/codex/tasks/task_e_68ada26dadf88320b397332d7b5f03ad