### PR TITLE
refactor: replace tables with mat-table components

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-creators/manage-creators.component.html
@@ -14,25 +14,25 @@
   </button>
 </div>
 
-<div mat-table [dataSource]="dataSource" class="mat-elevation-z8" multiTemplateDataRows>
+<mat-table [dataSource]="dataSource" class="mat-elevation-z8" multiTemplateDataRows>
   <ng-container matColumnDef="name">
-    <div mat-header-cell *matHeaderCellDef>Name</div>
-    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
+    <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.name }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="birthYear">
-    <div mat-header-cell *matHeaderCellDef>Geburt</div>
-    <div mat-cell *matCellDef="let element">{{ element.birthYear }}</div>
+    <mat-header-cell *matHeaderCellDef>Geburt</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.birthYear }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="deathYear">
-    <div mat-header-cell *matHeaderCellDef>Tod</div>
-    <div mat-cell *matCellDef="let element">{{ element.deathYear }}</div>
+    <mat-header-cell *matHeaderCellDef>Tod</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.deathYear }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <div mat-header-cell *matHeaderCellDef></div>
-    <div mat-cell *matCellDef="let element">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editPerson(element)">
         <mat-icon>edit</mat-icon>
       </button>
@@ -42,11 +42,11 @@
       <button mat-icon-button color="warn" (click)="deletePerson(element)" [disabled]="!element.canDelete">
         <mat-icon>delete</mat-icon>
       </button>
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="expandedDetail">
-    <div mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+    <mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
       <div class="piece-list" *ngIf="expandedPerson?.id === element.id">
         <div *ngIf="expandedPieces.length; else none">
           <ul>
@@ -57,13 +57,13 @@
         </div>
         <ng-template #none>Keine Stücke vorhanden.</ng-template>
       </div>
-    </div>
+    </mat-cell>
   </ng-container>
 
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleRow(row)" class="creator-row"></div>
-  <div mat-row *matRowDef="let row; columns: ['expandedDetail']; when: isExpansionDetailRow" class="detail-row"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleRow(row)" class="creator-row"></mat-row>
+  <mat-row *matRowDef="let row; columns: ['expandedDetail']; when: isExpansionDetailRow" class="detail-row"></mat-row>
+</mat-table>
 
 <mat-paginator [length]="totalPeople"
                [pageSizeOptions]="pageSizeOptions"

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -113,27 +113,27 @@
     </mat-card-header>
     <mat-card-content *ngIf="membersExpanded">
       <div class="table-wrapper mat-elevation-z4">
-        <div mat-table [dataSource]="dataSource">
+        <mat-table [dataSource]="dataSource">
           <!-- Name Column -->
           <ng-container matColumnDef="name">
-            <div mat-header-cell *matHeaderCellDef> Name </div>
-            <div mat-cell *matCellDef="let user"> {{user.name}} </div>
+            <mat-header-cell *matHeaderCellDef> Name </mat-header-cell>
+            <mat-cell *matCellDef="let user"> {{user.name}} </mat-cell>
           </ng-container>
           <!-- Email Column -->
           <ng-container matColumnDef="email">
-            <div mat-header-cell *matHeaderCellDef> E-Mail </div>
-            <div mat-cell *matCellDef="let user"> {{user.email}} </div>
+            <mat-header-cell *matHeaderCellDef> E-Mail </mat-header-cell>
+            <mat-cell *matCellDef="let user"> {{user.email}} </mat-cell>
           </ng-container>
           <ng-container matColumnDef="address">
-            <div mat-header-cell *matHeaderCellDef>Adresse</div>
-            <div mat-cell *matCellDef="let user">
+            <mat-header-cell *matHeaderCellDef>Adresse</mat-header-cell>
+            <mat-cell *matCellDef="let user">
               {{ user.street ? user.street + ',' : '' }} {{ user.postalCode }} {{ user.city }}
-            </div>
+            </mat-cell>
           </ng-container>
           <!-- Role Column -->
           <ng-container matColumnDef="role">
-            <div mat-header-cell *matHeaderCellDef> Rollen </div>
-            <div mat-cell *matCellDef="let user">
+            <mat-header-cell *matHeaderCellDef> Rollen </mat-header-cell>
+            <mat-cell *matCellDef="let user">
               <ng-container *ngIf="isChoirAdmin; else roleText">
                 <mat-form-field appearance="outline" class="roles-select">
                   <mat-select
