### PR TITLE
Improve mobile view of monthly plan schedule

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.scss
@@ -66,4 +66,20 @@ mat-tab-group {
   .manual-inputs {
     display: none;
   }
+
+  .plan {
+    overflow-x: auto;
+  }
+
+  .plan table {
+    min-width: 600px;
+  }
+
+  .counter-plan {
+    overflow-x: auto;
+  }
+
+  .counter-plan table {
+    min-width: 600px;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure monthly plan and counter plan tables scroll on small screens
- set minimum width for plan tables to keep columns readable on mobile

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68af3929c3988320a913b9605dd87c8c