### PR TITLE
refactor: replace tables with divs for responsive layouts

### DIFF
--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.html
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.html
@@ -1,35 +1,35 @@
 <h2>Primäre Palette</h2>
-<table mat-table [dataSource]="primaryColors" class="mat-elevation-z8">
+<div mat-table [dataSource]="primaryColors" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Farbname</th>
-    <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+    <div mat-header-cell *matHeaderCellDef>Farbname</div>
+    <div mat-cell *matCellDef="let c">{{ c.name }}</div>
   </ng-container>
   <ng-container matColumnDef="preview">
-    <th mat-header-cell *matHeaderCellDef>Farbe</th>
-    <td mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</td>
+    <div mat-header-cell *matHeaderCellDef>Farbe</div>
+    <div mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</div>
   </ng-container>
   <ng-container matColumnDef="scss">
-    <th mat-header-cell *matHeaderCellDef>SCSS</th>
-    <td mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></td>
+    <div mat-header-cell *matHeaderCellDef>SCSS</div>
+    <div mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></div>
   </ng-container>
-  <tr mat-header-row *matHeaderRowDef="['name','preview','scss']"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['name','preview','scss']"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="['name','preview','scss']"></div>
+  <div mat-row *matRowDef="let row; columns: ['name','preview','scss']"></div>
+</div>
 
 <h2>Akzent-Palette</h2>
-<table mat-table [dataSource]="accentColors" class="mat-elevation-z8">
+<div mat-table [dataSource]="accentColors" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Farbname</th>
-    <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+    <div mat-header-cell *matHeaderCellDef>Farbname</div>
+    <div mat-cell *matCellDef="let c">{{ c.name }}</div>
   </ng-container>
   <ng-container matColumnDef="preview">
-    <th mat-header-cell *matHeaderCellDef>Farbe</th>
-    <td mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</td>
+    <div mat-header-cell *matHeaderCellDef>Farbe</div>
+    <div mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</div>
   </ng-container>
   <ng-container matColumnDef="scss">
-    <th mat-header-cell *matHeaderCellDef>SCSS</th>
-    <td mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></td>
+    <div mat-header-cell *matHeaderCellDef>SCSS</div>
+    <div mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></div>
   </ng-container>
-  <tr mat-header-row *matHeaderRowDef="['name','preview','scss']"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['name','preview','scss']"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="['name','preview','scss']"></div>
+  <div mat-row *matRowDef="let row; columns: ['name','preview','scss']"></div>
+</div>

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
@@ -11,23 +11,23 @@
 
 <div *ngFor="let group of groups">
   <h3>{{ group.date }}</h3>
-  <table mat-table [dataSource]="group.items" class="mat-elevation-z8 log-table">
+  <div mat-table [dataSource]="group.items" class="mat-elevation-z8 log-table">
     <ng-container matColumnDef="timestamp">
-      <th mat-header-cell *matHeaderCellDef>Zeit</th>
-      <td mat-cell *matCellDef="let row">{{ row.timestamp || (row.date | date:'short') }}</td>
+      <div mat-header-cell *matHeaderCellDef>Zeit</div>
+      <div mat-cell *matCellDef="let row">{{ row.timestamp || (row.date | date:'short') }}</div>
     </ng-container>
 
     <ng-container matColumnDef="level">
-      <th mat-header-cell *matHeaderCellDef>Level</th>
-      <td mat-cell *matCellDef="let row">{{ row.level }}</td>
+      <div mat-header-cell *matHeaderCellDef>Level</div>
+      <div mat-cell *matCellDef="let row">{{ row.level }}</div>
     </ng-container>
 
     <ng-container matColumnDef="message">
-      <th mat-header-cell *matHeaderCellDef>Nachricht</th>
-      <td mat-cell *matCellDef="let row"><pre>{{ row.message || row.stack || row.raw }}</pre></td>
+      <div mat-header-cell *matHeaderCellDef>Nachricht</div>
+      <div mat-cell *matCellDef="let row"><pre>{{ row.message || row.stack || row.raw }}</pre></div>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="['timestamp','level','message']"></tr>
-    <tr mat-row *matRowDef="let row; columns: ['timestamp','level','message']"></tr>
-  </table>
+    <div mat-header-row *matHeaderRowDef="['timestamp','level','message']"></div>
+    <div mat-row *matRowDef="let row; columns: ['timestamp','level','message']"></div>
+  </div>
 </div>

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
@@ -8,39 +8,39 @@
   </button>
 </div>
 
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<div mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="email">
-    <th mat-header-cell *matHeaderCellDef>E-Mail</th>
-    <td mat-cell *matCellDef="let element">
+    <div mat-header-cell *matHeaderCellDef>E-Mail</div>
+    <div mat-cell *matCellDef="let element">
       <a href="#" (click)="openUser(element.email); $event.preventDefault()">{{ element.email }}</a>
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="success">
-    <th mat-header-cell *matHeaderCellDef>Erfolg</th>
-    <td mat-cell *matCellDef="let element">{{ element.success ? '✔' : '✖' }}</td>
+    <div mat-header-cell *matHeaderCellDef>Erfolg</div>
+    <div mat-cell *matCellDef="let element">{{ element.success ? '✔' : '✖' }}</div>
   </ng-container>
 
   <ng-container matColumnDef="reason">
-    <th mat-header-cell *matHeaderCellDef>Grund</th>
-    <td mat-cell *matCellDef="let element">{{ element.reason }}</td>
+    <div mat-header-cell *matHeaderCellDef>Grund</div>
+    <div mat-cell *matCellDef="let element">{{ element.reason }}</div>
   </ng-container>
 
   <ng-container matColumnDef="ipAddress">
-    <th mat-header-cell *matHeaderCellDef>IP</th>
-    <td mat-cell *matCellDef="let element">{{ element.ipAddress }}</td>
+    <div mat-header-cell *matHeaderCellDef>IP</div>
+    <div mat-cell *matCellDef="let element">{{ element.ipAddress }}</div>
   </ng-container>
 
   <ng-container matColumnDef="userAgent">
-    <th mat-header-cell *matHeaderCellDef>Browser</th>
-    <td mat-cell *matCellDef="let element">{{ element.userAgent }}</td>
+    <div mat-header-cell *matHeaderCellDef>Browser</div>
+    <div mat-cell *matCellDef="let element">{{ element.userAgent }}</div>
   </ng-container>
 
   <ng-container matColumnDef="createdAt">
-    <th mat-header-cell *matHeaderCellDef>Datum</th>
-    <td mat-cell *matCellDef="let element">{{ element.createdAt | date:'short' }}</td>
+    <div mat-header-cell *matHeaderCellDef>Datum</div>
+    <div mat-cell *matCellDef="let element">{{ element.createdAt | date:'short' }}</div>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -21,43 +21,43 @@
       <mat-icon>add</mat-icon>
       Mitglied hinzufügen
     </button>
-    <table mat-table [dataSource]="dataSource" class="member-table">
+    <div mat-table [dataSource]="dataSource" class="member-table">
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let user">{{user.name}}</td>
+        <div mat-header-cell *matHeaderCellDef>Name</div>
+        <div mat-cell *matCellDef="let user">{{user.name}}</div>
       </ng-container>
       <ng-container matColumnDef="email">
-        <th mat-header-cell *matHeaderCellDef>E-Mail</th>
-        <td mat-cell *matCellDef="let user">{{user.email}}</td>
+        <div mat-header-cell *matHeaderCellDef>E-Mail</div>
+        <div mat-cell *matCellDef="let user">{{user.email}}</div>
       </ng-container>
       <ng-container matColumnDef="role">
-        <th mat-header-cell *matHeaderCellDef>Rollen</th>
-        <td mat-cell *matCellDef="let user">{{user.membership?.rolesInChoir?.join(', ') || '-'}}</td>
+        <div mat-header-cell *matHeaderCellDef>Rollen</div>
+        <div mat-cell *matCellDef="let user">{{user.membership?.rolesInChoir?.join(', ') || '-'}}</div>
       </ng-container>
       <ng-container matColumnDef="organist">
-        <th mat-header-cell *matHeaderCellDef>Organist</th>
-        <td mat-cell *matCellDef="let user">
+        <div mat-header-cell *matHeaderCellDef>Organist</div>
+        <div mat-cell *matCellDef="let user">
           <mat-checkbox [checked]="user.membership?.rolesInChoir?.includes('organist')" (change)="toggleOrganist(user, $event.checked)"></mat-checkbox>
-        </td>
+        </div>
       </ng-container>
       <ng-container matColumnDef="status">
-        <th mat-header-cell *matHeaderCellDef>Status</th>
-        <td mat-cell *matCellDef="let user">{{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}}</td>
+        <div mat-header-cell *matHeaderCellDef>Status</div>
+        <div mat-cell *matCellDef="let user">{{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}}</div>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let user">
+        <div mat-header-cell *matHeaderCellDef></div>
+        <div mat-cell *matCellDef="let user">
           <button mat-icon-button color="warn" (click)="removeMember(user)">
             <mat-icon>person_remove</mat-icon>
           </button>
-        </td>
+        </div>
       </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-      <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</td>
-      </tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+      <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
+      <div class="mat-row" *matNoDataRow>
+        <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</div>
+      </div>
+    </div>
   </div>
 </div>
 <div mat-dialog-actions align="end">

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
@@ -2,44 +2,44 @@
   <button mat-flat-button color="primary" (click)="addChoir()">Chor hinzufügen</button>
 </div>
 
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<div mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <div mat-header-cell *matHeaderCellDef>Name</div>
+    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
   </ng-container>
 
   <ng-container matColumnDef="location">
-    <th mat-header-cell *matHeaderCellDef>Ort</th>
-    <td mat-cell *matCellDef="let element">{{ element.location }}</td>
+    <div mat-header-cell *matHeaderCellDef>Ort</div>
+    <div mat-cell *matCellDef="let element">{{ element.location }}</div>
   </ng-container>
 
   <ng-container matColumnDef="memberCount">
