### PR TITLE
Enable editing and deleting program items

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -370,3 +370,28 @@ exports.updateItem = async (req, res) => {
     res.status(500).send({ message: err.message });
   }
 };
+
+// Delete a program item
+exports.deleteItem = async (req, res) => {
+  let { id, itemId } = req.params;
+  try {
+    const program = await ensureEditableProgram(id, req.userId);
+    if (!program) return res.status(404).send({ message: 'program not found' });
+    id = program.id;
+
+    const item = await db.program_item.findOne({ where: { id: itemId, programId: id } });
+    if (!item) return res.status(404).send({ message: 'item not found' });
+
+    await item.destroy();
+
+    const remaining = await db.program_item.findAll({
+      where: { programId: id },
+      order: [['sortIndex', 'ASC']],
+    });
+    await Promise.all(remaining.map((it, index) => it.update({ sortIndex: index })));
+
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -41,5 +41,6 @@ router.put(
   validate,
   wrap(controller.updateItem)
 );
+router.delete('/:id/items/:itemId', role.requireDirector, wrap(controller.deleteItem));
 
 module.exports = router;

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -49,13 +49,14 @@ const controller = require('../src/controllers/program.controller');
     // update duration of piece item
     const updReq = {
       params: { id: res.data.id, itemId: pieceItem.id },
-      body: { durationSec: 180 },
+      body: { durationSec: 180, note: 'updated note' },
       userId: user.id,
     };
     const updRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
     await controller.updateItem(updReq, updRes);
     assert.strictEqual(updRes.statusCode, 200);
     assert.strictEqual(updRes.data.durationSec, 180);
+    assert.strictEqual(updRes.data.note, 'updated note');
 
     // add a free piece
     const freeReq = {
@@ -105,6 +106,14 @@ const controller = require('../src/controllers/program.controller');
     assert.strictEqual(orderRes.statusCode, 200);
     assert.deepStrictEqual(orderRes.data.map(i => i.id), [breakItem.id, pieceItem.id, freeItem.id]);
     assert.strictEqual(orderRes.data[0].sortIndex, 0);
+
+    // delete free piece item
+    const delItemReq = { params: { id: res.data.id, itemId: freeItem.id }, userId: user.id };
+    const delItemRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+    await controller.deleteItem(delItemReq, delItemRes);
+    assert.strictEqual(delItemRes.statusCode, 204);
+    const afterDeleteItems = await db.program_item.findAll({ where: { programId: res.data.id } });
+    assert.strictEqual(afterDeleteItems.length, 2);
 
     // add a speech item
     const speechReq = {

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -87,4 +87,8 @@ export class ProgramService {
     ): Observable<ProgramItem> {
       return this.http.put<ProgramItem>(`${this.apiUrl}/programs/${programId}/items/${itemId}`, data);
     }
+
+    deleteItem(programId: string, itemId: string): Observable<void> {
+      return this.http.delete<void>(`${this.apiUrl}/programs/${programId}/items/${itemId}`);
+    }
   }

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -83,7 +83,7 @@
   <ng-container matColumnDef="note">
     <th mat-header-cell *matHeaderCellDef> Notiz </th>
     <td mat-cell *matCellDef="let item">
-      <input matInput [(ngModel)]="item.note" />
+      <input matInput [(ngModel)]="item.note" (blur)="onNoteChange(item)" />
     </td>
   </ng-container>
 
@@ -114,6 +114,10 @@
           <button mat-button (click)="fillSlotWithBreak(item)">Pause</button>
         </ng-container>
       </ng-container>
+
+      <button mat-icon-button color="warn" (click)="deleteItem(item)" aria-label="Löschen">
+        <mat-icon>delete</mat-icon>
+      </button>
     </td>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -210,6 +210,20 @@ export class ProgramEditorComponent implements OnInit {
     }
   }
 
+  onNoteChange(item: ProgramItem) {
+    this.programService
+      .updateItem(this.programId, item.id, { note: item.note ?? null })
+      .subscribe(updated => {
+        Object.assign(item, this.enhanceItem(updated));
+      });
+  }
+
+  deleteItem(item: ProgramItem) {
+    this.programService.deleteItem(this.programId, item.id).subscribe(() => {
+      this.items = this.items.filter(i => i.id !== item.id);
+    });
+  }
+
   private enhanceItem(item: ProgramItem): ProgramItem {
     return {
       ...item,


### PR DESCRIPTION
## Summary
- allow program items to be deleted and keep ordering consistent
- persist item notes from editor and expose delete action in UI
- cover item updates and deletion with backend tests

## Testing
- `node choir-app-backend/tests/program.controller.test.js`
- `npm test --prefix choir-app-frontend` *(fails: error while loading shared libraries: libcups.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68adc93f1b2c83208ba141e093f32d24