@@ -149,16 +149,16 @@
                 </mat-form-field>
               </ng-container>
               <ng-template #roleText>{{ user.membership?.rolesInChoir?.join(', ') || '-' }}</ng-template>
-            </div>
+            </mat-cell>
           </ng-container>
           <ng-container matColumnDef="status">
-            <div mat-header-cell *matHeaderCellDef> Status </div>
-            <div mat-cell *matCellDef="let user"> {{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}} </div>
+            <mat-header-cell *matHeaderCellDef> Status </mat-header-cell>
+            <mat-cell *matCellDef="let user"> {{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}} </mat-cell>
           </ng-container>
           <!-- Actions Column -->
           <ng-container matColumnDef="actions">
-            <div mat-header-cell *matHeaderCellDef></div>
-            <div mat-cell *matCellDef="let user" class="actions-cell">
+            <mat-header-cell *matHeaderCellDef></mat-header-cell>
+            <mat-cell *matCellDef="let user" class="actions-cell">
               <!-- Verhindern, dass man sich selbst entfernt -->
               <button
                 mat-icon-button
@@ -168,16 +168,16 @@
                 [disabled]="dataSource.data.length <= 1">
                 <mat-icon>person_remove</mat-icon>
               </button>
-            </div>
+            </mat-cell>
           </ng-container>
-          <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-          <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-          <div class="mat-row" *matNoDataRow>
-            <div class="mat-cell" [attr.colspan]="displayedColumns.length">
+          <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+          <mat-row class="mat-row" *matNoDataRow>
+            <mat-cell class="mat-cell" [attr.colspan]="displayedColumns.length">
               Keine Mitglieder gefunden.
-            </div>
-          </div>
-        </div>
+            </mat-cell>
+          </mat-row>
+        </mat-table>
       </div>
     </mat-card-content>
   </mat-card>
@@ -188,31 +188,31 @@
     </mat-card-header>
     <mat-card-content>
       <div class="table-wrapper mat-elevation-z4">
-        <div mat-table [dataSource]="collectionDataSource">
+        <mat-table [dataSource]="collectionDataSource">
           <ng-container matColumnDef="title">
-            <div mat-header-cell *matHeaderCellDef> Titel </div>
-            <div mat-cell *matCellDef="let col">{{ col.title }}</div>
+            <mat-header-cell *matHeaderCellDef> Titel </mat-header-cell>
+            <mat-cell *matCellDef="let col">{{ col.title }}</mat-cell>
           </ng-container>
           <ng-container matColumnDef="publisher">
-            <div mat-header-cell *matHeaderCellDef> Verlag </div>
-            <div mat-cell *matCellDef="let col">{{ col.publisher || '-' }}</div>
+            <mat-header-cell *matHeaderCellDef> Verlag </mat-header-cell>
+            <mat-cell *matCellDef="let col">{{ col.publisher || '-' }}</mat-cell>
           </ng-container>
           <ng-container matColumnDef="actions">
-            <div mat-header-cell *matHeaderCellDef></div>
-            <div mat-cell *matCellDef="let col" class="actions-cell">
+            <mat-header-cell *matHeaderCellDef></mat-header-cell>
+            <mat-cell *matCellDef="let col" class="actions-cell">
               <button *ngIf="isChoirAdmin" mat-icon-button color="warn" (click)="removeCollection(col)" matTooltip="Sammlung entfernen">
                 <mat-icon>delete</mat-icon>
               </button>
-            </div>
+            </mat-cell>
           </ng-container>
-          <div mat-header-row *matHeaderRowDef="displayedCollectionColumns"></div>
-          <div mat-row *matRowDef="let row; columns: displayedCollectionColumns;"></div>
-          <div class="mat-row" *matNoDataRow>
-            <div class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
+          <mat-header-row *matHeaderRowDef="displayedCollectionColumns"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: displayedCollectionColumns;"></mat-row>
+          <mat-row class="mat-row" *matNoDataRow>
+            <mat-cell class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
               Keine Sammlungen vorhanden.
-            </div>
-          </div>
-        </div>
+            </mat-cell>
+          </mat-row>
+        </mat-table>
       </div>
     </mat-card-content>
   </mat-card>

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -68,32 +68,32 @@
     </div>
 
     <!-- Display Selected Pieces in a Table -->