-    <th mat-header-cell *matHeaderCellDef>Mitglieder</th>
-    <td mat-cell *matCellDef="let element">{{ element.memberCount }}</td>
+    <div mat-header-cell *matHeaderCellDef>Mitglieder</div>
+    <div mat-cell *matCellDef="let element">{{ element.memberCount }}</div>
   </ng-container>
 
   <ng-container matColumnDef="eventCount">
-    <th mat-header-cell *matHeaderCellDef>Ereignisse</th>
-    <td mat-cell *matCellDef="let element">{{ element.eventCount }}</td>
+    <div mat-header-cell *matHeaderCellDef>Ereignisse</div>
+    <div mat-cell *matCellDef="let element">{{ element.eventCount }}</div>
   </ng-container>
 
   <ng-container matColumnDef="pieceCount">
-    <th mat-header-cell *matHeaderCellDef>Repertoire</th>
-    <td mat-cell *matCellDef="let element">{{ element.pieceCount }}</td>
+    <div mat-header-cell *matHeaderCellDef>Repertoire</div>
+    <div mat-cell *matCellDef="let element">{{ element.pieceCount }}</div>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef></th>
-    <td mat-cell *matCellDef="let element">
+    <div mat-header-cell *matHeaderCellDef></div>
+    <div mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editChoir(element)">
         <mat-icon>edit</mat-icon>
       </button>
       <button mat-icon-button color="warn" (click)="deleteChoir(element)">
         <mat-icon>delete</mat-icon>
       </button>
-    </td>
+    </div>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
@@ -14,25 +14,25 @@
   </button>
 </div>
 
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8" multiTemplateDataRows>
+<div mat-table [dataSource]="dataSource" class="mat-elevation-z8" multiTemplateDataRows>
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <div mat-header-cell *matHeaderCellDef>Name</div>
+    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
   </ng-container>
 
   <ng-container matColumnDef="birthYear">
-    <th mat-header-cell *matHeaderCellDef>Geburt</th>
-    <td mat-cell *matCellDef="let element">{{ element.birthYear }}</td>
+    <div mat-header-cell *matHeaderCellDef>Geburt</div>
+    <div mat-cell *matCellDef="let element">{{ element.birthYear }}</div>
   </ng-container>
 
   <ng-container matColumnDef="deathYear">
-    <th mat-header-cell *matHeaderCellDef>Tod</th>
-    <td mat-cell *matCellDef="let element">{{ element.deathYear }}</td>
+    <div mat-header-cell *matHeaderCellDef>Tod</div>
+    <div mat-cell *matCellDef="let element">{{ element.deathYear }}</div>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef></th>
-    <td mat-cell *matCellDef="let element">
+    <div mat-header-cell *matHeaderCellDef></div>
+    <div mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editPerson(element)">
         <mat-icon>edit</mat-icon>
       </button>
@@ -42,11 +42,11 @@
       <button mat-icon-button color="warn" (click)="deletePerson(element)" [disabled]="!element.canDelete">
         <mat-icon>delete</mat-icon>
       </button>
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="expandedDetail">
-    <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+    <div mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
       <div class="piece-list" *ngIf="expandedPerson?.id === element.id">
         <div *ngIf="expandedPieces.length; else none">
           <ul>
@@ -57,13 +57,13 @@
         </div>
         <ng-template #none>Keine Stücke vorhanden.</ng-template>
       </div>
-    </td>
+    </div>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleRow(row)" class="creator-row"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['expandedDetail']; when: isExpansionDetailRow" class="detail-row"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleRow(row)" class="creator-row"></div>
+  <div mat-row *matRowDef="let row; columns: ['expandedDetail']; when: isExpansionDetailRow" class="detail-row"></div>
+</div>
 
 <mat-paginator [length]="totalPeople"
                [pageSizeOptions]="pageSizeOptions"

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
@@ -5,29 +5,29 @@
         Cover ({{ unassignedCovers }} unzugewiesen)
       </mat-panel-title>
     </mat-expansion-panel-header>
-    <table mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
+    <div mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
       <ng-container matColumnDef="filename">
-        <th mat-header-cell *matHeaderCellDef>Datei</th>
-        <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+        <div mat-header-cell *matHeaderCellDef>Datei</div>
+        <div mat-cell *matCellDef="let f">{{ f.filename }}</div>
       </ng-container>
       <ng-container matColumnDef="linked">
-        <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
-        <td mat-cell *matCellDef="let f">
+        <div mat-header-cell *matHeaderCellDef>Zugewiesen</div>
+        <div mat-cell *matCellDef="let f">
           <a *ngIf="f.collectionId" [routerLink]="['/collections/edit', f.collectionId]">{{ f.collectionTitle }}</a>
           <span *ngIf="!f.collectionId">–</span>
-        </td>
+        </div>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-        <td mat-cell *matCellDef="let f">
+        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
+        <div mat-cell *matCellDef="let f">
           <button mat-icon-button color="warn" *ngIf="!f.collectionId" (click)="delete('covers', f.filename)" matTooltip="Löschen">
             <mat-icon>delete</mat-icon>
           </button>
-        </td>
+        </div>
       </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+      <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
+    </div>
     <p *ngIf="covers.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>
 
@@ -37,29 +37,29 @@
         Notenbild ({{ unassignedImages }} unzugewiesen)
       </mat-panel-title>
     </mat-expansion-panel-header>
-    <table mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
+    <div mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
       <ng-container matColumnDef="filename">
-        <th mat-header-cell *matHeaderCellDef>Datei</th>
-        <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+        <div mat-header-cell *matHeaderCellDef>Datei</div>
+        <div mat-cell *matCellDef="let f">{{ f.filename }}</div>
       </ng-container>
       <ng-container matColumnDef="linked">
-        <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
-        <td mat-cell *matCellDef="let f">
+        <div mat-header-cell *matHeaderCellDef>Zugewiesen</div>
+        <div mat-cell *matCellDef="let f">
           <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
           <span *ngIf="!f.pieceId">–</span>
-        </td>
+        </div>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-        <td mat-cell *matCellDef="let f">
+        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
+        <div mat-cell *matCellDef="let f">
           <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('images', f.filename)" matTooltip="Löschen">
             <mat-icon>delete</mat-icon>
           </button>
-        </td>
+        </div>
       </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+      <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
+    </div>
     <p *ngIf="images.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>
 
@@ -69,33 +69,33 @@
         Hochgeladene Dateien ({{ unassignedFiles }} unzugewiesen)
       </mat-panel-title>
     </mat-expansion-panel-header>
-    <table mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
+    <div mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
       <ng-container matColumnDef="filename">
-        <th mat-header-cell *matHeaderCellDef>Datei</th>
-        <td mat-cell *matCellDef="let f">{{ f.filename }}</td>
+        <div mat-header-cell *matHeaderCellDef>Datei</div>
+        <div mat-cell *matCellDef="let f">{{ f.filename }}</div>
       </ng-container>
       <ng-container matColumnDef="downloadName">
-        <th mat-header-cell *matHeaderCellDef>Downloadname</th>
-        <td mat-cell *matCellDef="let f">{{ f.downloadName || '–' }}</td>
+        <div mat-header-cell *matHeaderCellDef>Downloadname</div>
+        <div mat-cell *matCellDef="let f">{{ f.downloadName || '–' }}</div>
       </ng-container>
       <ng-container matColumnDef="linked">
-        <th mat-header-cell *matHeaderCellDef>Zugewiesen</th>
-        <td mat-cell *matCellDef="let f">
+        <div mat-header-cell *matHeaderCellDef>Zugewiesen</div>
+        <div mat-cell *matCellDef="let f">
           <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
           <span *ngIf="!f.pieceId">–</span>
-        </td>
+        </div>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-        <td mat-cell *matCellDef="let f">
+        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
+        <div mat-cell *matCellDef="let f">
           <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('files', f.filename)" matTooltip="Löschen">
             <mat-icon>delete</mat-icon>
           </button>
-        </td>
+        </div>
       </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedFileColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedFileColumns"></tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="displayedFileColumns"></div>
+      <div mat-row *matRowDef="let row; columns: displayedFileColumns"></div>
+    </div>
     <p *ngIf="files.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>
 </mat-accordion>

--- a/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
@@ -1,26 +1,26 @@
 <h2>Änderungsvorschläge</h2>
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8 full-width">
+<div mat-table [dataSource]="dataSource" class="mat-elevation-z8 full-width">
     <ng-container matColumnDef="piece">
-        <th mat-header-cell *matHeaderCellDef>Stück</th>
-        <td mat-cell *matCellDef="let c">{{ c.piece?.title || ('Piece ' + c.pieceId) }}</td>
+        <div mat-header-cell *matHeaderCellDef>Stück</div>
+        <div mat-cell *matCellDef="let c">{{ c.piece?.title || ('Piece ' + c.pieceId) }}</div>
     </ng-container>
 
     <ng-container matColumnDef="createdAt">
-        <th mat-header-cell *matHeaderCellDef>Datum</th>
-        <td mat-cell *matCellDef="let c">{{ c.createdAt | date:'short' }}</td>
+        <div mat-header-cell *matHeaderCellDef>Datum</div>
+        <div mat-cell *matCellDef="let c">{{ c.createdAt | date:'short' }}</div>
     </ng-container>
 
     <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let c">
+        <div mat-header-cell *matHeaderCellDef></div>
+        <div mat-cell *matCellDef="let c">
             <button mat-button color="primary" (click)="approve(c)">Übernehmen</button>
             <button mat-button color="warn" (click)="decline(c)">Ablehnen</button>
-        </td>
+        </div>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-    <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell" colspan="3">Keine Vorschläge vorhanden.</td>
-    </tr>
-</table>
+    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+    <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+    <div class="mat-row" *matNoDataRow>
+        <div class="mat-cell" colspan="3">Keine Vorschläge vorhanden.</div>
+    </div>
+</div>

