### PR TITLE
fix: retain choir modules after user reload

### DIFF
--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -95,10 +95,16 @@ export class AuthService {
     this.userReloadTriggered = true;
     this.http.get<User>(`${environment.apiUrl}/users/me`).pipe(
       tap(freshUser => {
-        localStorage.setItem(USER_KEY, JSON.stringify(freshUser));
-        this.currentUserSubject.next(freshUser);
-        this.activeChoir$.next(freshUser.activeChoir || null);
-        this.availableChoirs$.next(freshUser.availableChoirs || []);
+        const existingModules = this.activeChoir$.value?.modules;
+        let activeChoir = freshUser.activeChoir || null;
+        if (activeChoir) {
+          activeChoir = { ...activeChoir, modules: activeChoir.modules ?? existingModules };
+        }
+        const updatedUser = { ...freshUser, activeChoir } as User;
+        localStorage.setItem(USER_KEY, JSON.stringify(updatedUser));
+        this.currentUserSubject.next(updatedUser);
+        this.activeChoir$.next(activeChoir);
+        this.availableChoirs$.next(updatedUser.availableChoirs || []);
       }),
       catchError(() => of(null))
     ).subscribe();


### PR DESCRIPTION
## Summary
- preserve existing choir module data when reloading the user to keep Dienstplan menu enabled

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f2173e648320b58990ae4e371283