-    <div mat-table [dataSource]="selectedPiecesDataSource" class="selected-pieces-table">
+    <mat-table [dataSource]="selectedPiecesDataSource" class="selected-pieces-table">
       <ng-container matColumnDef="reference">
-        <div mat-header-cell *matHeaderCellDef>Ref</div>
-        <div mat-cell *matCellDef="let piece">{{ piece.reference }}</div>
+        <mat-header-cell *matHeaderCellDef>Ref</mat-header-cell>
+        <mat-cell *matCellDef="let piece">{{ piece.reference }}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="title">
-        <div mat-header-cell *matHeaderCellDef>Titel</div>
-        <div mat-cell *matCellDef="let piece">{{ piece.title }}</div>
+        <mat-header-cell *matHeaderCellDef>Titel</mat-header-cell>
+        <mat-cell *matCellDef="let piece">{{ piece.title }}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef></div>
-        <div mat-cell *matCellDef="let piece">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let piece">
           <button mat-icon-button color="warn" (click)="remove(piece)">
             <mat-icon>delete</mat-icon>
           </button>
-        </div>
+        </mat-cell>
       </ng-container>
 
-      <div mat-header-row *matHeaderRowDef="pieceColumns"></div>
-      <div mat-row *matRowDef="let row; columns: pieceColumns;"></div>
-      <div class="mat-row" *matNoDataRow>
-        <div class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</div>
-      </div>
-    </div>
+      <mat-header-row *matHeaderRowDef="pieceColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: pieceColumns;"></mat-row>
+      <mat-row class="mat-row" *matNoDataRow>
+        <mat-cell class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</mat-cell>
+      </mat-row>
+    </mat-table>
 
   </form>
 </div>

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -95,109 +95,109 @@
 
         <!-- The table itself. It is always present in the DOM, but can be overlaid by the loading shade. -->
         <div class="table-scroll-container">
-          <div mat-table [dataSource]="dataSource" matSort>
+          <mat-table [dataSource]="dataSource" matSort>
 
             <!-- Title Column -->
             <ng-container matColumnDef="title">
               <!-- mat-sort-header tells the table this column is sortable. 'title' must match the column name. -->
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </div>
-              <div mat-cell *matCellDef="let piece">
+              <mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </mat-header-cell>
+              <mat-cell *matCellDef="let piece">
                 <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Composer Column -->
             <ng-container matColumnDef="composer">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="composer"> Komponist/Ursprung </div>
-              <div mat-cell *matCellDef="let piece">
+              <mat-header-cell *matHeaderCellDef mat-sort-header="composer"> Komponist/Ursprung </mat-header-cell>
+              <mat-cell *matCellDef="let piece">
                 {{piece.composer?.name || piece.origin}}
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Reference Column -->
             <ng-container matColumnDef="reference">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="reference"> Nr. </div>
-              <div mat-cell *matCellDef="let piece"> {{ formatReferenceForDisplay(piece) }} </div>
+              <mat-header-cell *matHeaderCellDef mat-sort-header="reference"> Nr. </mat-header-cell>
+              <mat-cell *matCellDef="let piece"> {{ formatReferenceForDisplay(piece) }} </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="category">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="category"> Rubrik </div>
-              <div mat-cell *matCellDef="let piece">
+              <mat-header-cell *matHeaderCellDef mat-sort-header="category"> Rubrik </mat-header-cell>
+              <mat-cell *matCellDef="let piece">
                 {{piece.category?.name}}
-              </div>
+              </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="lastSung">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="lastSung"> Zuletzt gesungen </div>
-              <div mat-cell *matCellDef="let piece"> {{ piece.lastSung ? (piece.lastSung | date:'shortDate') : '-' }} </div>
+              <mat-header-cell *matHeaderCellDef mat-sort-header="lastSung"> Zuletzt gesungen </mat-header-cell>
+              <mat-cell *matCellDef="let piece"> {{ piece.lastSung ? (piece.lastSung | date:'shortDate') : '-' }} </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="lastRehearsed">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="lastRehearsed"> Zuletzt geprobt </div>
-              <div mat-cell *matCellDef="let piece"> {{ piece.lastRehearsed ? (piece.lastRehearsed | date:'shortDate') : '-' }} </div>
+              <mat-header-cell *matHeaderCellDef mat-sort-header="lastRehearsed"> Zuletzt geprobt </mat-header-cell>
+              <mat-cell *matCellDef="let piece"> {{ piece.lastRehearsed ? (piece.lastRehearsed | date:'shortDate') : '-' }} </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="timesSung">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="timesSung"> Anzahl gesungen </div>
-              <div mat-cell *matCellDef="let piece"> {{ piece.timesSung || 0 }} </div>
+              <mat-header-cell *matHeaderCellDef mat-sort-header="timesSung"> Anzahl gesungen </mat-header-cell>
+              <mat-cell *matCellDef="let piece"> {{ piece.timesSung || 0 }} </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="timesRehearsed">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="timesRehearsed"> Anzahl geprobt </div>
-              <div mat-cell *matCellDef="let piece"> {{ piece.timesRehearsed || 0 }} </div>
+              <mat-header-cell *matHeaderCellDef mat-sort-header="timesRehearsed"> Anzahl geprobt </mat-header-cell>
+              <mat-cell *matCellDef="let piece"> {{ piece.timesRehearsed || 0 }} </mat-cell>
             </ng-container>
 
             <!-- Status Column (Not sortable in this example) -->
             <!-- Rating Column -->
             <ng-container matColumnDef="rating">