--- a/choir-app-frontend/src/app/features/admin/manage-publishers/manage-publishers.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-publishers/manage-publishers.component.html
@@ -4,23 +4,23 @@
 <div class="letter-filter">
   <button mat-button *ngFor="let l of letters" (click)="onLetterSelect(l)" [color]="selectedLetter === l ? 'primary' : undefined">{{ l }}</button>
 </div>
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<div mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <div mat-header-cell *matHeaderCellDef>Name</div>
+    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
   </ng-container>
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef></th>
-    <td mat-cell *matCellDef="let element">
+    <div mat-header-cell *matHeaderCellDef></div>
+    <div mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editPublisher(element)">
         <mat-icon>edit</mat-icon>
       </button>
       <button mat-icon-button color="warn" (click)="deletePublisher(element)" [disabled]="!element.canDelete">
         <mat-icon>delete</mat-icon>
       </button>
-    </td>
+    </div>
   </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+</div>
 <mat-paginator [length]="totalPublishers" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -7,25 +7,25 @@
   </mat-form-field>
 </div>
 
-<table
+<div
   mat-table
   [dataSource]="dataSource"
   class="mat-elevation-z8"
   *ngIf="!(isHandset$ | async)"
 >
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    <div mat-header-cell *matHeaderCellDef>Name</div>
+    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
   </ng-container>
 
   <ng-container matColumnDef="email">
-    <th mat-header-cell *matHeaderCellDef>E-Mail</th>
-    <td mat-cell *matCellDef="let element">{{ element.email }}</td>
+    <div mat-header-cell *matHeaderCellDef>E-Mail</div>
+    <div mat-cell *matCellDef="let element">{{ element.email }}</div>
   </ng-container>
 
   <ng-container matColumnDef="roles">
-    <th mat-header-cell *matHeaderCellDef>Rollen</th>
-    <td mat-cell *matCellDef="let element">
+    <div mat-header-cell *matHeaderCellDef>Rollen</div>
+    <div mat-cell *matCellDef="let element">
       <mat-form-field appearance="outline" class="roles-select">
         <mat-select
           [ngModel]="element.roles"
@@ -39,22 +39,22 @@
           <mat-option value="librarian">Bibliothekar</mat-option>
         </mat-select>
       </mat-form-field>
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="choirs">
-    <th mat-header-cell *matHeaderCellDef>Chöre</th>
-    <td mat-cell *matCellDef="let element">{{ choirList(element) }}</td>
+    <div mat-header-cell *matHeaderCellDef>Chöre</div>
+    <div mat-cell *matCellDef="let element">{{ choirList(element) }}</div>
   </ng-container>
 
   <ng-container matColumnDef="lastLogin">
-    <th mat-header-cell *matHeaderCellDef>Letzter Login</th>
-    <td mat-cell *matCellDef="let element">{{ element.lastLogin | date:'short' }}</td>
+    <div mat-header-cell *matHeaderCellDef>Letzter Login</div>
+    <div mat-cell *matCellDef="let element">{{ element.lastLogin | date:'short' }}</div>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef></th>
-    <td mat-cell *matCellDef="let element">
+    <div mat-header-cell *matHeaderCellDef></div>
+    <div mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editUser(element)">
         <mat-icon>edit</mat-icon>
       </button>
@@ -67,12 +67,12 @@
       <button mat-icon-button color="warn" (click)="deleteUser(element)">
         <mat-icon>delete</mat-icon>
       </button>
-    </td>
+    </div>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+</div>
 
 <mat-accordion *ngIf="isHandset$ | async">
   <mat-expansion-panel *ngFor="let element of dataSource.filteredData">

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -113,27 +113,27 @@
     </mat-card-header>
     <mat-card-content *ngIf="membersExpanded">
       <div class="table-wrapper mat-elevation-z4">
-        <table mat-table [dataSource]="dataSource">
+        <div mat-table [dataSource]="dataSource">
           <!-- Name Column -->
           <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef> Name </th>
-            <td mat-cell *matCellDef="let user"> {{user.name}} </td>
+            <div mat-header-cell *matHeaderCellDef> Name </div>
+            <div mat-cell *matCellDef="let user"> {{user.name}} </div>
           </ng-container>
           <!-- Email Column -->
           <ng-container matColumnDef="email">
-            <th mat-header-cell *matHeaderCellDef> E-Mail </th>
-            <td mat-cell *matCellDef="let user"> {{user.email}} </td>
+            <div mat-header-cell *matHeaderCellDef> E-Mail </div>
+            <div mat-cell *matCellDef="let user"> {{user.email}} </div>
           </ng-container>
           <ng-container matColumnDef="address">
-            <th mat-header-cell *matHeaderCellDef>Adresse</th>
-            <td mat-cell *matCellDef="let user">
+            <div mat-header-cell *matHeaderCellDef>Adresse</div>
+            <div mat-cell *matCellDef="let user">
               {{ user.street ? user.street + ',' : '' }} {{ user.postalCode }} {{ user.city }}
-            </td>
+            </div>
           </ng-container>
           <!-- Role Column -->
           <ng-container matColumnDef="role">
-            <th mat-header-cell *matHeaderCellDef> Rollen </th>
-            <td mat-cell *matCellDef="let user">
+            <div mat-header-cell *matHeaderCellDef> Rollen </div>
+            <div mat-cell *matCellDef="let user">
               <ng-container *ngIf="isChoirAdmin; else roleText">
                 <mat-form-field appearance="outline" class="roles-select">
                   <mat-select
@@ -149,16 +149,16 @@
                 </mat-form-field>
               </ng-container>
               <ng-template #roleText>{{ user.membership?.rolesInChoir?.join(', ') || '-' }}</ng-template>
-            </td>
+            </div>
           </ng-container>
           <ng-container matColumnDef="status">
-            <th mat-header-cell *matHeaderCellDef> Status </th>
-            <td mat-cell *matCellDef="let user"> {{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}} </td>
+            <div mat-header-cell *matHeaderCellDef> Status </div>
+            <div mat-cell *matCellDef="let user"> {{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}} </div>
           </ng-container>
           <!-- Actions Column -->
           <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef></th>
-            <td mat-cell *matCellDef="let user" class="actions-cell">
+            <div mat-header-cell *matHeaderCellDef></div>
+            <div mat-cell *matCellDef="let user" class="actions-cell">
               <!-- Verhindern, dass man sich selbst entfernt -->
               <button
                 mat-icon-button
@@ -168,16 +168,16 @@
                 [disabled]="dataSource.data.length <= 1">
                 <mat-icon>person_remove</mat-icon>
               </button>
-            </td>
+            </div>
           </ng-container>
-          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-          <tr class="mat-row" *matNoDataRow>
-            <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+          <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+          <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+          <div class="mat-row" *matNoDataRow>
+            <div class="mat-cell" [attr.colspan]="displayedColumns.length">
               Keine Mitglieder gefunden.
-            </td>
-          </tr>
-        </table>
+            </div>
+          </div>
+        </div>
       </div>
     </mat-card-content>
   </mat-card>
@@ -188,31 +188,31 @@
     </mat-card-header>
     <mat-card-content>
       <div class="table-wrapper mat-elevation-z4">
-        <table mat-table [dataSource]="collectionDataSource">
+        <div mat-table [dataSource]="collectionDataSource">
           <ng-container matColumnDef="title">
-            <th mat-header-cell *matHeaderCellDef> Titel </th>
-            <td mat-cell *matCellDef="let col">{{ col.title }}</td>
+            <div mat-header-cell *matHeaderCellDef> Titel </div>
+            <div mat-cell *matCellDef="let col">{{ col.title }}</div>
           </ng-container>
           <ng-container matColumnDef="publisher">
-            <th mat-header-cell *matHeaderCellDef> Verlag </th>
-            <td mat-cell *matCellDef="let col">{{ col.publisher || '-' }}</td>
+            <div mat-header-cell *matHeaderCellDef> Verlag </div>
+            <div mat-cell *matCellDef="let col">{{ col.publisher || '-' }}</div>
           </ng-container>
           <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef></th>
-            <td mat-cell *matCellDef="let col" class="actions-cell">
+            <div mat-header-cell *matHeaderCellDef></div>
+            <div mat-cell *matCellDef="let col" class="actions-cell">
               <button *ngIf="isChoirAdmin" mat-icon-button color="warn" (click)="removeCollection(col)" matTooltip="Sammlung entfernen">
                 <mat-icon>delete</mat-icon>
               </button>
-            </td>
+            </div>
           </ng-container>
-          <tr mat-header-row *matHeaderRowDef="displayedCollectionColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedCollectionColumns;"></tr>
-          <tr class="mat-row" *matNoDataRow>
-            <td class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
+          <div mat-header-row *matHeaderRowDef="displayedCollectionColumns"></div>
+          <div mat-row *matRowDef="let row; columns: displayedCollectionColumns;"></div>
+          <div class="mat-row" *matNoDataRow>
+            <div class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
               Keine Sammlungen vorhanden.
-            </td>
-          </tr>
-        </table>
+            </div>
+          </div>
+        </div>
       </div>
     </mat-card-content>
   </mat-card>

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -1,39 +1,39 @@
 <div class="table-container mat-elevation-z4">
-  <table mat-table [dataSource]="dataSource">
+  <div mat-table [dataSource]="dataSource">
     <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef>Name</th>
-      <td mat-cell *matCellDef="let m">{{ m.name }}</td>
+      <div mat-header-cell *matHeaderCellDef>Name</div>
+      <div mat-cell *matCellDef="let m">{{ m.name }}</div>
     </ng-container>
 
     <ng-container matColumnDef="voice">
-      <th mat-header-cell *matHeaderCellDef>Stimme</th>
-      <td mat-cell *matCellDef="let m">{{ m.voice || '-' }}</td>
+      <div mat-header-cell *matHeaderCellDef>Stimme</div>
+      <div mat-cell *matCellDef="let m">{{ m.voice || '-' }}</div>
     </ng-container>
 
     <ng-container matColumnDef="email">
