### PR TITLE
Fix Dienstplan visibility for organists

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -16,9 +16,10 @@ import { MainLayoutComponent } from './main-layout.component';
 describe('MainLayoutComponent', () => {
   let component: MainLayoutComponent;
   let fixture: ComponentFixture<MainLayoutComponent>;
+  let authServiceMock: any;
 
   beforeEach(async () => {
-    const authServiceMock = {
+    authServiceMock = {
       isLoggedIn$: of(true),
       isAdmin$: of(false),
       currentUser$: new BehaviorSubject<any>({ roles: ['singer'] }),
@@ -66,5 +67,14 @@ describe('MainLayoutComponent', () => {
     const homeVisible = await firstValueFrom(homeItem!.visibleSubject!);
     expect(eventsVisible).toBeFalse();
     expect(homeVisible).toBeTrue();
+  });
+
+  it('shows dienstplan for organists even if singers cannot see it', async () => {
+    authServiceMock.currentUser$.next({ roles: ['singer', 'organist'] });
+    authServiceMock.activeChoir$.next({ modules: { dienstplan: true, singerMenu: { dienstplan: false } } });
+    fixture.detectChanges();
+    const dienstplanItem = component.navItems.find(i => i.key === 'dienstplan');
+    const visible = await firstValueFrom(dienstplanItem!.visibleSubject!);
+    expect(visible).toBeTrue();
   });
 });

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -204,7 +204,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
       map(([user, choir]) => {
         const roles = Array.isArray(user?.roles) ? user!.roles : [];
         const isSingerOnly = roles.includes('singer') &&
-          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
+          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian', 'organist'].includes(r));
         if (!isSingerOnly) {
           return true;
         }


### PR DESCRIPTION
## Summary
- prevent organists from being treated as singer-only users for menu visibility
- add regression test ensuring Dienstplan remains visible for organists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af57dd64408320a47c2991383210b3