### PR TITLE
Redirect to edit page after program creation

### DIFF
--- a/choir-app-frontend/src/app/features/programs/program-create.component.ts
+++ b/choir-app-frontend/src/app/features/programs/program-create.component.ts
@@ -47,12 +47,12 @@ export class ProgramCreateComponent {
           forkJoin(labels.map(label => this.programService.addSlotItem(program.id, { label }))).subscribe({
             complete: () => {
               this.snackBar.open('Programm erstellt', 'OK', { duration: 3000 });
-              this.router.navigate(['/dashboard']);
+              this.router.navigate(['/programs', program.id]);
             }
           });
         } else {
           this.snackBar.open('Programm erstellt', 'OK', { duration: 3000 });
-          this.router.navigate(['/dashboard']);
+          this.router.navigate(['/programs', program.id]);
         }
       },
       error: () => this.snackBar.open('Fehler beim Erstellen', 'Schließen', { duration: 4000 })


### PR DESCRIPTION
## Summary
- Redirect newly created programs to their editor for immediate modification

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68adc838c25c83209caf1f97383d0d30