-      <th mat-header-cell *matHeaderCellDef>E-Mail</th>
-      <td mat-cell *matCellDef="let m">{{ m.email }}</td>
+      <div mat-header-cell *matHeaderCellDef>E-Mail</div>
+      <div mat-cell *matCellDef="let m">{{ m.email }}</div>
     </ng-container>
 
     <ng-container matColumnDef="street">
-      <th mat-header-cell *matHeaderCellDef>Straße</th>
-      <td mat-cell *matCellDef="let m">{{ mask(m.street, m.shareWithChoir) }}</td>
+      <div mat-header-cell *matHeaderCellDef>Straße</div>
+      <div mat-cell *matCellDef="let m">{{ mask(m.street, m.shareWithChoir) }}</div>
     </ng-container>
 
     <ng-container matColumnDef="postalCode">
-      <th mat-header-cell *matHeaderCellDef>PLZ</th>
-      <td mat-cell *matCellDef="let m">{{ mask(m.postalCode, m.shareWithChoir) }}</td>
+      <div mat-header-cell *matHeaderCellDef>PLZ</div>
+      <div mat-cell *matCellDef="let m">{{ mask(m.postalCode, m.shareWithChoir) }}</div>
     </ng-container>
 
     <ng-container matColumnDef="city">
-      <th mat-header-cell *matHeaderCellDef>Ort</th>
-      <td mat-cell *matCellDef="let m">{{ mask(m.city, m.shareWithChoir) }}</td>
+      <div mat-header-cell *matHeaderCellDef>Ort</div>
+      <div mat-cell *matCellDef="let m">{{ mask(m.city, m.shareWithChoir) }}</div>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-    <tr class="mat-row" *matNoDataRow>
-      <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</td>
-    </tr>
-  </table>
+    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+    <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+    <div class="mat-row" *matNoDataRow>
+      <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</div>
+    </div>
+  </div>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -139,11 +139,11 @@
 
           <div *ngIf="selectedPieceLinks.length > 0; else noPieces">
           <!-- Using a mat-table for a clean, structured display -->
-          <table class="piece-link-table" mat-table [dataSource]="pieceLinkDataSource" matSort matSortActive="number" matSortDirection="asc">
+          <div class="piece-link-table" mat-table [dataSource]="pieceLinkDataSource" matSort matSortActive="number" matSortDirection="asc">
             <!-- Number Column Definition -->
             <ng-container matColumnDef="number">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="number"> Nr. </th>
-              <td mat-cell *matCellDef="let link" class="number-cell">
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="number"> Nr. </div>
+              <div mat-cell *matCellDef="let link" class="number-cell">
                 <mat-form-field appearance="outline">
                   <input
                     matInput
@@ -152,38 +152,38 @@
                     [ngModelOptions]="{standalone: true}"
                   />
                 </mat-form-field>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Title Column Definition -->
             <ng-container matColumnDef="title">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
-              <td mat-cell *matCellDef="let link">
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </div>
+              <div mat-cell *matCellDef="let link">
                 <div class="piece-title">{{ link.piece.title }}</div>
                 <div
                   class="piece-composer"
                   *ngIf="link.piece.composer?.name || link.piece.origin"
                 >{{ link.piece.composer?.name || link.piece.origin }}</div>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Actions Column Definition -->
             <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef></th>
-              <td mat-cell *matCellDef="let link" class="actions-cell">
+              <div mat-header-cell *matHeaderCellDef></div>
+              <div mat-cell *matCellDef="let link" class="actions-cell">
                 <button type="button" mat-icon-button (click)="openEditPieceDialog(link.piece.id)" matTooltip="Stück bearbeiten">
                   <mat-icon>edit</mat-icon>
                 </button>
                 <button type="button" mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Stück aus Sammlung entfernen">
                   <mat-icon>delete</mat-icon>
                 </button>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Update the row definitions to use the new column array name -->
-            <tr mat-header-row *matHeaderRowDef="pieceLinkColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: pieceLinkColumns;"></tr>
-          </table>
+            <div mat-header-row *matHeaderRowDef="pieceLinkColumns"></div>
+            <div mat-row *matRowDef="let row; columns: pieceLinkColumns;"></div>
+          </div>
 
           <mat-paginator
             *ngIf="selectedPieceLinks.length > 0"

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -20,57 +20,57 @@
 <ng-container *ngIf="!(isHandset$ | async); else mobileView">
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">
-  <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
+  <div mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
 
     <!-- Cover Column -->
     <ng-container matColumnDef="cover">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let collection" class="cover-cell">
+      <div mat-header-cell *matHeaderCellDef></div>
+      <div mat-cell *matCellDef="let collection" class="cover-cell">
         <img *ngIf="collection.coverImageData" [src]="collection.coverImageData" alt="Cover" loading="lazy" />
-      </td>
+      </div>
     </ng-container>
 
     <!-- Status Column -->
     <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header="status"> Status </th>
-      <td mat-cell *matCellDef="let collection" class="status-cell">
+      <div mat-header-cell *matHeaderCellDef mat-sort-header="status"> Status </div>
+      <div mat-cell *matCellDef="let collection" class="status-cell">
         <mat-icon
           class="status-icon"
           [color]="collection.isAdded ? 'primary' : 'disabled'"
           [matTooltip]="collection.isAdded ? 'Sammlung ist im Chorrepertoire.' : 'Nicht im Repertoire.'">
           {{ collection.isAdded ? 'check_circle' : 'do_not_disturb_on' }}
         </mat-icon>
-      </td>
+      </div>
     </ng-container>
 
     <!-- Title Column -->
     <ng-container matColumnDef="title">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
-      <td mat-cell *matCellDef="let collection" class="title-cell">
+      <div mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </div>
+      <div mat-cell *matCellDef="let collection" class="title-cell">
         <strong>{{ collection.title }}</strong>
         <div class="subtitle-hint" *ngIf="collection.subtitle">{{ collection.subtitle }}</div>
         <div class="prefix-hint" *ngIf="!collection.singleEdition && collection.prefix">{{ collection.prefix }}</div>
         <div class="prefix-hint" *ngIf="collection.singleEdition">{{ getCollectionComposer(collection) }}</div>
-      </td>
+      </div>
     </ng-container>
 
     <ng-container matColumnDef="titles">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header="titles"> Stücke </th>
-      <td mat-cell *matCellDef="let collection" class="titles-cell">
+      <div mat-header-cell *matHeaderCellDef mat-sort-header="titles"> Stücke </div>
+      <div mat-cell *matCellDef="let collection" class="titles-cell">
         {{ collection.pieceCount || 0 }}
-      </td>
+      </div>
     </ng-container>
 
     <!-- Publisher Column -->
     <ng-container matColumnDef="publisher">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header="publisher"> Verlag </th>
-      <td mat-cell *matCellDef="let collection" class="publisher-cell"> {{ collection.publisher || '-' }} </td>
+      <div mat-header-cell *matHeaderCellDef mat-sort-header="publisher"> Verlag </div>
+      <div mat-cell *matCellDef="let collection" class="publisher-cell"> {{ collection.publisher || '-' }} </div>
     </ng-container>
 
     <!-- Actions Column -->
     <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let collection" class="actions-cell">
+        <div mat-header-cell *matHeaderCellDef></div>
+        <div mat-cell *matCellDef="let collection" class="actions-cell">
             <button
               mat-icon-button
               color="primary"
@@ -87,17 +87,17 @@
             <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
                 <mat-icon>edit</mat-icon>
             </button>
-        </td>
+        </div>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" [class.selected]="selectedCollection?.id === row.id"></tr>
-    <tr class="mat-row" *matNoDataRow>
-      <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+    <div mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></div>
+    <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" [class.selected]="selectedCollection?.id === row.id"></div>
+    <div class="mat-row" *matNoDataRow>
+      <div class="mat-cell" [attr.colspan]="displayedColumns.length">
         Es wurden noch keine Sammlungen erstellt.
-      </td>
-    </tr>
-  </table>
+      </div>
+    </div>
+  </div>
   </div>
   <mat-paginator [pageSizeOptions]="pageSizeOptions"
                  [pageSize]="pageSize"

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
@@ -22,26 +22,26 @@
     <mat-divider *ngIf="previewData.length > 0"></mat-divider>
     <div *ngIf="previewData.length > 0" class="preview-area">
     <p>Bitte prüfe, ob die Daten korrekt eingelesen werden.</p>
-    <table mat-table [dataSource]="previewData">
+    <div mat-table [dataSource]="previewData">
       <ng-container matColumnDef="nummer">
-        <th mat-header-cell *matHeaderCellDef> Nummer </th>
-        <td mat-cell *matCellDef="let row"> {{ row.nummer || row.number }} </td>
+        <div mat-header-cell *matHeaderCellDef> Nummer </div>
+        <div mat-cell *matCellDef="let row"> {{ row.nummer || row.number }} </div>
       </ng-container>
       <ng-container matColumnDef="titel">
-        <th mat-header-cell *matHeaderCellDef> Titel </th>
-        <td mat-cell *matCellDef="let row"> {{ row.titel || row.title }} </td>
+        <div mat-header-cell *matHeaderCellDef> Titel </div>
+        <div mat-cell *matCellDef="let row"> {{ row.titel || row.title }} </div>
       </ng-container>
       <ng-container matColumnDef="komponist">
-        <th mat-header-cell *matHeaderCellDef> Komponist </th>
-        <td mat-cell *matCellDef="let row"> {{ row.komponist || row.composer }} </td>
+        <div mat-header-cell *matHeaderCellDef> Komponist </div>
+        <div mat-cell *matCellDef="let row"> {{ row.komponist || row.composer }} </div>
       </ng-container>
       <ng-container matColumnDef="kategorie">
-        <th mat-header-cell *matHeaderCellDef> Kategorie </th>
-        <td mat-cell *matCellDef="let row"> {{ row.kategorie || row.rubrik || row.category }} </td>
+        <div mat-header-cell *matHeaderCellDef> Kategorie </div>
+        <div mat-cell *matCellDef="let row"> {{ row.kategorie || row.rubrik || row.category }} </div>
       </ng-container>