-              <div mat-header-cell *matHeaderCellDef> Bewertung </div>
-              <div mat-cell *matCellDef="let piece">
+              <mat-header-cell *matHeaderCellDef> Bewertung </mat-header-cell>
+              <mat-cell *matCellDef="let piece">
                 <mat-select [value]="piece.choir_repertoire?.rating"
                             (selectionChange)="onRatingChange($event.value, piece.id)"
                             (click)="$event.stopPropagation()" [disabled]="!canRate">
                   <mat-option [value]="null">-</mat-option>
                   <mat-option *ngFor="let r of [1,2,3,4,5]" [value]="r">{{ r }}</mat-option>
                 </mat-select>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Status Column (Not sortable in this example) -->
             <ng-container matColumnDef="status">
-              <div mat-header-cell *matHeaderCellDef> Status </div>
-              <div mat-cell *matCellDef="let piece">
+              <mat-header-cell *matHeaderCellDef> Status </mat-header-cell>
+              <mat-cell *matCellDef="let piece">
                 <mat-select [value]="piece.choir_repertoire?.status"
                   (selectionChange)="onStatusChange($event.value, piece.id)" (click)="$event.stopPropagation()">
                   <mat-option value="CAN_BE_SUNG">Aufführbar</mat-option>
                   <mat-option value="IN_REHEARSAL">Wird geprobt</mat-option>
                   <mat-option value="NOT_READY">Nicht im Repertoire</mat-option>
                 </mat-select>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Actions Column (Not sortable) -->
             <ng-container matColumnDef="actions">
-              <div mat-header-cell *matHeaderCellDef></div>
-              <div mat-cell *matCellDef="let piece" class="actions-cell">
+              <mat-header-cell *matHeaderCellDef></mat-header-cell>
+              <mat-cell *matCellDef="let piece" class="actions-cell">
                 <button mat-icon-button matTooltip="Stück editieren" (click)="openEditPieceDialog(piece.id)">
                   <mat-icon>edit</mat-icon>
                 </button>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Define the header and data rows -->
-            <div mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></div>
-            <div mat-row *matRowDef="let row; columns: displayedColumns;"
+            <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
+            <mat-row *matRowDef="let row; columns: displayedColumns;"
                 (mouseenter)="onRowMouseEnter($event, row)"
                 (mousemove)="onRowMouseMove($event)"
-                (mouseleave)="onRowMouseLeave()"></div>
+                (mouseleave)="onRowMouseLeave()"></mat-row>
 
             <!-- Row shown when there is no matching data. -->
-            <div class="mat-row" *matNoDataRow>
-              <div class="mat-cell" [attr.colspan]="displayedColumns.length">
+            <mat-row class="mat-row" *matNoDataRow>
+              <mat-cell class="mat-cell" [attr.colspan]="displayedColumns.length">
                 Keine Stücken passend zu den Filtern gefunden.
-              </div>
-            </div>
-          </div>
+              </mat-cell>
+            </mat-row>
+          </mat-table>
         </div>
 
         <!-- The Paginator -->


### PR DESCRIPTION
## Summary
- swap HTML `<table>` tags for `<mat-table>` elements across creator, choir, event dialog and literature views
- update header, cell and row elements to their `mat-*` counterparts for consistent Material styling

## Testing
- `npm test --silent --prefix choir-app-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b53b12e2588320a13f19785fb74b93