### PR TITLE
Allow blank instrument when adding free piece

### DIFF
--- a/choir-app-backend/src/validators/program.validation.js
+++ b/choir-app-backend/src/validators/program.validation.js
@@ -30,7 +30,7 @@ exports.programItemFreePieceValidation = [
   body('title').isString().notEmpty(),
   body('composer').optional().isString(),
   body('instrument')
-    .optional()
+    .optional({ checkFalsy: true })
     .isString()
     .matches(/^[\p{L}\s.,-]+$/u)
     .withMessage('instrument contains invalid characters'),

--- a/choir-app-backend/tests/program.validation.test.js
+++ b/choir-app-backend/tests/program.validation.test.js
@@ -11,6 +11,13 @@ const { programItemFreePieceValidation } = require('../src/validators/program.va
     let res = validationResult(invalidReq);
     assert.ok(!res.isEmpty(), 'should fail when instrument contains digits');
 
+    const emptyReq = { body: { title: 'X', instrument: '' } };
+    for (const v of programItemFreePieceValidation) {
+      await v.run(emptyReq);
+    }
+    res = validationResult(emptyReq);
+    assert.ok(res.isEmpty(), 'should pass when instrument is empty');
+
     const validReq = { body: { title: 'X', instrument: 'Piano Solo' } };
     for (const v of programItemFreePieceValidation) {
       await v.run(validReq);


### PR DESCRIPTION
## Summary
- permit empty `instrument` value for free program items
- add validation test for empty instrument strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af57a5e1d483209b0c0b9b65d133fc