-      <tr mat-header-row *matHeaderRowDef="previewColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: previewColumns;"></tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="previewColumns"></div>
+      <div mat-row *matRowDef="let row; columns: previewColumns;"></div>
+    </div>
   </div>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -14,36 +14,36 @@
 <ng-container *ngIf="!(isHandset$ | async); else mobileView">
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">
-    <table mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
+    <div mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
       <ng-container matColumnDef="title">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header="title">Titel</th>
-        <td mat-cell *matCellDef="let piece" class="title-cell">
+        <div mat-header-cell *matHeaderCellDef mat-sort-header="title">Titel</div>
+        <div mat-cell *matCellDef="let piece" class="title-cell">
           <strong>{{ piece.title }}</strong>
           <div class="subtitle-hint" *ngIf="piece.subtitle">{{ piece.subtitle }}</div>
-        </td>
+        </div>
       </ng-container>
 
       <ng-container matColumnDef="composer">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist/Ursprung</th>
-        <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin || '-' }}</td>
+        <div mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist/Ursprung</div>
+        <div mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin || '-' }}</div>
       </ng-container>
 
       <ng-container matColumnDef="author">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header="author">Dichter</th>
-        <td mat-cell *matCellDef="let piece">{{ piece.author?.name || '-' }}</td>
+        <div mat-header-cell *matHeaderCellDef mat-sort-header="author">Dichter</div>
+        <div mat-cell *matCellDef="let piece">{{ piece.author?.name || '-' }}</div>
       </ng-container>
 
       <ng-container matColumnDef="collections">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header="collectionCount">Anzahl in Sammlungen</th>
-        <td mat-cell *matCellDef="let piece" class="count-cell">{{ piece.collectionCount || 0 }}</td>
+        <div mat-header-cell *matHeaderCellDef mat-sort-header="collectionCount">Anzahl in Sammlungen</div>
+        <div mat-cell *matCellDef="let piece" class="count-cell">{{ piece.collectionCount || 0 }}</div>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openPiece(row)"></tr>
-      <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</td>
-      </tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></div>
+      <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openPiece(row)"></div>
+      <div class="mat-row" *matNoDataRow>
+        <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</div>
+      </div>
+    </div>
   </div>
   <mat-paginator [length]="totalPieces" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>
 </div>

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -68,32 +68,32 @@
     </div>
 
     <!-- Display Selected Pieces in a Table -->
-    <table mat-table [dataSource]="selectedPiecesDataSource" class="selected-pieces-table">
+    <div mat-table [dataSource]="selectedPiecesDataSource" class="selected-pieces-table">
       <ng-container matColumnDef="reference">
-        <th mat-header-cell *matHeaderCellDef>Ref</th>
-        <td mat-cell *matCellDef="let piece">{{ piece.reference }}</td>
+        <div mat-header-cell *matHeaderCellDef>Ref</div>
+        <div mat-cell *matCellDef="let piece">{{ piece.reference }}</div>
       </ng-container>
 
       <ng-container matColumnDef="title">
-        <th mat-header-cell *matHeaderCellDef>Titel</th>
-        <td mat-cell *matCellDef="let piece">{{ piece.title }}</td>
+        <div mat-header-cell *matHeaderCellDef>Titel</div>
+        <div mat-cell *matCellDef="let piece">{{ piece.title }}</div>
       </ng-container>
 
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let piece">
+        <div mat-header-cell *matHeaderCellDef></div>
+        <div mat-cell *matCellDef="let piece">
           <button mat-icon-button color="warn" (click)="remove(piece)">
             <mat-icon>delete</mat-icon>
           </button>
-        </td>
+        </div>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="pieceColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: pieceColumns;"></tr>
-      <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</td>
-      </tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="pieceColumns"></div>
+      <div mat-row *matRowDef="let row; columns: pieceColumns;"></div>
+      <div class="mat-row" *matNoDataRow>
+        <div class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</div>
+      </div>
+    </div>
 
   </form>
 </div>

--- a/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.html
@@ -26,22 +26,22 @@
     <mat-divider *ngIf="previewData.length > 0"></mat-divider>
     <div *ngIf="previewData.length > 0" class="preview-area">
       <p>Bitte prüfe, ob die Daten korrekt eingelesen werden.</p>
-      <table mat-table [dataSource]="previewData">
+      <div mat-table [dataSource]="previewData">
         <ng-container matColumnDef="reference">
-          <th mat-header-cell *matHeaderCellDef>Referenz</th>
-          <td mat-cell *matCellDef="let row">{{ row.referenz || row.reference }}</td>
+          <div mat-header-cell *matHeaderCellDef>Referenz</div>
+          <div mat-cell *matCellDef="let row">{{ row.referenz || row.reference }}</div>
         </ng-container>
         <ng-container matColumnDef="title">
-          <th mat-header-cell *matHeaderCellDef>Titel</th>
-          <td mat-cell *matCellDef="let row">{{ row.titel || row.title }}</td>
+          <div mat-header-cell *matHeaderCellDef>Titel</div>
+          <div mat-cell *matCellDef="let row">{{ row.titel || row.title }}</div>
         </ng-container>
         <ng-container matColumnDef="date">
-          <th mat-header-cell *matHeaderCellDef>Datum</th>
-          <td mat-cell *matCellDef="let row">{{ row.datum || row.date }}</td>
+          <div mat-header-cell *matHeaderCellDef>Datum</div>
+          <div mat-cell *matCellDef="let row">{{ row.datum || row.date }}</div>
         </ng-container>
-        <tr mat-header-row *matHeaderRowDef="previewColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: previewColumns;"></tr>
-      </table>
+        <div mat-header-row *matHeaderRowDef="previewColumns"></div>
+        <div mat-row *matRowDef="let row; columns: previewColumns;"></div>
+      </div>
     </div>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -26,53 +26,53 @@
 
 
 <div class="table-wrapper mat-elevation-z4">
-  <table mat-table [dataSource]="dataSource" class="event-table">
+  <div mat-table [dataSource]="dataSource" class="event-table">
     <ng-container matColumnDef="select">
-      <th mat-header-cell *matHeaderCellDef>
+      <div mat-header-cell *matHeaderCellDef>
         <mat-checkbox (change)="toggleAll()" [checked]="isAllSelected()" [indeterminate]="selection.hasValue() && !isAllSelected()"></mat-checkbox>
-      </th>
-      <td mat-cell *matCellDef="let ev">
+      </div>
+      <div mat-cell *matCellDef="let ev">
         <mat-checkbox (click)="$event.stopPropagation()" (change)="toggleEvent(ev)" [checked]="selection.isSelected(ev)"></mat-checkbox>
-      </td>
+      </div>
     </ng-container>
     <ng-container matColumnDef="date">
-      <th mat-header-cell *matHeaderCellDef>Datum</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</td>
+      <div mat-header-cell *matHeaderCellDef>Datum</div>
+      <div mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</div>
     </ng-container>
 
     <ng-container matColumnDef="type">
-      <th mat-header-cell *matHeaderCellDef>Typ</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.type | eventTypeLabel }}</td>
+      <div mat-header-cell *matHeaderCellDef>Typ</div>
+      <div mat-cell *matCellDef="let ev">{{ ev.type | eventTypeLabel }}</div>
     </ng-container>
 
     <ng-container matColumnDef="updatedAt">
-      <th mat-header-cell *matHeaderCellDef>Geändert</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.updatedAt | date:'short' }}</td>
+      <div mat-header-cell *matHeaderCellDef>Geändert</div>
+      <div mat-cell *matCellDef="let ev">{{ ev.updatedAt | date:'short' }}</div>
     </ng-container>
 
     <ng-container matColumnDef="director">
-      <th mat-header-cell *matHeaderCellDef>Leiter</th>
-      <td mat-cell *matCellDef="let ev">{{ ev.director?.name }}</td>
+      <div mat-header-cell *matHeaderCellDef>Leiter</div>
+      <div mat-cell *matCellDef="let ev">{{ ev.director?.name }}</div>
     </ng-container>
 
     <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let ev" class="actions-cell">
+      <div mat-header-cell *matHeaderCellDef></div>
+      <div mat-cell *matCellDef="let ev" class="actions-cell">
         <button *ngIf="!isSingerOnly" mat-icon-button (click)="editEvent(ev); $event.stopPropagation()">
           <mat-icon>edit</mat-icon>
         </button>
         <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button color="warn" (click)="deleteEvent(ev); $event.stopPropagation()">
           <mat-icon>delete</mat-icon>
         </button>
-      </td>
+      </div>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectEvent(row)"></tr>
-    <tr class="mat-row" *matNoDataRow>
-      <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Events gefunden.</td>
-    </tr>
-  </table>
+    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+    <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectEvent(row)"></div>
+    <div class="mat-row" *matNoDataRow>
+      <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Events gefunden.</div>
+    </div>
+  </div>
 
   <mat-paginator [pageSizeOptions]="pageSizeOptions"
                  [pageSize]="pageSize"

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -67,29 +67,29 @@
       </mat-card-header>
       <mat-card-content>
         <div class="table-wrapper mat-elevation-z4">
-          <table mat-table [dataSource]="rehearsalDataSource">
+          <div mat-table [dataSource]="rehearsalDataSource">
             <ng-container matColumnDef="title">
-              <th mat-header-cell *matHeaderCellDef> Titel </th>
-              <td mat-cell *matCellDef="let piece">
+              <div mat-header-cell *matHeaderCellDef> Titel </div>
+              <div mat-cell *matCellDef="let piece">
                 <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
-              </td>
+              </div>
             </ng-container>
             <ng-container matColumnDef="composer">
-              <th mat-header-cell *matHeaderCellDef> Komponist/Ursprung </th>
-              <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</td>
+              <div mat-header-cell *matHeaderCellDef> Komponist/Ursprung </div>
+              <div mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</div>
             </ng-container>
             <ng-container matColumnDef="reference">
