### PR TITLE
feat: improve piece dialog mobile navigation

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -2,7 +2,7 @@
 
 <div mat-dialog-content>
   <mat-sidenav-container class="dialog-container">
-    <mat-sidenav mode="side" opened>
+    <mat-sidenav mode="side" opened class="desktop-nav">
       <mat-nav-list>
         <a mat-list-item [class.active]="activeSection==='general'" (click)="activeSection='general'">Grundinformationen</a>
         <a mat-list-item [class.active]="activeSection==='opus'" (click)="activeSection='opus'">Werkinformationen</a>
@@ -12,6 +12,12 @@
     </mat-sidenav>
 
     <mat-sidenav-content>
+      <mat-nav-list class="mobile-nav">
+        <a mat-list-item [class.active]="activeSection==='general'" (click)="activeSection='general'">Grundinformationen</a>
+        <a mat-list-item [class.active]="activeSection==='opus'" (click)="activeSection='opus'">Werkinformationen</a>
+        <a mat-list-item [class.active]="activeSection==='text'" (click)="activeSection='text'">Text</a>
+        <a mat-list-item [class.active]="activeSection==='files'" (click)="activeSection='files'">Dateien &amp; Links</a>
+      </mat-nav-list>
       <form [formGroup]="pieceForm" id="piece-form" (ngSubmit)="onSave()">
         <ng-container [ngSwitch]="activeSection">
           <ng-container *ngSwitchCase="'general'">

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.scss
@@ -43,6 +43,11 @@ mat-sidenav {
   width: 220px;
 }
 
+mat-nav-list.mobile-nav {
+  display: none;
+  padding: 0;
+}
+
 @media (max-width: 599px) {
   .form-section {
     grid-template-columns: 1fr;
@@ -52,8 +57,18 @@ mat-sidenav {
     grid-template-columns: 1fr;
   }
 
-  mat-sidenav {
-    width: 70vw;
+  mat-sidenav.desktop-nav {
+    display: none;
+  }
+
+  mat-nav-list.mobile-nav {
+    display: flex;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+    a.mat-list-item {
+      flex: 1 0 auto;
+      justify-content: center;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add mobile top navigation to piece dialog and hide desktop sidenav on small screens
- style responsive form layout and navigation with media queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af3bec24d48320ac4cd4a0b03fb0a2