### PR TITLE
refactor: centralize controller error handling

### DIFF
--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -7,74 +7,62 @@ const { isPublicHoliday } = require('../services/holiday.service');
 
 exports.findByMonth = async (req, res) => {
     const { year, month } = req.params;
-    try {
-        const rules = await db.plan_rule.findAll({ where: { choirId: req.activeChoirId } });
-        const dateSet = new Set();
-        for (const rule of rules) {
-            for (const d of datesForRule(year, month, rule)) {
-                if (isPublicHoliday(d) && d.getUTCDay() !== 0) continue;
-                dateSet.add(isoDateString(d));
-            }
+    const rules = await db.plan_rule.findAll({ where: { choirId: req.activeChoirId } });
+    const dateSet = new Set();
+    for (const rule of rules) {
+        for (const d of datesForRule(year, month, rule)) {
+            if (isPublicHoliday(d) && d.getUTCDay() !== 0) continue;
+            dateSet.add(isoDateString(d));
         }
-
-        if (Number(month) === 12) {
-            const dec25 = new Date(Date.UTC(year, 11, 25));
-            const dec26 = new Date(Date.UTC(year, 11, 26));
-            const hasRuleForDec25 = rules.some(r => r.dayOfWeek === dec25.getUTCDay());
-
-            if (!hasRuleForDec25) {
-                dateSet.add(isoDateString(dec25));
-            }
-
-            if (dec26.getUTCDay() === 0) {
-                dateSet.delete(isoDateString(dec26));
-            }
-        }
-        const dates = Array.from(dateSet).sort();
-        const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
-        const avail = await db.user_availability.findAll({
-            where: {
-                userId: req.userId,
-                choirId: req.activeChoirId,
-                date: { [Op.between]: [ `${year}-${String(month).padStart(2,'0')}-01`, `${year}-${String(month).padStart(2,'0')}-${String(lastDay).padStart(2,'0')}` ] }
-            }
-        });
-        const map = Object.fromEntries(avail.map(a => [a.date, a]));
-        const result = dates.map(d => map[d] ? map[d] : { date: d, status: 'AVAILABLE' });
-        res.status(200).send(result);
-    } catch (err) {
-        res.status(500).send({ message: err.message || 'Could not fetch availability.' });
     }
+
+    if (Number(month) === 12) {
+        const dec25 = new Date(Date.UTC(year, 11, 25));
+        const dec26 = new Date(Date.UTC(year, 11, 26));
+        const hasRuleForDec25 = rules.some(r => r.dayOfWeek === dec25.getUTCDay());
+
+        if (!hasRuleForDec25) {
+            dateSet.add(isoDateString(dec25));
+        }
+
+        if (dec26.getUTCDay() === 0) {
+            dateSet.delete(isoDateString(dec26));
+        }
+    }
+    const dates = Array.from(dateSet).sort();
+    const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    const avail = await db.user_availability.findAll({
+        where: {
+            userId: req.userId,
+            choirId: req.activeChoirId,
+            date: { [Op.between]: [ `${year}-${String(month).padStart(2,'0')}-01`, `${year}-${String(month).padStart(2,'0')}-${String(lastDay).padStart(2,'0')}` ] }
+        }
+    });
+    const map = Object.fromEntries(avail.map(a => [a.date, a]));
+    const result = dates.map(d => map[d] ? map[d] : { date: d, status: 'AVAILABLE' });
+    res.status(200).send(result);
 };
 
 exports.setAvailability = async (req, res) => {
     const { date, status } = req.body;
     if (!date || !status) return res.status(400).send({ message: 'date and status required' });
-    try {
-        const [avail] = await db.user_availability.findOrCreate({
-            where: { userId: req.userId, choirId: req.activeChoirId, date },
-            defaults: { status }
-        });
-        if (avail.status !== status) await avail.update({ status });
-        res.status(200).send(avail);
-    } catch (err) {
-        res.status(500).send({ message: err.message || 'Could not save availability.' });
-    }
+    const [avail] = await db.user_availability.findOrCreate({
+        where: { userId: req.userId, choirId: req.activeChoirId, date },
+        defaults: { status }
+    });
+    if (avail.status !== status) await avail.update({ status });
+    res.status(200).send(avail);
 };
 
 exports.findAllByMonth = async (req, res) => {
     const { year, month } = req.params;
-    try {
-        const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
-        const avail = await db.user_availability.findAll({
-            where: {
-                choirId: req.activeChoirId,
-                date: { [Op.between]: [ `${year}-${String(month).padStart(2,'0')}-01`, `${year}-${String(month).padStart(2,'0')}-${String(lastDay).padStart(2,'0')}` ] }
-            },
-            attributes: ['userId', 'date', 'status']
-        });
-        res.status(200).send(avail);
-    } catch (err) {
-        res.status(500).send({ message: err.message || 'Could not fetch availability.' });
-    }
+    const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    const avail = await db.user_availability.findAll({
+        where: {
+            choirId: req.activeChoirId,
+            date: { [Op.between]: [ `${year}-${String(month).padStart(2,'0')}-01`, `${year}-${String(month).padStart(2,'0')}-${String(lastDay).padStart(2,'0')}` ] }
+        },
+        attributes: ['userId', 'date', 'status']
+    });
+    res.status(200).send(avail);
 };

--- a/choir-app-backend/src/controllers/planEntry.controller.js
+++ b/choir-app-backend/src/controllers/planEntry.controller.js
@@ -7,45 +7,33 @@ exports.create = async (req, res) => {
     if (!monthlyPlanId || !date) {
         return res.status(400).send({ message: 'monthlyPlanId and date are required.' });
     }
-    try {
-        const entry = await PlanEntry.create({ monthlyPlanId, date, notes, directorId, organistId });
-        const full = await PlanEntry.findByPk(entry.id, {
-            include: [
-                { model: User, as: 'director', attributes: ['id', 'name'] },
-                { model: User, as: 'organist', attributes: ['id', 'name'], required: false }
-            ]
-        });
-        res.status(201).send(full);
-    } catch (err) {
-        res.status(500).send({ message: err.message || 'Could not create entry.' });
-    }
+    const entry = await PlanEntry.create({ monthlyPlanId, date, notes, directorId, organistId });
+    const full = await PlanEntry.findByPk(entry.id, {
+        include: [
+            { model: User, as: 'director', attributes: ['id', 'name'] },
+            { model: User, as: 'organist', attributes: ['id', 'name'], required: false }
+        ]
+    });
+    res.status(201).send(full);
 };
 
 exports.update = async (req, res) => {
     const id = req.params.id;
-    try {
-        const entry = await PlanEntry.findByPk(id);
-        if (!entry) return res.status(404).send({ message: 'Entry not found.' });
-        await entry.update(req.body);
-        const full = await PlanEntry.findByPk(id, {
-            include: [
-                { model: User, as: 'director', attributes: ['id', 'name'] },
-                { model: User, as: 'organist', attributes: ['id', 'name'], required: false }
-            ]
-        });
-        res.status(200).send(full);
-    } catch (err) {
-        res.status(500).send({ message: err.message || 'Could not update entry.' });
-    }
+    const entry = await PlanEntry.findByPk(id);
+    if (!entry) return res.status(404).send({ message: 'Entry not found.' });
+    await entry.update(req.body);
+    const full = await PlanEntry.findByPk(id, {
+        include: [
+            { model: User, as: 'director', attributes: ['id', 'name'] },
+            { model: User, as: 'organist', attributes: ['id', 'name'], required: false }
+        ]
+    });
+    res.status(200).send(full);
 };
 
 exports.delete = async (req, res) => {
     const id = req.params.id;
-    try {
-        const num = await PlanEntry.destroy({ where: { id } });
-        if (num === 1) res.send({ message: 'Entry deleted.' });
-        else res.status(404).send({ message: 'Entry not found.' });
-    } catch (err) {
-        res.status(500).send({ message: err.message || 'Could not delete entry.' });
-    }
+    const num = await PlanEntry.destroy({ where: { id } });
+    if (num === 1) res.send({ message: 'Entry deleted.' });
+    else res.status(404).send({ message: 'Entry not found.' });
 };


### PR DESCRIPTION
## Summary
- remove per-route try/catch in plan entry controller to rely on shared async handler
- remove redundant try/catch in availability controller for centralized error handling

## Testing
- `npm run lint` *(fails: no-unused-vars and other existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52ad06e108320b585e3f57e4b11c1