-              <th mat-header-cell *matHeaderCellDef> Sammlung </th>
-              <td mat-cell *matCellDef="let piece">{{ formatReference(piece) }}</td>
+              <div mat-header-cell *matHeaderCellDef> Sammlung </div>
+              <div mat-cell *matCellDef="let piece">{{ formatReference(piece) }}</div>
             </ng-container>
-            <tr mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></tr>
-            <tr class="mat-row" *matNoDataRow>
-              <td class="mat-cell" [attr.colspan]="displayedRehearsalColumns.length">
+            <div mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></div>
+            <div mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></div>
+            <div class="mat-row" *matNoDataRow>
+              <div class="mat-cell" [attr.colspan]="displayedRehearsalColumns.length">
                 Keine Stücke in Probe.
-              </td>
-            </tr>
-          </table>
+              </div>
+            </div>
+          </div>
         </div>
       </mat-card-content>
     </mat-card>

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -31,31 +31,31 @@
       </mat-menu>
     </div>
 
-    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8" multiTemplateDataRows>
+    <div mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8" multiTemplateDataRows>
       <ng-container matColumnDef="cover">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let element" class="cover-cell">
+        <div mat-header-cell *matHeaderCellDef></div>
+        <div mat-cell *matCellDef="let element" class="cover-cell">
           <img *ngIf="element.collection?.coverImageData" [src]="element.collection.coverImageData" alt="Cover" loading="lazy" />
-        </td>
+        </div>
       </ng-container>
 
       <ng-container matColumnDef="title">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Titel</th>
-        <td mat-cell *matCellDef="let element">
+        <div mat-header-cell *matHeaderCellDef mat-sort-header>Titel</div>
+        <div mat-cell *matCellDef="let element">
           <div class="composer-hint" *ngIf="getCollectionComposer(element.collection) as composer">{{ composer }}</div>
           <div class="title">{{ element.collection?.title }}</div>
           <div class="subtitle-hint" *ngIf="getCollectionHint(element.collection) as hint">{{ hint }}</div>
-        </td>
+        </div>
       </ng-container>
 
       <ng-container matColumnDef="copies">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Exemplare</th>
-        <td mat-cell *matCellDef="let element">{{element.copies}}</td>
+        <div mat-header-cell *matHeaderCellDef mat-sort-header>Exemplare</div>
+        <div mat-cell *matCellDef="let element">{{element.copies}}</div>
       </ng-container>
 
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let element">
+        <div mat-header-cell *matHeaderCellDef></div>
+        <div mat-cell *matCellDef="let element">
           <button mat-icon-button color="primary" *ngIf="element.status === 'available'" (click)="addToCart(element, $event)">
             <mat-icon>add_shopping_cart</mat-icon>
           </button>
@@ -67,11 +67,11 @@
             <button mat-menu-item (click)="changeStatus(element, $event)">Entleihstatus ändern</button>
             <button mat-menu-item class="delete-button" (click)="deleteItem(element, $event)">Löschen</button>
           </mat-menu>
-        </td>
+        </div>
       </ng-container>
 
       <ng-container matColumnDef="expandedDetail">
-        <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+        <div mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
           <div *ngIf="expandedItem === element">
             <mat-nav-list>
               <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
@@ -84,13 +84,13 @@
             </mat-nav-list>
             <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
           </div>
-        </td>
+        </div>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></tr>
-      <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
-    </table>
+      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+      <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></div>
+      <div mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></div>
+    </div>
     <mat-paginator #libraryPaginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" showFirstLastButtons></mat-paginator>
   </mat-tab>
 

--- a/choir-app-frontend/src/app/features/library/loan-cart.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-cart.component.html
@@ -1,26 +1,26 @@
 <div *ngIf="items$ | async as items">
-  <table mat-table [dataSource]="items" class="mat-elevation-z8" *ngIf="items.length > 0">
+  <div mat-table [dataSource]="items" class="mat-elevation-z8" *ngIf="items.length > 0">
     <ng-container matColumnDef="title">
-      <th mat-header-cell *matHeaderCellDef>Sammlung</th>
-      <td mat-cell *matCellDef="let row">{{row.item.collection?.title}}</td>
+      <div mat-header-cell *matHeaderCellDef>Sammlung</div>
+      <div mat-cell *matCellDef="let row">{{row.item.collection?.title}}</div>
     </ng-container>
     <ng-container matColumnDef="quantity">
-      <th mat-header-cell *matHeaderCellDef>Anzahl</th>
-      <td mat-cell *matCellDef="let row">
+      <div mat-header-cell *matHeaderCellDef>Anzahl</div>
+      <div mat-cell *matCellDef="let row">
         <input matInput type="number" [(ngModel)]="row.quantity" min="1" />
-      </td>
+      </div>
     </ng-container>
     <ng-container matColumnDef="remove">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let row">
+      <div mat-header-cell *matHeaderCellDef></div>
+      <div mat-cell *matCellDef="let row">
         <button mat-icon-button color="warn" (click)="remove(row.item.id)">
           <mat-icon>delete</mat-icon>
         </button>
-      </td>
+      </div>
     </ng-container>
-    <tr mat-header-row *matHeaderRowDef="['title','quantity','remove']"></tr>
-    <tr mat-row *matRowDef="let row; columns: ['title','quantity','remove']"></tr>
-  </table>
+    <div mat-header-row *matHeaderRowDef="['title','quantity','remove']"></div>
+    <div mat-row *matRowDef="let row; columns: ['title','quantity','remove']"></div>
+  </div>
   <p *ngIf="items.length === 0">Keine Sammlungen im Entleihkorb.</p>
 
   <div class="form-section" *ngIf="items.length > 0">

--- a/choir-app-frontend/src/app/features/library/loan-list.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.html
@@ -1,32 +1,20 @@
-<table mat-table [dataSource]="loans" class="mat-elevation-z8">
-  <ng-container matColumnDef="collectionTitle">
-    <th mat-header-cell *matHeaderCellDef>Sammlungstitel</th>
-    <td mat-cell *matCellDef="let element">{{element.collectionTitle}}</td>
-  </ng-container>
+<div class="loan-table mat-elevation-z8">
+  <div class="loan-row loan-header">
+    <div>Sammlungstitel</div>
+    <div>Chor</div>
+    <div>Startdatum</div>
+    <div>Enddatum</div>
+    <div>Status</div>
+    <div class="actions"></div>
+  </div>
 
