### PR TITLE
feat: add composer autocomplete to program dialogs

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.html
@@ -7,7 +7,12 @@
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Komponist:in</mat-label>
-      <input matInput formControlName="composer" />
+      <input type="text" matInput [formControl]="composerCtrl" [matAutocomplete]="autoComposer" />
+      <mat-autocomplete #autoComposer="matAutocomplete">
+        <mat-option *ngFor="let composer of filteredComposers$ | async" [value]="composer.name">
+          {{ composer.name }}
+        </mat-option>
+      </mat-autocomplete>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Instrument</mat-label>

--- a/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.ts
@@ -1,8 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators, FormControl } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Composer } from '@core/models/composer';
+import { Observable, startWith, map } from 'rxjs';
 
 @Component({
   selector: 'app-program-free-piece-dialog',
@@ -11,16 +14,34 @@ import { MaterialModule } from '@modules/material.module';
   templateUrl: './program-free-piece-dialog.component.html',
   styleUrls: ['./program-free-piece-dialog.component.scss'],
 })
-export class ProgramFreePieceDialogComponent {
+export class ProgramFreePieceDialogComponent implements OnInit {
   form: FormGroup;
+  composerCtrl = new FormControl('');
+  filteredComposers$!: Observable<Composer[]>;
+  allComposers: Composer[] = [];
 
-  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<ProgramFreePieceDialogComponent>) {
+  constructor(
+    private fb: FormBuilder,
+    private dialogRef: MatDialogRef<ProgramFreePieceDialogComponent>,
+    private api: ApiService
+  ) {
     this.form = this.fb.group({
       title: ['', Validators.required],
-      composer: [''],
+      composer: this.composerCtrl,
       instrument: [''],
       performerNames: [''],
       duration: ['', Validators.pattern(/^\d{1,2}:\d{2}$/)],
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.getComposers().subscribe(list => {
+      this.allComposers = list;
+      this.filteredComposers$ = this.composerCtrl.valueChanges.pipe(
+        startWith(''),
+        map(value => (value || '').toLowerCase()),
+        map(name => this.allComposers.filter(c => c.name.toLowerCase().includes(name)))
+      );
     });
   }
 

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.html
@@ -10,7 +10,12 @@
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Komponist</mat-label>
-      <input matInput formControlName="composer" />
+      <input type="text" matInput [formControl]="composerCtrl" [matAutocomplete]="autoComposer" />
+      <mat-autocomplete #autoComposer="matAutocomplete">
+        <mat-option *ngFor="let composer of filteredComposers$ | async" [value]="composer.name">
+          {{ composer.name }}
+        </mat-option>
+      </mat-autocomplete>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Tags</mat-label>


### PR DESCRIPTION
## Summary
- add composer autocomplete to free program piece dialog
- offer composer suggestions when searching program pieces

## Testing
- `npm test` *(fails: ChromeHeadless failed to start: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adc90b8c2c8320adfd40eb31b162be