### PR TITLE
Configure rate limit via env and raise default to 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ the database and can later be changed through the admin endpoint
 After saving new settings you can send yourself a test email from that page to verify the configuration.
 Any errors during mail delivery are written to `logs/error.log` for troubleshooting.
 
+### Rate Limiting
+
+Configure the number of requests allowed per minute with the `RATE_LIMIT_MAX`
+environment variable in `choir-app-backend/.env` or via the environment. The
+default is 200 requests per minute:
+
+```ini
+RATE_LIMIT_MAX=200
+```
+
 ### Mail Templates
 
 Invitation, password reset, monthly plan and availability request mails are based on templates

--- a/choir-app-backend/.env
+++ b/choir-app-backend/.env
@@ -14,3 +14,4 @@ SMTP_USER=no-reply
 SMTP_PASS=
 EMAIL_FROM=no-reply@nak-chorleiter.de
 SMTP_STARTTLS=false
+RATE_LIMIT_MAX=200

--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -26,10 +26,11 @@ if (process.env.NODE_ENV != "production") {
     });
 }
 
-// Set up rate limiter: maximum of twenty requests per minute
+// Set up rate limiter: maximum of RATE_LIMIT_MAX requests per minute (default 200)
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX, 10) || 200;
 const limiter = RateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute
-    max: 100, // Erhöhen Sie das Limit auf einen vernünftigeren Wert
+    max: RATE_LIMIT_MAX,
     standardHeaders: true,
     legacyHeaders: false,
     handler: (req, res, _next) => {


### PR DESCRIPTION
## Summary
- replace hardcoded express-rate-limit value with env-driven `RATE_LIMIT_MAX`
- document rate limiting and add default `RATE_LIMIT_MAX=200`

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b52a6b343483208307eb38b30691f9