-  <ng-container matColumnDef="choirName">
-    <th mat-header-cell *matHeaderCellDef>Chor</th>
-    <td mat-cell *matCellDef="let element">{{element.choirName}}</td>
-  </ng-container>
-
-  <ng-container matColumnDef="startDate">
-    <th mat-header-cell *matHeaderCellDef>Startdatum</th>
-    <td mat-cell *matCellDef="let element">{{element.startDate | date}}</td>
-  </ng-container>
-
-  <ng-container matColumnDef="endDate">
-    <th mat-header-cell *matHeaderCellDef>Enddatum</th>
-    <td mat-cell *matCellDef="let element">{{element.endDate | date}}</td>
-  </ng-container>
-
-  <ng-container matColumnDef="status">
-    <th mat-header-cell *matHeaderCellDef>Status</th>
-    <td mat-cell *matCellDef="let element">{{element.status | loanStatusLabel}}</td>
-  </ng-container>
-
-  <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef></th>
-    <td mat-cell *matCellDef="let element">
+  <div class="loan-row" *ngFor="let element of loans">
+    <div>{{ element.collectionTitle }}</div>
+    <div>{{ element.choirName }}</div>
+    <div>{{ element.startDate | date }}</div>
+    <div>{{ element.endDate | date }}</div>
+    <div>{{ element.status | loanStatusLabel }}</div>
+    <div class="actions">
       <button mat-icon-button [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">
         <mat-icon>more_vert</mat-icon>
       </button>
@@ -34,9 +22,9 @@
         <button mat-menu-item (click)="openEdit(element)">Ausleihe bearbeiten</button>
         <button mat-menu-item (click)="endLoan(element)">Ausleihe beenden</button>
       </mat-menu>
-    </td>
-  </ng-container>
+    </div>
+  </div>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-</table>
+  <div class="no-data" *ngIf="loans.length === 0">Keine Ausleihen gefunden.</div>
+</div>
+

--- a/choir-app-frontend/src/app/features/library/loan-list.component.scss
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.scss
@@ -1,1 +1,50 @@
-table { width: 100%; }
+.loan-table {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.loan-row {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  align-items: center;
+}
+
+.loan-row > div {
+  padding: 8px;
+}
+
+.loan-header {
+  font-weight: 600;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+@media (max-width: 600px) {
+  .loan-row {
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: auto;
+    padding: 4px 0;
+  }
+
+  .loan-header {
+    display: none;
+  }
+
+  .loan-row > div {
+    padding: 4px;
+  }
+
+  .loan-row > div:nth-child(odd) {
+    font-weight: 600;
+  }
+
+  .loan-row > div:nth-child(even) {
+    text-align: right;
+  }
+}
+
+.no-data {
+  padding: 16px;
+  text-align: center;
+  font-style: italic;
+}
+

--- a/choir-app-frontend/src/app/features/library/loan-list.component.ts
+++ b/choir-app-frontend/src/app/features/library/loan-list.component.ts
@@ -15,7 +15,6 @@ import { LoanEditDialogComponent } from './loan-edit-dialog.component';
   styleUrls: ['./loan-list.component.scss']
 })
 export class LoanListComponent implements OnInit {
-  displayedColumns: string[] = ['collectionTitle', 'choirName', 'startDate', 'endDate', 'status', 'actions'];
   loans: Loan[] = [];
 
   constructor(private api: ApiService, private dialog: MatDialog) {}

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -95,109 +95,109 @@
 
         <!-- The table itself. It is always present in the DOM, but can be overlaid by the loading shade. -->
         <div class="table-scroll-container">
-          <table mat-table [dataSource]="dataSource" matSort>
+          <div mat-table [dataSource]="dataSource" matSort>
 
             <!-- Title Column -->
             <ng-container matColumnDef="title">
               <!-- mat-sort-header tells the table this column is sortable. 'title' must match the column name. -->
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </th>
-              <td mat-cell *matCellDef="let piece">
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </div>
+              <div mat-cell *matCellDef="let piece">
                 <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Composer Column -->
             <ng-container matColumnDef="composer">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="composer"> Komponist/Ursprung </th>
-              <td mat-cell *matCellDef="let piece">
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="composer"> Komponist/Ursprung </div>
+              <div mat-cell *matCellDef="let piece">
                 {{piece.composer?.name || piece.origin}}
-              </td>
+              </div>
             </ng-container>
 
             <!-- Reference Column -->
             <ng-container matColumnDef="reference">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="reference"> Nr. </th>
-              <td mat-cell *matCellDef="let piece"> {{ formatReferenceForDisplay(piece) }} </td>
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="reference"> Nr. </div>
+              <div mat-cell *matCellDef="let piece"> {{ formatReferenceForDisplay(piece) }} </div>
             </ng-container>
 
             <ng-container matColumnDef="category">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="category"> Rubrik </th>
-              <td mat-cell *matCellDef="let piece">
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="category"> Rubrik </div>
+              <div mat-cell *matCellDef="let piece">
                 {{piece.category?.name}}
-              </td>
+              </div>
             </ng-container>
 
             <ng-container matColumnDef="lastSung">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="lastSung"> Zuletzt gesungen </th>
-              <td mat-cell *matCellDef="let piece"> {{ piece.lastSung ? (piece.lastSung | date:'shortDate') : '-' }} </td>
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="lastSung"> Zuletzt gesungen </div>
+              <div mat-cell *matCellDef="let piece"> {{ piece.lastSung ? (piece.lastSung | date:'shortDate') : '-' }} </div>
             </ng-container>
 
             <ng-container matColumnDef="lastRehearsed">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="lastRehearsed"> Zuletzt geprobt </th>
-              <td mat-cell *matCellDef="let piece"> {{ piece.lastRehearsed ? (piece.lastRehearsed | date:'shortDate') : '-' }} </td>
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="lastRehearsed"> Zuletzt geprobt </div>
+              <div mat-cell *matCellDef="let piece"> {{ piece.lastRehearsed ? (piece.lastRehearsed | date:'shortDate') : '-' }} </div>
             </ng-container>
 
             <ng-container matColumnDef="timesSung">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="timesSung"> Anzahl gesungen </th>
-              <td mat-cell *matCellDef="let piece"> {{ piece.timesSung || 0 }} </td>
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="timesSung"> Anzahl gesungen </div>
+              <div mat-cell *matCellDef="let piece"> {{ piece.timesSung || 0 }} </div>
             </ng-container>
 
             <ng-container matColumnDef="timesRehearsed">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header="timesRehearsed"> Anzahl geprobt </th>
-              <td mat-cell *matCellDef="let piece"> {{ piece.timesRehearsed || 0 }} </td>
+              <div mat-header-cell *matHeaderCellDef mat-sort-header="timesRehearsed"> Anzahl geprobt </div>
+              <div mat-cell *matCellDef="let piece"> {{ piece.timesRehearsed || 0 }} </div>
             </ng-container>
 
             <!-- Status Column (Not sortable in this example) -->
             <!-- Rating Column -->
             <ng-container matColumnDef="rating">
-              <th mat-header-cell *matHeaderCellDef> Bewertung </th>
-              <td mat-cell *matCellDef="let piece">
+              <div mat-header-cell *matHeaderCellDef> Bewertung </div>
+              <div mat-cell *matCellDef="let piece">
                 <mat-select [value]="piece.choir_repertoire?.rating"
                             (selectionChange)="onRatingChange($event.value, piece.id)"
                             (click)="$event.stopPropagation()" [disabled]="!canRate">
                   <mat-option [value]="null">-</mat-option>
                   <mat-option *ngFor="let r of [1,2,3,4,5]" [value]="r">{{ r }}</mat-option>
                 </mat-select>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Status Column (Not sortable in this example) -->
             <ng-container matColumnDef="status">
-              <th mat-header-cell *matHeaderCellDef> Status </th>
-              <td mat-cell *matCellDef="let piece">
+              <div mat-header-cell *matHeaderCellDef> Status </div>
+              <div mat-cell *matCellDef="let piece">
                 <mat-select [value]="piece.choir_repertoire?.status"
                   (selectionChange)="onStatusChange($event.value, piece.id)" (click)="$event.stopPropagation()">
                   <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>
                   <mat-option value="IN_REHEARSAL">Wird geprobt</mat-option>
                   <mat-option value="NOT_READY">Nicht im Repertoire</mat-option>
                 </mat-select>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Actions Column (Not sortable) -->
             <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef></th>
-              <td mat-cell *matCellDef="let piece" class="actions-cell">
+              <div mat-header-cell *matHeaderCellDef></div>
+              <div mat-cell *matCellDef="let piece" class="actions-cell">
                 <button mat-icon-button matTooltip="Stück editieren" (click)="openEditPieceDialog(piece.id)">
                   <mat-icon>edit</mat-icon>
                 </button>
-              </td>
+              </div>
             </ng-container>
 
             <!-- Define the header and data rows -->
-            <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+            <div mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></div>
+            <div mat-row *matRowDef="let row; columns: displayedColumns;"
                 (mouseenter)="onRowMouseEnter($event, row)"
                 (mousemove)="onRowMouseMove($event)"
-                (mouseleave)="onRowMouseLeave()"></tr>
+                (mouseleave)="onRowMouseLeave()"></div>
 
             <!-- Row shown when there is no matching data. -->
-            <tr class="mat-row" *matNoDataRow>
-              <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+            <div class="mat-row" *matNoDataRow>
+              <div class="mat-cell" [attr.colspan]="displayedColumns.length">
                 Keine Stücken passend zu den Filtern gefunden.
-              </td>
-            </tr>
-          </table>
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- The Paginator -->

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -1,21 +1,21 @@
-<table mat-table [dataSource]="availabilities" class="mat-elevation-z2">
+<div mat-table [dataSource]="availabilities" class="mat-elevation-z2">
   <ng-container matColumnDef="date">
-    <th mat-header-cell *matHeaderCellDef>Datum</th>
-    <td mat-cell *matCellDef="let a">
+    <div mat-header-cell *matHeaderCellDef>Datum</div>
+    <div mat-cell *matCellDef="let a">
       {{ a.date | date:'EEE dd.MM.yyyy' }}
       <span class="holiday" *ngIf="a.holidayHint"> ({{ a.holidayHint }})</span>
-    </td>
+    </div>
   </ng-container>
   <ng-container matColumnDef="status">
-    <th mat-header-cell *matHeaderCellDef>Status</th>
-    <td mat-cell *matCellDef="let a" [ngClass]="cellClass(a.status)">
+    <div mat-header-cell *matHeaderCellDef>Status</div>
+    <div mat-cell *matCellDef="let a" [ngClass]="cellClass(a.status)">
       <mat-select [value]="a.status" (selectionChange)="setStatus(a.date, $any($event.value))">
         <mat-option value="AVAILABLE">verfügbar</mat-option>
         <mat-option value="MAYBE">verfügbar nach Absprache</mat-option>
         <mat-option value="UNAVAILABLE">nicht verfügbar</mat-option>
       </mat-select>
-    </td>
+    </div>
   </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
+</div>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -33,17 +33,17 @@
     <button *ngIf="plan.finalized" mat-raised-button color="accent" (click)="openEmailDialog()" matTooltip="Als E-Mail versenden"><mat-icon>mail</mat-icon></button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="accent" (click)="openAvailabilityDialog()" matTooltip="Verfügbarkeit anfragen"><mat-icon>Drafts</mat-icon></button>
   </div>
-  <table mat-table [dataSource]="entries" class="mat-elevation-z2">
+  <div mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">
-      <th mat-header-cell *matHeaderCellDef>Datum</th>
-      <td mat-cell *matCellDef="let ev" [matTooltip]="timestamp(ev.date)">
+      <div mat-header-cell *matHeaderCellDef>Datum</div>
+      <div mat-cell *matCellDef="let ev" [matTooltip]="timestamp(ev.date)">
         {{ ev.date | date:'shortDate' }}
         <span class="holiday" *ngIf="ev.holidayHint"> ({{ ev.holidayHint }})</span>
-      </td>
+      </div>
     </ng-container>
     <ng-container matColumnDef="director">
-      <th mat-header-cell *matHeaderCellDef>Chorleiter</th>
-      <td mat-cell *matCellDef="let ev">
+      <div mat-header-cell *matHeaderCellDef>Chorleiter</div>
+      <div mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else directorText">
           <mat-select [value]="ev.director?.id || null" (selectionChange)="updateDirector(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
@@ -55,11 +55,11 @@
           {{ ev.director?.name }}
           <mat-icon *ngIf="ev.director?.id && isMaybe(ev.director.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-template>
-      </td>
+      </div>
     </ng-container>
     <ng-container matColumnDef="organist">
-      <th mat-header-cell *matHeaderCellDef>Organist</th>
-      <td mat-cell *matCellDef="let ev">
+      <div mat-header-cell *matHeaderCellDef>Organist</div>
+      <div mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else organistText">
           <mat-select [value]="ev.organist?.id || null" (selectionChange)="updateOrganist(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
@@ -71,49 +71,49 @@
           {{ ev.organist?.name }}
           <mat-icon *ngIf="ev.organist?.id && isMaybe(ev.organist.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-template>
-      </td>
+      </div>
     </ng-container>
     <ng-container matColumnDef="notes">
-      <th mat-header-cell *matHeaderCellDef>Notizen</th>
-      <td mat-cell *matCellDef="let ev">
+      <div mat-header-cell *matHeaderCellDef>Notizen</div>
+      <div mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else notesText">
           <input matInput [(ngModel)]="ev.notes" (blur)="updateNotes(ev, ev.notes)" />
         </ng-container>
         <ng-template #notesText>{{ ev.notes }}</ng-template>
-      </td>
+      </div>
     </ng-container>
     <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let ev">
+      <div mat-header-cell *matHeaderCellDef></div>
+      <div mat-cell *matCellDef="let ev">
         <button mat-icon-button color="warn" *ngIf="isChoirAdmin && !plan.finalized" (click)="deleteEntry(ev)">
           <mat-icon>delete</mat-icon>
         </button>
-      </td>
+      </div>
     </ng-container>
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns;"
-        [class.assigned]="plan.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></tr>
-  </table>
+    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+    <div mat-row *matRowDef="let row; columns: displayedColumns;"
+        [class.assigned]="plan.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></div>
+  </div>
 
   <div class="spacer"></div>
   <div class="counter-plan" *ngIf="counterPlanDates.length > 0">
     <h3>Gegenplan</h3>
-    <table class="counter-plan-table">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">
+    <div class="counter-plan-table">
+      <divead>
+        <div>
+          <div>Name</div>
+          <div *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">
             {{ d | date:'dd.MM.' }}
-          </th>
-        </tr>
+          </div>
+        </div>
       </thead>
       <tbody>
-        <tr *ngFor="let row of counterPlanRows">
-          <td>{{ row.user.name }}</td>
-          <td *ngFor="let key of counterPlanDateKeys">{{ row.assignments[key] }}</td>
-        </tr>
+        <div *ngFor="let row of counterPlanRows">
+          <div>{{ row.user.name }}</div>
+          <div *ngFor="let key of counterPlanDateKeys">{{ row.assignments[key] }}</div>
+        </div>
       </tbody>
-    </table>
+    </div>
   </div>
 
     </div>

--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -1,35 +1,35 @@
 <div class="table-container mat-elevation-z4" *ngIf="members.length > 0">
-  <table mat-table [dataSource]="members">
+  <div mat-table [dataSource]="members">
     <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef>Name</th>
-      <td mat-cell *matCellDef="let m">{{ m.name }}</td>
+      <div mat-header-cell *matHeaderCellDef>Name</div>
+      <div mat-cell *matCellDef="let m">{{ m.name }}</div>
     </ng-container>
 
     <ng-container matColumnDef="voice">
-      <th mat-header-cell *matHeaderCellDef>Stimme</th>
-      <td mat-cell *matCellDef="let m">{{ voiceOf(m) }}</td>
+      <div mat-header-cell *matHeaderCellDef>Stimme</div>
+      <div mat-cell *matCellDef="let m">{{ voiceOf(m) }}</div>
     </ng-container>
 
     <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
-      <th mat-header-cell *matHeaderCellDef>{{ col.label }}</th>
-      <td mat-cell *matCellDef="let m">
+      <div mat-header-cell *matHeaderCellDef>{{ col.label }}</div>
+      <div mat-cell *matCellDef="let m">
         <mat-icon *ngIf="iconFor(status(m.id, col.key)) as icon">{{ icon }}</mat-icon>
-      </td>
+      </div>
     </ng-container>
 
     <ng-container *ngFor="let col of monthColumns" [matColumnDef]="col.key">
-      <th mat-header-cell *matHeaderCellDef>{{ col.label }}</th>
-      <td mat-cell *matCellDef="let m">
+      <div mat-header-cell *matHeaderCellDef>{{ col.label }}</div>
+      <div mat-cell *matCellDef="let m">
         <ng-container *ngFor="let ev of col.events">
           <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon">{{ icon }}</mat-icon>
         </ng-container>
-      </td>
+      </div>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    <tr class="mat-row" *matNoDataRow>
-      <td class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</td>
-    </tr>
-  </table>
+    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+    <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
+    <div class="mat-row" *matNoDataRow>
+      <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</div>
+    </div>
+  </div>
 </div>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -13,7 +13,7 @@
 </div>
 
 <div *ngIf="items.length" class="table-container">
-  <table
+  <div
     mat-table
     [dataSource]="items"
     class="program-table"
@@ -21,8 +21,8 @@
     (cdkDropListDropped)="drop($event)"
   >
   <ng-container matColumnDef="move">
-    <th mat-header-cell *matHeaderCellDef></th>
-    <td mat-cell *matCellDef="let item; let i = index">
+    <div mat-header-cell *matHeaderCellDef></div>
+    <div mat-cell *matCellDef="let item; let i = index">
       <button
         mat-icon-button
         (click)="moveUp(i)"
@@ -42,68 +42,68 @@
       <span class="drag-handle" cdkDragHandle aria-label="Greifen">
         <mat-icon>drag_indicator</mat-icon>
       </span>
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef> Titel </th>
-    <td mat-cell *matCellDef="let item">
+    <div mat-header-cell *matHeaderCellDef> Titel </div>
+    <div mat-cell *matCellDef="let item">
       <ng-container [ngSwitch]="item.type">
         <span *ngSwitchCase="'piece'">{{ item.pieceTitleSnapshot }}</span>
         <span *ngSwitchCase="'speech'">{{ item.speechTitle }}</span>
         <span *ngSwitchCase="'break'">{{ item.breakTitle || 'Pause' }}</span>
         <span *ngSwitchCase="'slot'">{{ item.slotLabel }}</span>
       </ng-container>
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="composer">
-    <th mat-header-cell *matHeaderCellDef> Komponist / Sprecher </th>
-    <td mat-cell *matCellDef="let item">
+    <div mat-header-cell *matHeaderCellDef> Komponist / Sprecher </div>
+    <div mat-cell *matCellDef="let item">
       <ng-container [ngSwitch]="item.type">
         <span *ngSwitchCase="'piece'">{{ item.pieceComposerSnapshot }}</span>
         <span *ngSwitchCase="'speech'">{{ item.speechSpeaker }}</span>
         <span *ngSwitchCase="'slot'"></span>
       </ng-container>
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="duration">
-    <th mat-header-cell *matHeaderCellDef> Dauer (mm:ss) </th>
-    <td mat-cell *matCellDef="let item">
+    <div mat-header-cell *matHeaderCellDef> Dauer (mm:ss) </div>
+    <div mat-cell *matCellDef="let item">
       <input
         matInput
         [(ngModel)]="item.durationStr"
         (ngModelChange)="onDurationChange(item)"
         placeholder="mm:ss"
       />
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="note">
-    <th mat-header-cell *matHeaderCellDef> Notiz </th>
-    <td mat-cell *matCellDef="let item">
+    <div mat-header-cell *matHeaderCellDef> Notiz </div>
+    <div mat-cell *matCellDef="let item">
       <input matInput [(ngModel)]="item.note" (blur)="onNoteChange(item)" />
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="time">
-    <th mat-header-cell *matHeaderCellDef> Uhrzeit </th>
-    <td mat-cell *matCellDef="let item; let i = index">
+    <div mat-header-cell *matHeaderCellDef> Uhrzeit </div>
+    <div mat-cell *matCellDef="let item; let i = index">
       {{ getPlannedTime(i) }}
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="sum">
-    <th mat-header-cell *matHeaderCellDef> Summe </th>
-    <td mat-cell *matCellDef="let item; let i = index">
+    <div mat-header-cell *matHeaderCellDef> Summe </div>
+    <div mat-cell *matCellDef="let item; let i = index">
       {{ getCumulativeDuration(i) }}
-    </td>
+    </div>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef> Aktionen </th>
-    <td mat-cell *matCellDef="let item">
+    <div mat-header-cell *matHeaderCellDef> Aktionen </div>
+    <div mat-cell *matCellDef="let item">
 
       <ng-container [ngSwitch]="item.type">
         <a *ngSwitchCase="'piece'" [routerLink]="['/pieces', item.pieceId]" target="_blank">Details</a>
@@ -118,12 +118,12 @@
       <button mat-icon-button color="warn" (click)="deleteItem(item)" aria-label="Löschen">
         <mat-icon>delete</mat-icon>
       </button>
-    </td>
+    </div>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns" cdkDrag></tr>
-  </table>
+  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
+  <div mat-row *matRowDef="let row; columns: displayedColumns" cdkDrag></div>
+  </div>
 </div>
 
 <div *ngIf="items.length" class="total-duration">

--- a/choir-app-frontend/src/app/features/programs/program-list.component.html
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.html
@@ -1,23 +1,23 @@
 <h2>Programme</h2>
 <button mat-raised-button color="primary" routerLink="/programs/create">Neues Programm</button>
 
-<table mat-table [dataSource]="programs" *ngIf="programs.length > 0">
+<div mat-table [dataSource]="programs" *ngIf="programs.length > 0">
   <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef>Titel</th>
-    <td mat-cell *matCellDef="let program">{{ program.title }}</td>
+    <div mat-header-cell *matHeaderCellDef>Titel</div>
+    <div mat-cell *matCellDef="let program">{{ program.title }}</div>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Aktionen</th>
-    <td mat-cell *matCellDef="let program">
+        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
+    <div mat-cell *matCellDef="let program">
       <button mat-button [routerLink]="['/programs', program.id]">Bearbeiten</button>
       <button mat-button color="warn" (click)="delete(program)">Löschen</button>
-    </td>
+    </div>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="['title', 'actions']"></tr>
-  <tr mat-row *matRowDef="let row; columns: ['title', 'actions']"></tr>
-</table>
+  <div mat-header-row *matHeaderRowDef="['title', 'actions']"></div>
+  <div mat-row *matRowDef="let row; columns: ['title', 'actions']"></div>
+</div>
 
 <p *ngIf="programs.length === 0">Keine Programme vorhanden.</p>
 


### PR DESCRIPTION
## Summary
- refactor: replace table tags with div-based mat-table containers for responsive layout across all components

## Testing
- ❌ `npm test` (ChromeHeadless missing libatk-1.0.so.0)
- ⚠️ `npm run lint` (No lint target configured)


------
https://chatgpt.com/codex/tasks/task_e_68b4b49603c083209682a047a327c03f