### PR TITLE
refactor: replace deprecated mat table markup

### DIFF
--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.html
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.html
@@ -1,35 +1,35 @@
 <h2>Primäre Palette</h2>
-<div mat-table [dataSource]="primaryColors" class="mat-elevation-z8">
+<mat-table [dataSource]="primaryColors" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <div mat-header-cell *matHeaderCellDef>Farbname</div>
-    <div mat-cell *matCellDef="let c">{{ c.name }}</div>
+    <mat-header-cell *matHeaderCellDef>Farbname</mat-header-cell>
+    <mat-cell *matCellDef="let c">{{ c.name }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="preview">
-    <div mat-header-cell *matHeaderCellDef>Farbe</div>
-    <div mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</div>
+    <mat-header-cell *matHeaderCellDef>Farbe</mat-header-cell>
+    <mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="scss">
-    <div mat-header-cell *matHeaderCellDef>SCSS</div>
-    <div mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></div>
+    <mat-header-cell *matHeaderCellDef>SCSS</mat-header-cell>
+    <mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></mat-cell>
   </ng-container>
-  <div mat-header-row *matHeaderRowDef="['name','preview','scss']"></div>
-  <div mat-row *matRowDef="let row; columns: ['name','preview','scss']"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="['name','preview','scss']"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: ['name','preview','scss']"></mat-row>
+</mat-table>
 
 <h2>Akzent-Palette</h2>
-<div mat-table [dataSource]="accentColors" class="mat-elevation-z8">
+<mat-table [dataSource]="accentColors" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <div mat-header-cell *matHeaderCellDef>Farbname</div>
-    <div mat-cell *matCellDef="let c">{{ c.name }}</div>
+    <mat-header-cell *matHeaderCellDef>Farbname</mat-header-cell>
+    <mat-cell *matCellDef="let c">{{ c.name }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="preview">
-    <div mat-header-cell *matHeaderCellDef>Farbe</div>
-    <div mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</div>
+    <mat-header-cell *matHeaderCellDef>Farbe</mat-header-cell>
+    <mat-cell *matCellDef="let c"><span class="color-box" [style.background]="c.hex"></span> {{ c.hex }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="scss">
-    <div mat-header-cell *matHeaderCellDef>SCSS</div>
-    <div mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></div>
+    <mat-header-cell *matHeaderCellDef>SCSS</mat-header-cell>
+    <mat-cell *matCellDef="let c"><code>{{ c.scss }}</code></mat-cell>
   </ng-container>
-  <div mat-header-row *matHeaderRowDef="['name','preview','scss']"></div>
-  <div mat-row *matRowDef="let row; columns: ['name','preview','scss']"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="['name','preview','scss']"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: ['name','preview','scss']"></mat-row>
+</mat-table>

--- a/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
+++ b/choir-app-frontend/src/app/features/admin/log-viewer/log-viewer.component.html
@@ -11,23 +11,23 @@
 
 <div *ngFor="let group of groups">
   <h3>{{ group.date }}</h3>
-  <div mat-table [dataSource]="group.items" class="mat-elevation-z8 log-table">
+  <mat-table [dataSource]="group.items" class="mat-elevation-z8 log-table">
     <ng-container matColumnDef="timestamp">
-      <div mat-header-cell *matHeaderCellDef>Zeit</div>
-      <div mat-cell *matCellDef="let row">{{ row.timestamp || (row.date | date:'short') }}</div>
+      <mat-header-cell *matHeaderCellDef>Zeit</mat-header-cell>
+      <mat-cell *matCellDef="let row">{{ row.timestamp || (row.date | date:'short') }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="level">
-      <div mat-header-cell *matHeaderCellDef>Level</div>
-      <div mat-cell *matCellDef="let row">{{ row.level }}</div>
+      <mat-header-cell *matHeaderCellDef>Level</mat-header-cell>
+      <mat-cell *matCellDef="let row">{{ row.level }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="message">
-      <div mat-header-cell *matHeaderCellDef>Nachricht</div>
-      <div mat-cell *matCellDef="let row"><pre>{{ row.message || row.stack || row.raw }}</pre></div>
+      <mat-header-cell *matHeaderCellDef>Nachricht</mat-header-cell>
+      <mat-cell *matCellDef="let row"><pre>{{ row.message || row.stack || row.raw }}</pre></mat-cell>
     </ng-container>
 
-    <div mat-header-row *matHeaderRowDef="['timestamp','level','message']"></div>
-    <div mat-row *matRowDef="let row; columns: ['timestamp','level','message']"></div>
-  </div>
+    <mat-header-row *matHeaderRowDef="['timestamp','level','message']"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: ['timestamp','level','message']"></mat-row>
+  </mat-table>
 </div>

--- a/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
+++ b/choir-app-frontend/src/app/features/admin/login-attempts/login-attempts.component.html
@@ -8,39 +8,39 @@
   </button>
 </div>
 
-<div mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="email">
-    <div mat-header-cell *matHeaderCellDef>E-Mail</div>
-    <div mat-cell *matCellDef="let element">
+    <mat-header-cell *matHeaderCellDef>E-Mail</mat-header-cell>
+    <mat-cell *matCellDef="let element">
       <a href="#" (click)="openUser(element.email); $event.preventDefault()">{{ element.email }}</a>
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="success">
-    <div mat-header-cell *matHeaderCellDef>Erfolg</div>
-    <div mat-cell *matCellDef="let element">{{ element.success ? '✔' : '✖' }}</div>
+    <mat-header-cell *matHeaderCellDef>Erfolg</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.success ? '✔' : '✖' }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="reason">
-    <div mat-header-cell *matHeaderCellDef>Grund</div>
-    <div mat-cell *matCellDef="let element">{{ element.reason }}</div>
+    <mat-header-cell *matHeaderCellDef>Grund</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.reason }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="ipAddress">
-    <div mat-header-cell *matHeaderCellDef>IP</div>
-    <div mat-cell *matCellDef="let element">{{ element.ipAddress }}</div>
+    <mat-header-cell *matHeaderCellDef>IP</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.ipAddress }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="userAgent">
-    <div mat-header-cell *matHeaderCellDef>Browser</div>
-    <div mat-cell *matCellDef="let element">{{ element.userAgent }}</div>
+    <mat-header-cell *matHeaderCellDef>Browser</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.userAgent }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="createdAt">
-    <div mat-header-cell *matHeaderCellDef>Datum</div>
-    <div mat-cell *matCellDef="let element">{{ element.createdAt | date:'short' }}</div>
+    <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.createdAt | date:'short' }}</mat-cell>
   </ng-container>
 
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+</mat-table>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -21,43 +21,43 @@
       <mat-icon>add</mat-icon>
       Mitglied hinzufügen
     </button>
-    <div mat-table [dataSource]="dataSource" class="member-table">
+    <mat-table [dataSource]="dataSource" class="member-table">
       <ng-container matColumnDef="name">
-        <div mat-header-cell *matHeaderCellDef>Name</div>
-        <div mat-cell *matCellDef="let user">{{user.name}}</div>
+        <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+        <mat-cell *matCellDef="let user">{{user.name}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="email">
-        <div mat-header-cell *matHeaderCellDef>E-Mail</div>
-        <div mat-cell *matCellDef="let user">{{user.email}}</div>
+        <mat-header-cell *matHeaderCellDef>E-Mail</mat-header-cell>
+        <mat-cell *matCellDef="let user">{{user.email}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="role">
-        <div mat-header-cell *matHeaderCellDef>Rollen</div>
-        <div mat-cell *matCellDef="let user">{{user.membership?.rolesInChoir?.join(', ') || '-'}}</div>
+        <mat-header-cell *matHeaderCellDef>Rollen</mat-header-cell>
+        <mat-cell *matCellDef="let user">{{user.membership?.rolesInChoir?.join(', ') || '-'}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="organist">
-        <div mat-header-cell *matHeaderCellDef>Organist</div>
-        <div mat-cell *matCellDef="let user">
+        <mat-header-cell *matHeaderCellDef>Organist</mat-header-cell>
+        <mat-cell *matCellDef="let user">
           <mat-checkbox [checked]="user.membership?.rolesInChoir?.includes('organist')" (change)="toggleOrganist(user, $event.checked)"></mat-checkbox>
-        </div>
+        </mat-cell>
       </ng-container>
       <ng-container matColumnDef="status">
-        <div mat-header-cell *matHeaderCellDef>Status</div>
-        <div mat-cell *matCellDef="let user">{{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}}</div>
+        <mat-header-cell *matHeaderCellDef>Status</mat-header-cell>
+        <mat-cell *matCellDef="let user">{{user.membership?.registrationStatus === 'PENDING' ? 'Registrierung ausstehend' : 'Registriert'}}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef></div>
-        <div mat-cell *matCellDef="let user">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let user">
           <button mat-icon-button color="warn" (click)="removeMember(user)">
             <mat-icon>person_remove</mat-icon>
           </button>
-        </div>
+        </mat-cell>
       </ng-container>
-      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-      <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
-      <div class="mat-row" *matNoDataRow>
-        <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</div>
-      </div>
-    </div>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+      <mat-row *matNoDataRow>
+        <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
+      </mat-row>
+    </mat-table>
   </div>
 </div>
 <div mat-dialog-actions align="end">

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/manage-choirs.component.html
@@ -2,44 +2,44 @@
   <button mat-flat-button color="primary" (click)="addChoir()">Chor hinzufügen</button>
 </div>
 
-<div mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <div mat-header-cell *matHeaderCellDef>Name</div>
-    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
+    <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.name }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="location">
-    <div mat-header-cell *matHeaderCellDef>Ort</div>
-    <div mat-cell *matCellDef="let element">{{ element.location }}</div>
+    <mat-header-cell *matHeaderCellDef>Ort</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.location }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="memberCount">
-    <div mat-header-cell *matHeaderCellDef>Mitglieder</div>
-    <div mat-cell *matCellDef="let element">{{ element.memberCount }}</div>
+    <mat-header-cell *matHeaderCellDef>Mitglieder</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.memberCount }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="eventCount">
-    <div mat-header-cell *matHeaderCellDef>Ereignisse</div>
-    <div mat-cell *matCellDef="let element">{{ element.eventCount }}</div>
+    <mat-header-cell *matHeaderCellDef>Ereignisse</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.eventCount }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="pieceCount">
-    <div mat-header-cell *matHeaderCellDef>Repertoire</div>
-    <div mat-cell *matCellDef="let element">{{ element.pieceCount }}</div>
+    <mat-header-cell *matHeaderCellDef>Repertoire</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.pieceCount }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <div mat-header-cell *matHeaderCellDef></div>
-    <div mat-cell *matCellDef="let element">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editChoir(element)">
         <mat-icon>edit</mat-icon>
       </button>
       <button mat-icon-button color="warn" (click)="deleteChoir(element)">
         <mat-icon>delete</mat-icon>
       </button>
-    </div>
+    </mat-cell>
   </ng-container>
 
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+</mat-table>

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
@@ -5,29 +5,29 @@
         Cover ({{ unassignedCovers }} unzugewiesen)
       </mat-panel-title>
     </mat-expansion-panel-header>
-    <div mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
+    <mat-table [dataSource]="covers" class="mat-elevation-z1" *ngIf="covers.length > 0">
       <ng-container matColumnDef="filename">
-        <div mat-header-cell *matHeaderCellDef>Datei</div>
-        <div mat-cell *matCellDef="let f">{{ f.filename }}</div>
+        <mat-header-cell *matHeaderCellDef>Datei</mat-header-cell>
+        <mat-cell *matCellDef="let f">{{ f.filename }}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="linked">
-        <div mat-header-cell *matHeaderCellDef>Zugewiesen</div>
-        <div mat-cell *matCellDef="let f">
+        <mat-header-cell *matHeaderCellDef>Zugewiesen</mat-header-cell>
+        <mat-cell *matCellDef="let f">
           <a *ngIf="f.collectionId" [routerLink]="['/collections/edit', f.collectionId]">{{ f.collectionTitle }}</a>
           <span *ngIf="!f.collectionId">–</span>
-        </div>
+        </mat-cell>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
-        <div mat-cell *matCellDef="let f">
+        <mat-header-cell *matHeaderCellDef>Aktionen</mat-header-cell>
+        <mat-cell *matCellDef="let f">
           <button mat-icon-button color="warn" *ngIf="!f.collectionId" (click)="delete('covers', f.filename)" matTooltip="Löschen">
             <mat-icon>delete</mat-icon>
           </button>
-        </div>
+        </mat-cell>
       </ng-container>
-      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-      <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
-    </div>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+    </mat-table>
     <p *ngIf="covers.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>
 
@@ -37,29 +37,29 @@
         Notenbild ({{ unassignedImages }} unzugewiesen)
       </mat-panel-title>
     </mat-expansion-panel-header>
-    <div mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
+    <mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
       <ng-container matColumnDef="filename">
-        <div mat-header-cell *matHeaderCellDef>Datei</div>
-        <div mat-cell *matCellDef="let f">{{ f.filename }}</div>
+        <mat-header-cell *matHeaderCellDef>Datei</mat-header-cell>
+        <mat-cell *matCellDef="let f">{{ f.filename }}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="linked">
-        <div mat-header-cell *matHeaderCellDef>Zugewiesen</div>
-        <div mat-cell *matCellDef="let f">
+        <mat-header-cell *matHeaderCellDef>Zugewiesen</mat-header-cell>
+        <mat-cell *matCellDef="let f">
           <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
           <span *ngIf="!f.pieceId">–</span>
-        </div>
+        </mat-cell>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
-        <div mat-cell *matCellDef="let f">
+        <mat-header-cell *matHeaderCellDef>Aktionen</mat-header-cell>
+        <mat-cell *matCellDef="let f">
           <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('images', f.filename)" matTooltip="Löschen">
             <mat-icon>delete</mat-icon>
           </button>
-        </div>
+        </mat-cell>
       </ng-container>
-      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-      <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
-    </div>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+    </mat-table>
     <p *ngIf="images.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>
 
@@ -69,33 +69,33 @@
         Hochgeladene Dateien ({{ unassignedFiles }} unzugewiesen)
       </mat-panel-title>
     </mat-expansion-panel-header>
-    <div mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
+    <mat-table [dataSource]="files" class="mat-elevation-z1" *ngIf="files.length > 0">
       <ng-container matColumnDef="filename">
-        <div mat-header-cell *matHeaderCellDef>Datei</div>
-        <div mat-cell *matCellDef="let f">{{ f.filename }}</div>
+        <mat-header-cell *matHeaderCellDef>Datei</mat-header-cell>
+        <mat-cell *matCellDef="let f">{{ f.filename }}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="downloadName">
-        <div mat-header-cell *matHeaderCellDef>Downloadname</div>
-        <div mat-cell *matCellDef="let f">{{ f.downloadName || '–' }}</div>
+        <mat-header-cell *matHeaderCellDef>Downloadname</mat-header-cell>
+        <mat-cell *matCellDef="let f">{{ f.downloadName || '–' }}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="linked">
-        <div mat-header-cell *matHeaderCellDef>Zugewiesen</div>
-        <div mat-cell *matCellDef="let f">
+        <mat-header-cell *matHeaderCellDef>Zugewiesen</mat-header-cell>
+        <mat-cell *matCellDef="let f">
           <a *ngIf="f.pieceId" [routerLink]="['/pieces', f.pieceId]">{{ f.pieceTitle }}</a>
           <span *ngIf="!f.pieceId">–</span>
-        </div>
+        </mat-cell>
       </ng-container>
       <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
-        <div mat-cell *matCellDef="let f">
+        <mat-header-cell *matHeaderCellDef>Aktionen</mat-header-cell>
+        <mat-cell *matCellDef="let f">
           <button mat-icon-button color="warn" *ngIf="!f.pieceId" (click)="delete('files', f.filename)" matTooltip="Löschen">
             <mat-icon>delete</mat-icon>
           </button>
-        </div>
+        </mat-cell>
       </ng-container>
-      <div mat-header-row *matHeaderRowDef="displayedFileColumns"></div>
-      <div mat-row *matRowDef="let row; columns: displayedFileColumns"></div>
-    </div>
+      <mat-header-row *matHeaderRowDef="displayedFileColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedFileColumns"></mat-row>
+    </mat-table>
     <p *ngIf="files.length === 0">Keine Dateien gefunden.</p>
   </mat-expansion-panel>
 </mat-accordion>

--- a/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
@@ -1,26 +1,26 @@
 <h2>Änderungsvorschläge</h2>
-<div mat-table [dataSource]="dataSource" class="mat-elevation-z8 full-width">
+<mat-table [dataSource]="dataSource" class="mat-elevation-z8 full-width">
     <ng-container matColumnDef="piece">
-        <div mat-header-cell *matHeaderCellDef>Stück</div>
-        <div mat-cell *matCellDef="let c">{{ c.piece?.title || ('Piece ' + c.pieceId) }}</div>
+        <mat-header-cell *matHeaderCellDef>Stück</mat-header-cell>
+        <mat-cell *matCellDef="let c">{{ c.piece?.title || ('Piece ' + c.pieceId) }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="createdAt">
-        <div mat-header-cell *matHeaderCellDef>Datum</div>
-        <div mat-cell *matCellDef="let c">{{ c.createdAt | date:'short' }}</div>
+        <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
+        <mat-cell *matCellDef="let c">{{ c.createdAt | date:'short' }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef></div>
-        <div mat-cell *matCellDef="let c">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let c">
             <button mat-button color="primary" (click)="approve(c)">Übernehmen</button>
             <button mat-button color="warn" (click)="decline(c)">Ablehnen</button>
-        </div>
+        </mat-cell>
     </ng-container>
 
-    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-    <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-    <div class="mat-row" *matNoDataRow>
-        <div class="mat-cell" colspan="3">Keine Vorschläge vorhanden.</div>
-    </div>
-</div>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-row *matNoDataRow>
+        <mat-cell colspan="3">Keine Vorschläge vorhanden.</mat-cell>
+    </mat-row>
+</mat-table>

--- a/choir-app-frontend/src/app/features/admin/manage-publishers/manage-publishers.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-publishers/manage-publishers.component.html
@@ -4,23 +4,23 @@
 <div class="letter-filter">
   <button mat-button *ngFor="let l of letters" (click)="onLetterSelect(l)" [color]="selectedLetter === l ? 'primary' : undefined">{{ l }}</button>
 </div>
-<div mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+<mat-table [dataSource]="dataSource" class="mat-elevation-z8">
   <ng-container matColumnDef="name">
-    <div mat-header-cell *matHeaderCellDef>Name</div>
-    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
+    <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.name }}</mat-cell>
   </ng-container>
   <ng-container matColumnDef="actions">
-    <div mat-header-cell *matHeaderCellDef></div>
-    <div mat-cell *matCellDef="let element">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editPublisher(element)">
         <mat-icon>edit</mat-icon>
       </button>
       <button mat-icon-button color="warn" (click)="deletePublisher(element)" [disabled]="!element.canDelete">
         <mat-icon>delete</mat-icon>
       </button>
-    </div>
+    </mat-cell>
   </ng-container>
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+</mat-table>
 <mat-paginator [length]="totalPublishers" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -7,25 +7,24 @@
   </mat-form-field>
 </div>
 
-<div
-  mat-table
+<mat-table
   [dataSource]="dataSource"
   class="mat-elevation-z8"
   *ngIf="!(isHandset$ | async)"
 >
   <ng-container matColumnDef="name">
-    <div mat-header-cell *matHeaderCellDef>Name</div>
-    <div mat-cell *matCellDef="let element">{{ element.name }}</div>
+    <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.name }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="email">
-    <div mat-header-cell *matHeaderCellDef>E-Mail</div>
-    <div mat-cell *matCellDef="let element">{{ element.email }}</div>
+    <mat-header-cell *matHeaderCellDef>E-Mail</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.email }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="roles">
-    <div mat-header-cell *matHeaderCellDef>Rollen</div>
-    <div mat-cell *matCellDef="let element">
+    <mat-header-cell *matHeaderCellDef>Rollen</mat-header-cell>
+    <mat-cell *matCellDef="let element">
       <mat-form-field appearance="outline" class="roles-select">
         <mat-select
           [ngModel]="element.roles"
@@ -39,22 +38,22 @@
           <mat-option value="librarian">Bibliothekar</mat-option>
         </mat-select>
       </mat-form-field>
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="choirs">
-    <div mat-header-cell *matHeaderCellDef>Chöre</div>
-    <div mat-cell *matCellDef="let element">{{ choirList(element) }}</div>
+    <mat-header-cell *matHeaderCellDef>Chöre</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ choirList(element) }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="lastLogin">
-    <div mat-header-cell *matHeaderCellDef>Letzter Login</div>
-    <div mat-cell *matCellDef="let element">{{ element.lastLogin | date:'short' }}</div>
+    <mat-header-cell *matHeaderCellDef>Letzter Login</mat-header-cell>
+    <mat-cell *matCellDef="let element">{{ element.lastLogin | date:'short' }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <div mat-header-cell *matHeaderCellDef></div>
-    <div mat-cell *matCellDef="let element">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
       <button mat-icon-button color="primary" (click)="editUser(element)">
         <mat-icon>edit</mat-icon>
       </button>
@@ -67,12 +66,12 @@
       <button mat-icon-button color="warn" (click)="deleteUser(element)">
         <mat-icon>delete</mat-icon>
       </button>
-    </div>
+    </mat-cell>
   </ng-container>
 
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+</mat-table>
 
 <mat-accordion *ngIf="isHandset$ | async">
   <mat-expansion-panel *ngFor="let element of dataSource.filteredData">

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -1,39 +1,39 @@
 <div class="table-container mat-elevation-z4">
-  <div mat-table [dataSource]="dataSource">
+  <mat-table [dataSource]="dataSource">
     <ng-container matColumnDef="name">
-      <div mat-header-cell *matHeaderCellDef>Name</div>
-      <div mat-cell *matCellDef="let m">{{ m.name }}</div>
+      <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ m.name }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="voice">
-      <div mat-header-cell *matHeaderCellDef>Stimme</div>
-      <div mat-cell *matCellDef="let m">{{ m.voice || '-' }}</div>
+      <mat-header-cell *matHeaderCellDef>Stimme</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ m.voice || '-' }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="email">
-      <div mat-header-cell *matHeaderCellDef>E-Mail</div>
-      <div mat-cell *matCellDef="let m">{{ m.email }}</div>
+      <mat-header-cell *matHeaderCellDef>E-Mail</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ m.email }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="street">
-      <div mat-header-cell *matHeaderCellDef>Straße</div>
-      <div mat-cell *matCellDef="let m">{{ mask(m.street, m.shareWithChoir) }}</div>
+      <mat-header-cell *matHeaderCellDef>Straße</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ mask(m.street, m.shareWithChoir) }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="postalCode">
-      <div mat-header-cell *matHeaderCellDef>PLZ</div>
-      <div mat-cell *matCellDef="let m">{{ mask(m.postalCode, m.shareWithChoir) }}</div>
+      <mat-header-cell *matHeaderCellDef>PLZ</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ mask(m.postalCode, m.shareWithChoir) }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="city">
-      <div mat-header-cell *matHeaderCellDef>Ort</div>
-      <div mat-cell *matCellDef="let m">{{ mask(m.city, m.shareWithChoir) }}</div>
+      <mat-header-cell *matHeaderCellDef>Ort</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ mask(m.city, m.shareWithChoir) }}</mat-cell>
     </ng-container>
 
-    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-    <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-    <div class="mat-row" *matNoDataRow>
-      <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</div>
-    </div>
-  </div>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-row *matNoDataRow>
+      <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
+    </mat-row>
+  </mat-table>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.html
@@ -139,11 +139,11 @@
 
           <div *ngIf="selectedPieceLinks.length > 0; else noPieces">
           <!-- Using a mat-table for a clean, structured display -->
-          <div class="piece-link-table" mat-table [dataSource]="pieceLinkDataSource" matSort matSortActive="number" matSortDirection="asc">
+          <mat-table class="piece-link-table" [dataSource]="pieceLinkDataSource" matSort matSortActive="number" matSortDirection="asc">
             <!-- Number Column Definition -->
             <ng-container matColumnDef="number">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="number"> Nr. </div>
-              <div mat-cell *matCellDef="let link" class="number-cell">
+              <mat-header-cell *matHeaderCellDef mat-sort-header="number"> Nr. </mat-header-cell>
+              <mat-cell *matCellDef="let link" class="number-cell">
                 <mat-form-field appearance="outline">
                   <input
                     matInput
@@ -152,38 +152,38 @@
                     [ngModelOptions]="{standalone: true}"
                   />
                 </mat-form-field>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Title Column Definition -->
             <ng-container matColumnDef="title">
-              <div mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </div>
-              <div mat-cell *matCellDef="let link">
+              <mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </mat-header-cell>
+              <mat-cell *matCellDef="let link">
                 <div class="piece-title">{{ link.piece.title }}</div>
                 <div
                   class="piece-composer"
                   *ngIf="link.piece.composer?.name || link.piece.origin"
                 >{{ link.piece.composer?.name || link.piece.origin }}</div>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Actions Column Definition -->
             <ng-container matColumnDef="actions">
-              <div mat-header-cell *matHeaderCellDef></div>
-              <div mat-cell *matCellDef="let link" class="actions-cell">
+              <mat-header-cell *matHeaderCellDef></mat-header-cell>
+              <mat-cell *matCellDef="let link" class="actions-cell">
                 <button type="button" mat-icon-button (click)="openEditPieceDialog(link.piece.id)" matTooltip="Stück bearbeiten">
                   <mat-icon>edit</mat-icon>
                 </button>
                 <button type="button" mat-icon-button color="warn" (click)="removePieceFromCollection(link.piece)" matTooltip="Stück aus Sammlung entfernen">
                   <mat-icon>delete</mat-icon>
                 </button>
-              </div>
+              </mat-cell>
             </ng-container>
 
             <!-- Update the row definitions to use the new column array name -->
-            <div mat-header-row *matHeaderRowDef="pieceLinkColumns"></div>
-            <div mat-row *matRowDef="let row; columns: pieceLinkColumns;"></div>
-          </div>
+            <mat-header-row *matHeaderRowDef="pieceLinkColumns"></mat-header-row>
+            <mat-row *matRowDef="let row; columns: pieceLinkColumns;"></mat-row>
+          </mat-table>
 
           <mat-paginator
             *ngIf="selectedPieceLinks.length > 0"

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -20,57 +20,57 @@
 <ng-container *ngIf="!(isHandset$ | async); else mobileView">
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">
-  <div mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
+  <mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
 
     <!-- Cover Column -->
     <ng-container matColumnDef="cover">
-      <div mat-header-cell *matHeaderCellDef></div>
-      <div mat-cell *matCellDef="let collection" class="cover-cell">
+      <mat-header-cell *matHeaderCellDef></mat-header-cell>
+      <mat-cell *matCellDef="let collection" class="cover-cell">
         <img *ngIf="collection.coverImageData" [src]="collection.coverImageData" alt="Cover" loading="lazy" />
-      </div>
+      </mat-cell>
     </ng-container>
 
     <!-- Status Column -->
     <ng-container matColumnDef="status">
-      <div mat-header-cell *matHeaderCellDef mat-sort-header="status"> Status </div>
-      <div mat-cell *matCellDef="let collection" class="status-cell">
+      <mat-header-cell *matHeaderCellDef mat-sort-header="status"> Status </mat-header-cell>
+      <mat-cell *matCellDef="let collection" class="status-cell">
         <mat-icon
           class="status-icon"
           [color]="collection.isAdded ? 'primary' : 'disabled'"
           [matTooltip]="collection.isAdded ? 'Sammlung ist im Chorrepertoire.' : 'Nicht im Repertoire.'">
           {{ collection.isAdded ? 'check_circle' : 'do_not_disturb_on' }}
         </mat-icon>
-      </div>
+      </mat-cell>
     </ng-container>
 
     <!-- Title Column -->
     <ng-container matColumnDef="title">
-      <div mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </div>
-      <div mat-cell *matCellDef="let collection" class="title-cell">
+      <mat-header-cell *matHeaderCellDef mat-sort-header="title"> Titel </mat-header-cell>
+      <mat-cell *matCellDef="let collection" class="title-cell">
         <strong>{{ collection.title }}</strong>
         <div class="subtitle-hint" *ngIf="collection.subtitle">{{ collection.subtitle }}</div>
         <div class="prefix-hint" *ngIf="!collection.singleEdition && collection.prefix">{{ collection.prefix }}</div>
         <div class="prefix-hint" *ngIf="collection.singleEdition">{{ getCollectionComposer(collection) }}</div>
-      </div>
+      </mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="titles">
-      <div mat-header-cell *matHeaderCellDef mat-sort-header="titles"> Stücke </div>
-      <div mat-cell *matCellDef="let collection" class="titles-cell">
+      <mat-header-cell *matHeaderCellDef mat-sort-header="titles"> Stücke </mat-header-cell>
+      <mat-cell *matCellDef="let collection" class="titles-cell">
         {{ collection.pieceCount || 0 }}
-      </div>
+      </mat-cell>
     </ng-container>
 
     <!-- Publisher Column -->
     <ng-container matColumnDef="publisher">
-      <div mat-header-cell *matHeaderCellDef mat-sort-header="publisher"> Verlag </div>
-      <div mat-cell *matCellDef="let collection" class="publisher-cell"> {{ collection.publisher || '-' }} </div>
+      <mat-header-cell *matHeaderCellDef mat-sort-header="publisher"> Verlag </mat-header-cell>
+      <mat-cell *matCellDef="let collection" class="publisher-cell"> {{ collection.publisher || '-' }} </mat-cell>
     </ng-container>
 
     <!-- Actions Column -->
     <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef></div>
-        <div mat-cell *matCellDef="let collection" class="actions-cell">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let collection" class="actions-cell">
             <button
               mat-icon-button
               color="primary"
@@ -87,17 +87,17 @@
             <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button [routerLink]="['/collections/edit', collection.id]" matTooltip="Sammlung bearbeiten" (click)="$event.stopPropagation()">
                 <mat-icon>edit</mat-icon>
             </button>
-        </div>
+        </mat-cell>
     </ng-container>
 
-    <div mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></div>
-    <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" [class.selected]="selectedCollection?.id === row.id"></div>
-    <div class="mat-row" *matNoDataRow>
-      <div class="mat-cell" [attr.colspan]="displayedColumns.length">
+    <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" [class.selected]="selectedCollection?.id === row.id"></mat-row>
+    <mat-row *matNoDataRow>
+      <mat-cell [attr.colspan]="displayedColumns.length">
         Es wurden noch keine Sammlungen erstellt.
-      </div>
-    </div>
-  </div>
+      </mat-cell>
+    </mat-row>
+  </mat-table>
   </div>
   <mat-paginator [pageSizeOptions]="pageSizeOptions"
                  [pageSize]="pageSize"

--- a/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/import-dialog/import-dialog.component.html
@@ -22,26 +22,26 @@
     <mat-divider *ngIf="previewData.length > 0"></mat-divider>
     <div *ngIf="previewData.length > 0" class="preview-area">
     <p>Bitte prüfe, ob die Daten korrekt eingelesen werden.</p>
-    <div mat-table [dataSource]="previewData">
+    <mat-table [dataSource]="previewData">
       <ng-container matColumnDef="nummer">
-        <div mat-header-cell *matHeaderCellDef> Nummer </div>
-        <div mat-cell *matCellDef="let row"> {{ row.nummer || row.number }} </div>
+        <mat-header-cell *matHeaderCellDef> Nummer </mat-header-cell>
+        <mat-cell *matCellDef="let row"> {{ row.nummer || row.number }} </mat-cell>
       </ng-container>
       <ng-container matColumnDef="titel">
-        <div mat-header-cell *matHeaderCellDef> Titel </div>
-        <div mat-cell *matCellDef="let row"> {{ row.titel || row.title }} </div>
+        <mat-header-cell *matHeaderCellDef> Titel </mat-header-cell>
+        <mat-cell *matCellDef="let row"> {{ row.titel || row.title }} </mat-cell>
       </ng-container>
       <ng-container matColumnDef="komponist">
-        <div mat-header-cell *matHeaderCellDef> Komponist </div>
-        <div mat-cell *matCellDef="let row"> {{ row.komponist || row.composer }} </div>
+        <mat-header-cell *matHeaderCellDef> Komponist </mat-header-cell>
+        <mat-cell *matCellDef="let row"> {{ row.komponist || row.composer }} </mat-cell>
       </ng-container>
       <ng-container matColumnDef="kategorie">
-        <div mat-header-cell *matHeaderCellDef> Kategorie </div>
-        <div mat-cell *matCellDef="let row"> {{ row.kategorie || row.rubrik || row.category }} </div>
+        <mat-header-cell *matHeaderCellDef> Kategorie </mat-header-cell>
+        <mat-cell *matCellDef="let row"> {{ row.kategorie || row.rubrik || row.category }} </mat-cell>
       </ng-container>
-      <div mat-header-row *matHeaderRowDef="previewColumns"></div>
-      <div mat-row *matRowDef="let row; columns: previewColumns;"></div>
-    </div>
+      <mat-header-row *matHeaderRowDef="previewColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: previewColumns;"></mat-row>
+    </mat-table>
   </div>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -14,36 +14,36 @@
 <ng-container *ngIf="!(isHandset$ | async); else mobileView">
 <div class="table-wrapper mat-elevation-z8">
   <div class="table-scroll-container">
-    <div mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
+    <mat-table [dataSource]="dataSource" matSort matSortActive="title" matSortDirection="asc">
       <ng-container matColumnDef="title">
-        <div mat-header-cell *matHeaderCellDef mat-sort-header="title">Titel</div>
-        <div mat-cell *matCellDef="let piece" class="title-cell">
+        <mat-header-cell *matHeaderCellDef mat-sort-header="title">Titel</mat-header-cell>
+        <mat-cell *matCellDef="let piece" class="title-cell">
           <strong>{{ piece.title }}</strong>
           <div class="subtitle-hint" *ngIf="piece.subtitle">{{ piece.subtitle }}</div>
-        </div>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="composer">
-        <div mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist/Ursprung</div>
-        <div mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin || '-' }}</div>
+        <mat-header-cell *matHeaderCellDef mat-sort-header="composer">Komponist/Ursprung</mat-header-cell>
+        <mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin || '-' }}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="author">
-        <div mat-header-cell *matHeaderCellDef mat-sort-header="author">Dichter</div>
-        <div mat-cell *matCellDef="let piece">{{ piece.author?.name || '-' }}</div>
+        <mat-header-cell *matHeaderCellDef mat-sort-header="author">Dichter</mat-header-cell>
+        <mat-cell *matCellDef="let piece">{{ piece.author?.name || '-' }}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="collections">
-        <div mat-header-cell *matHeaderCellDef mat-sort-header="collectionCount">Anzahl in Sammlungen</div>
-        <div mat-cell *matCellDef="let piece" class="count-cell">{{ piece.collectionCount || 0 }}</div>
+        <mat-header-cell *matHeaderCellDef mat-sort-header="collectionCount">Anzahl in Sammlungen</mat-header-cell>
+        <mat-cell *matCellDef="let piece" class="count-cell">{{ piece.collectionCount || 0 }}</mat-cell>
       </ng-container>
 
-      <div mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></div>
-      <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openPiece(row)"></div>
-      <div class="mat-row" *matNoDataRow>
-        <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</div>
-      </div>
-    </div>
+      <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openPiece(row)"></mat-row>
+      <mat-row *matNoDataRow>
+        <mat-cell [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</mat-cell>
+      </mat-row>
+    </mat-table>
   </div>
   <mat-paginator [length]="totalPieces" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>
 </div>

--- a/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-import-dialog/event-import-dialog.component.html
@@ -26,22 +26,22 @@
     <mat-divider *ngIf="previewData.length > 0"></mat-divider>
     <div *ngIf="previewData.length > 0" class="preview-area">
       <p>Bitte prüfe, ob die Daten korrekt eingelesen werden.</p>
-      <div mat-table [dataSource]="previewData">
+      <mat-table [dataSource]="previewData">
         <ng-container matColumnDef="reference">
-          <div mat-header-cell *matHeaderCellDef>Referenz</div>
-          <div mat-cell *matCellDef="let row">{{ row.referenz || row.reference }}</div>
+          <mat-header-cell *matHeaderCellDef>Referenz</mat-header-cell>
+          <mat-cell *matCellDef="let row">{{ row.referenz || row.reference }}</mat-cell>
         </ng-container>
         <ng-container matColumnDef="title">
-          <div mat-header-cell *matHeaderCellDef>Titel</div>
-          <div mat-cell *matCellDef="let row">{{ row.titel || row.title }}</div>
+          <mat-header-cell *matHeaderCellDef>Titel</mat-header-cell>
+          <mat-cell *matCellDef="let row">{{ row.titel || row.title }}</mat-cell>
         </ng-container>
         <ng-container matColumnDef="date">
-          <div mat-header-cell *matHeaderCellDef>Datum</div>
-          <div mat-cell *matCellDef="let row">{{ row.datum || row.date }}</div>
+          <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
+          <mat-cell *matCellDef="let row">{{ row.datum || row.date }}</mat-cell>
         </ng-container>
-        <div mat-header-row *matHeaderRowDef="previewColumns"></div>
-        <div mat-row *matRowDef="let row; columns: previewColumns;"></div>
-      </div>
+        <mat-header-row *matHeaderRowDef="previewColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: previewColumns;"></mat-row>
+      </mat-table>
     </div>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -26,53 +26,53 @@
 
 
 <div class="table-wrapper mat-elevation-z4">
-  <div mat-table [dataSource]="dataSource" class="event-table">
+  <mat-table [dataSource]="dataSource" class="event-table">
     <ng-container matColumnDef="select">
-      <div mat-header-cell *matHeaderCellDef>
+      <mat-header-cell *matHeaderCellDef>
         <mat-checkbox (change)="toggleAll()" [checked]="isAllSelected()" [indeterminate]="selection.hasValue() && !isAllSelected()"></mat-checkbox>
-      </div>
-      <div mat-cell *matCellDef="let ev">
+      </mat-header-cell>
+      <mat-cell *matCellDef="let ev">
         <mat-checkbox (click)="$event.stopPropagation()" (change)="toggleEvent(ev)" [checked]="selection.isSelected(ev)"></mat-checkbox>
-      </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="date">
-      <div mat-header-cell *matHeaderCellDef>Datum</div>
-      <div mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</div>
+      <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
+      <mat-cell *matCellDef="let ev">{{ ev.date | date:'shortDate' }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="type">
-      <div mat-header-cell *matHeaderCellDef>Typ</div>
-      <div mat-cell *matCellDef="let ev">{{ ev.type | eventTypeLabel }}</div>
+      <mat-header-cell *matHeaderCellDef>Typ</mat-header-cell>
+      <mat-cell *matCellDef="let ev">{{ ev.type | eventTypeLabel }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="updatedAt">
-      <div mat-header-cell *matHeaderCellDef>Geändert</div>
-      <div mat-cell *matCellDef="let ev">{{ ev.updatedAt | date:'short' }}</div>
+      <mat-header-cell *matHeaderCellDef>Geändert</mat-header-cell>
+      <mat-cell *matCellDef="let ev">{{ ev.updatedAt | date:'short' }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="director">
-      <div mat-header-cell *matHeaderCellDef>Leiter</div>
-      <div mat-cell *matCellDef="let ev">{{ ev.director?.name }}</div>
+      <mat-header-cell *matHeaderCellDef>Leiter</mat-header-cell>
+      <mat-cell *matCellDef="let ev">{{ ev.director?.name }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="actions">
-      <div mat-header-cell *matHeaderCellDef></div>
-      <div mat-cell *matCellDef="let ev" class="actions-cell">
+      <mat-header-cell *matHeaderCellDef></mat-header-cell>
+      <mat-cell *matCellDef="let ev" class="actions-cell">
         <button *ngIf="!isSingerOnly" mat-icon-button (click)="editEvent(ev); $event.stopPropagation()">
           <mat-icon>edit</mat-icon>
         </button>
         <button *ngIf="isChoirAdmin || isAdmin" mat-icon-button color="warn" (click)="deleteEvent(ev); $event.stopPropagation()">
           <mat-icon>delete</mat-icon>
         </button>
-      </div>
+      </mat-cell>
     </ng-container>
 
-    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-    <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectEvent(row)"></div>
-    <div class="mat-row" *matNoDataRow>
-      <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Events gefunden.</div>
-    </div>
-  </div>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectEvent(row)"></mat-row>
+    <mat-row *matNoDataRow>
+      <mat-cell [attr.colspan]="displayedColumns.length">Keine Events gefunden.</mat-cell>
+    </mat-row>
+  </mat-table>
 
   <mat-paginator [pageSizeOptions]="pageSizeOptions"
                  [pageSize]="pageSize"

--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -67,29 +67,29 @@
       </mat-card-header>
       <mat-card-content>
         <div class="table-wrapper mat-elevation-z4">
-          <div mat-table [dataSource]="rehearsalDataSource">
+          <mat-table [dataSource]="rehearsalDataSource">
             <ng-container matColumnDef="title">
-              <div mat-header-cell *matHeaderCellDef> Titel </div>
-              <div mat-cell *matCellDef="let piece">
+              <mat-header-cell *matHeaderCellDef> Titel </mat-header-cell>
+              <mat-cell *matCellDef="let piece">
                 <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
-              </div>
+              </mat-cell>
             </ng-container>
             <ng-container matColumnDef="composer">
-              <div mat-header-cell *matHeaderCellDef> Komponist/Ursprung </div>
-              <div mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</div>
+              <mat-header-cell *matHeaderCellDef> Komponist/Ursprung </mat-header-cell>
+              <mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</mat-cell>
             </ng-container>
             <ng-container matColumnDef="reference">
-              <div mat-header-cell *matHeaderCellDef> Sammlung </div>
-              <div mat-cell *matCellDef="let piece">{{ formatReference(piece) }}</div>
+              <mat-header-cell *matHeaderCellDef> Sammlung </mat-header-cell>
+              <mat-cell *matCellDef="let piece">{{ formatReference(piece) }}</mat-cell>
             </ng-container>
-            <div mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></div>
-            <div mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></div>
-            <div class="mat-row" *matNoDataRow>
-              <div class="mat-cell" [attr.colspan]="displayedRehearsalColumns.length">
+            <mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></mat-header-row>
+            <mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></mat-row>
+            <mat-row *matNoDataRow>
+              <mat-cell [attr.colspan]="displayedRehearsalColumns.length">
                 Keine Stücke in Probe.
-              </div>
-            </div>
-          </div>
+              </mat-cell>
+            </mat-row>
+          </mat-table>
         </div>
       </mat-card-content>
     </mat-card>

--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -31,31 +31,31 @@
       </mat-menu>
     </div>
 
-    <div mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8" multiTemplateDataRows>
+    <mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8" multiTemplateDataRows>
       <ng-container matColumnDef="cover">
-        <div mat-header-cell *matHeaderCellDef></div>
-        <div mat-cell *matCellDef="let element" class="cover-cell">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let element" class="cover-cell">
           <img *ngIf="element.collection?.coverImageData" [src]="element.collection.coverImageData" alt="Cover" loading="lazy" />
-        </div>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="title">
-        <div mat-header-cell *matHeaderCellDef mat-sort-header>Titel</div>
-        <div mat-cell *matCellDef="let element">
+        <mat-header-cell *matHeaderCellDef mat-sort-header>Titel</mat-header-cell>
+        <mat-cell *matCellDef="let element">
           <div class="composer-hint" *ngIf="getCollectionComposer(element.collection) as composer">{{ composer }}</div>
           <div class="title">{{ element.collection?.title }}</div>
           <div class="subtitle-hint" *ngIf="getCollectionHint(element.collection) as hint">{{ hint }}</div>
-        </div>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="copies">
-        <div mat-header-cell *matHeaderCellDef mat-sort-header>Exemplare</div>
-        <div mat-cell *matCellDef="let element">{{element.copies}}</div>
+        <mat-header-cell *matHeaderCellDef mat-sort-header>Exemplare</mat-header-cell>
+        <mat-cell *matCellDef="let element">{{element.copies}}</mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef></div>
-        <div mat-cell *matCellDef="let element">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let element">
           <button mat-icon-button color="primary" *ngIf="element.status === 'available'" (click)="addToCart(element, $event)">
             <mat-icon>add_shopping_cart</mat-icon>
           </button>
@@ -67,11 +67,11 @@
             <button mat-menu-item (click)="changeStatus(element, $event)">Entleihstatus ändern</button>
             <button mat-menu-item class="delete-button" (click)="deleteItem(element, $event)">Löschen</button>
           </mat-menu>
-        </div>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="expandedDetail">
-        <div mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+        <mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
           <div *ngIf="expandedItem === element">
             <mat-nav-list>
               <a mat-list-item *ngFor="let piece of paginatedPieces" [routerLink]="['/pieces', piece.id]" (click)="$event.stopPropagation()">
@@ -84,13 +84,13 @@
             </mat-nav-list>
             <mat-paginator [length]="expandedPieces.length" [pageSize]="piecePageSize" (page)="onPiecePage($event)"></mat-paginator>
           </div>
-        </div>
+        </mat-cell>
       </ng-container>
 
-      <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-      <div mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></div>
-      <div mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></div>
-    </div>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="toggleCollection(row)" class="clickable-row"></mat-row>
+      <mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></mat-row>
+    </mat-table>
     <mat-paginator #libraryPaginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" showFirstLastButtons></mat-paginator>
   </mat-tab>
 

--- a/choir-app-frontend/src/app/features/library/loan-cart.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-cart.component.html
@@ -1,26 +1,26 @@
 <div *ngIf="items$ | async as items">
-  <div mat-table [dataSource]="items" class="mat-elevation-z8" *ngIf="items.length > 0">
+  <mat-table [dataSource]="items" class="mat-elevation-z8" *ngIf="items.length > 0">
     <ng-container matColumnDef="title">
-      <div mat-header-cell *matHeaderCellDef>Sammlung</div>
-      <div mat-cell *matCellDef="let row">{{row.item.collection?.title}}</div>
+      <mat-header-cell *matHeaderCellDef>Sammlung</mat-header-cell>
+      <mat-cell *matCellDef="let row">{{row.item.collection?.title}}</mat-cell>
     </ng-container>
     <ng-container matColumnDef="quantity">
-      <div mat-header-cell *matHeaderCellDef>Anzahl</div>
-      <div mat-cell *matCellDef="let row">
+      <mat-header-cell *matHeaderCellDef>Anzahl</mat-header-cell>
+      <mat-cell *matCellDef="let row">
         <input matInput type="number" [(ngModel)]="row.quantity" min="1" />
-      </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="remove">
-      <div mat-header-cell *matHeaderCellDef></div>
-      <div mat-cell *matCellDef="let row">
+      <mat-header-cell *matHeaderCellDef></mat-header-cell>
+      <mat-cell *matCellDef="let row">
         <button mat-icon-button color="warn" (click)="remove(row.item.id)">
           <mat-icon>delete</mat-icon>
         </button>
-      </div>
+      </mat-cell>
     </ng-container>
-    <div mat-header-row *matHeaderRowDef="['title','quantity','remove']"></div>
-    <div mat-row *matRowDef="let row; columns: ['title','quantity','remove']"></div>
-  </div>
+    <mat-header-row *matHeaderRowDef="['title','quantity','remove']"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: ['title','quantity','remove']"></mat-row>
+  </mat-table>
   <p *ngIf="items.length === 0">Keine Sammlungen im Entleihkorb.</p>
 
   <div class="form-section" *ngIf="items.length > 0">

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -1,21 +1,21 @@
-<div mat-table [dataSource]="availabilities" class="mat-elevation-z2">
+<mat-table [dataSource]="availabilities" class="mat-elevation-z2">
   <ng-container matColumnDef="date">
-    <div mat-header-cell *matHeaderCellDef>Datum</div>
-    <div mat-cell *matCellDef="let a">
+    <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
+    <mat-cell *matCellDef="let a">
       {{ a.date | date:'EEE dd.MM.yyyy' }}
       <span class="holiday" *ngIf="a.holidayHint"> ({{ a.holidayHint }})</span>
-    </div>
+    </mat-cell>
   </ng-container>
   <ng-container matColumnDef="status">
-    <div mat-header-cell *matHeaderCellDef>Status</div>
-    <div mat-cell *matCellDef="let a" [ngClass]="cellClass(a.status)">
+    <mat-header-cell *matHeaderCellDef>Status</mat-header-cell>
+    <mat-cell *matCellDef="let a" [ngClass]="cellClass(a.status)">
       <mat-select [value]="a.status" (selectionChange)="setStatus(a.date, $any($event.value))">
         <mat-option value="AVAILABLE">verfügbar</mat-option>
         <mat-option value="MAYBE">verfügbar nach Absprache</mat-option>
         <mat-option value="UNAVAILABLE">nicht verfügbar</mat-option>
       </mat-select>
-    </div>
+    </mat-cell>
   </ng-container>
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns;"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+</mat-table>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -33,17 +33,17 @@
     <button *ngIf="plan.finalized" mat-raised-button color="accent" (click)="openEmailDialog()" matTooltip="Als E-Mail versenden"><mat-icon>mail</mat-icon></button>
     <button *ngIf="isChoirAdmin && !plan.finalized" mat-raised-button color="accent" (click)="openAvailabilityDialog()" matTooltip="Verfügbarkeit anfragen"><mat-icon>Drafts</mat-icon></button>
   </div>
-  <div mat-table [dataSource]="entries" class="mat-elevation-z2">
+  <mat-table [dataSource]="entries" class="mat-elevation-z2">
     <ng-container matColumnDef="date">
-      <div mat-header-cell *matHeaderCellDef>Datum</div>
-      <div mat-cell *matCellDef="let ev" [matTooltip]="timestamp(ev.date)">
+      <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
+      <mat-cell *matCellDef="let ev" [matTooltip]="timestamp(ev.date)">
         {{ ev.date | date:'shortDate' }}
         <span class="holiday" *ngIf="ev.holidayHint"> ({{ ev.holidayHint }})</span>
-      </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="director">
-      <div mat-header-cell *matHeaderCellDef>Chorleiter</div>
-      <div mat-cell *matCellDef="let ev">
+      <mat-header-cell *matHeaderCellDef>Chorleiter</mat-header-cell>
+      <mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else directorText">
           <mat-select [value]="ev.director?.id || null" (selectionChange)="updateDirector(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
@@ -55,11 +55,11 @@
           {{ ev.director?.name }}
           <mat-icon *ngIf="ev.director?.id && isMaybe(ev.director.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-template>
-      </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="organist">
-      <div mat-header-cell *matHeaderCellDef>Organist</div>
-      <div mat-cell *matCellDef="let ev">
+      <mat-header-cell *matHeaderCellDef>Organist</mat-header-cell>
+      <mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else organistText">
           <mat-select [value]="ev.organist?.id || null" (selectionChange)="updateOrganist(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
@@ -71,48 +71,48 @@
           {{ ev.organist?.name }}
           <mat-icon *ngIf="ev.organist?.id && isMaybe(ev.organist.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-template>
-      </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="notes">
-      <div mat-header-cell *matHeaderCellDef>Notizen</div>
-      <div mat-cell *matCellDef="let ev">
+      <mat-header-cell *matHeaderCellDef>Notizen</mat-header-cell>
+      <mat-cell *matCellDef="let ev">
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else notesText">
           <input matInput [(ngModel)]="ev.notes" (blur)="updateNotes(ev, ev.notes)" />
         </ng-container>
         <ng-template #notesText>{{ ev.notes }}</ng-template>
-      </div>
+      </mat-cell>
     </ng-container>
     <ng-container matColumnDef="actions">
-      <div mat-header-cell *matHeaderCellDef></div>
-      <div mat-cell *matCellDef="let ev">
+      <mat-header-cell *matHeaderCellDef></mat-header-cell>
+      <mat-cell *matCellDef="let ev">
         <button mat-icon-button color="warn" *ngIf="isChoirAdmin && !plan.finalized" (click)="deleteEntry(ev)">
           <mat-icon>delete</mat-icon>
         </button>
-      </div>
+      </mat-cell>
     </ng-container>
-    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-    <div mat-row *matRowDef="let row; columns: displayedColumns;"
-        [class.assigned]="plan.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></div>
-  </div>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns;"
+        [class.assigned]="plan.finalized && (row.director?.id === currentUserId || row.organist?.id === currentUserId)"></mat-row>
+  </mat-table>
 
   <div class="spacer"></div>
   <div class="counter-plan" *ngIf="counterPlanDates.length > 0">
     <h3>Gegenplan</h3>
     <div class="counter-plan-table">
-      <divead>
-        <div>
-          <div>Name</div>
-          <div *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">
-            {{ d | date:'dd.MM.' }}
-          </div>
-        </div>
-      </thead>
-      <tbody>
-        <div *ngFor="let row of counterPlanRows">
-          <div>{{ row.user.name }}</div>
-          <div *ngFor="let key of counterPlanDateKeys">{{ row.assignments[key] }}</div>
-        </div>
-      </tbody>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">{{ d | date:'dd.MM.' }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let row of counterPlanRows">
+            <td>{{ row.user.name }}</td>
+            <td *ngFor="let key of counterPlanDateKeys">{{ row.assignments[key] }}</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 

--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -1,35 +1,35 @@
 <div class="table-container mat-elevation-z4" *ngIf="members.length > 0">
-  <div mat-table [dataSource]="members">
+  <mat-table [dataSource]="members">
     <ng-container matColumnDef="name">
-      <div mat-header-cell *matHeaderCellDef>Name</div>
-      <div mat-cell *matCellDef="let m">{{ m.name }}</div>
+      <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ m.name }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="voice">
-      <div mat-header-cell *matHeaderCellDef>Stimme</div>
-      <div mat-cell *matCellDef="let m">{{ voiceOf(m) }}</div>
+      <mat-header-cell *matHeaderCellDef>Stimme</mat-header-cell>
+      <mat-cell *matCellDef="let m">{{ voiceOf(m) }}</mat-cell>
     </ng-container>
 
     <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
-      <div mat-header-cell *matHeaderCellDef>{{ col.label }}</div>
-      <div mat-cell *matCellDef="let m">
+      <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
+      <mat-cell *matCellDef="let m">
         <mat-icon *ngIf="iconFor(status(m.id, col.key)) as icon">{{ icon }}</mat-icon>
-      </div>
+      </mat-cell>
     </ng-container>
 
     <ng-container *ngFor="let col of monthColumns" [matColumnDef]="col.key">
-      <div mat-header-cell *matHeaderCellDef>{{ col.label }}</div>
-      <div mat-cell *matCellDef="let m">
+      <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
+      <mat-cell *matCellDef="let m">
         <ng-container *ngFor="let ev of col.events">
           <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon">{{ icon }}</mat-icon>
         </ng-container>
-      </div>
+      </mat-cell>
     </ng-container>
 
-    <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-    <div mat-row *matRowDef="let row; columns: displayedColumns"></div>
-    <div class="mat-row" *matNoDataRow>
-      <div class="mat-cell" [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</div>
-    </div>
-  </div>
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+    <mat-row *matNoDataRow>
+      <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
+    </mat-row>
+  </mat-table>
 </div>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -13,16 +13,15 @@
 </div>
 
 <div *ngIf="items.length" class="table-container">
-  <div
-    mat-table
+  <mat-table
     [dataSource]="items"
     class="program-table"
     cdkDropList
     (cdkDropListDropped)="drop($event)"
   >
   <ng-container matColumnDef="move">
-    <div mat-header-cell *matHeaderCellDef></div>
-    <div mat-cell *matCellDef="let item; let i = index">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let item; let i = index">
       <button
         mat-icon-button
         (click)="moveUp(i)"
@@ -42,68 +41,68 @@
       <span class="drag-handle" cdkDragHandle aria-label="Greifen">
         <mat-icon>drag_indicator</mat-icon>
       </span>
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="title">
-    <div mat-header-cell *matHeaderCellDef> Titel </div>
-    <div mat-cell *matCellDef="let item">
+    <mat-header-cell *matHeaderCellDef> Titel </mat-header-cell>
+    <mat-cell *matCellDef="let item">
       <ng-container [ngSwitch]="item.type">
         <span *ngSwitchCase="'piece'">{{ item.pieceTitleSnapshot }}</span>
         <span *ngSwitchCase="'speech'">{{ item.speechTitle }}</span>
         <span *ngSwitchCase="'break'">{{ item.breakTitle || 'Pause' }}</span>
         <span *ngSwitchCase="'slot'">{{ item.slotLabel }}</span>
       </ng-container>
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="composer">
-    <div mat-header-cell *matHeaderCellDef> Komponist / Sprecher </div>
-    <div mat-cell *matCellDef="let item">
+    <mat-header-cell *matHeaderCellDef> Komponist / Sprecher </mat-header-cell>
+    <mat-cell *matCellDef="let item">
       <ng-container [ngSwitch]="item.type">
         <span *ngSwitchCase="'piece'">{{ item.pieceComposerSnapshot }}</span>
         <span *ngSwitchCase="'speech'">{{ item.speechSpeaker }}</span>
         <span *ngSwitchCase="'slot'"></span>
       </ng-container>
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="duration">
-    <div mat-header-cell *matHeaderCellDef> Dauer (mm:ss) </div>
-    <div mat-cell *matCellDef="let item">
+    <mat-header-cell *matHeaderCellDef> Dauer (mm:ss) </mat-header-cell>
+    <mat-cell *matCellDef="let item">
       <input
         matInput
         [(ngModel)]="item.durationStr"
         (ngModelChange)="onDurationChange(item)"
         placeholder="mm:ss"
       />
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="note">
-    <div mat-header-cell *matHeaderCellDef> Notiz </div>
-    <div mat-cell *matCellDef="let item">
+    <mat-header-cell *matHeaderCellDef> Notiz </mat-header-cell>
+    <mat-cell *matCellDef="let item">
       <input matInput [(ngModel)]="item.note" (blur)="onNoteChange(item)" />
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="time">
-    <div mat-header-cell *matHeaderCellDef> Uhrzeit </div>
-    <div mat-cell *matCellDef="let item; let i = index">
+    <mat-header-cell *matHeaderCellDef> Uhrzeit </mat-header-cell>
+    <mat-cell *matCellDef="let item; let i = index">
       {{ getPlannedTime(i) }}
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="sum">
-    <div mat-header-cell *matHeaderCellDef> Summe </div>
-    <div mat-cell *matCellDef="let item; let i = index">
+    <mat-header-cell *matHeaderCellDef> Summe </mat-header-cell>
+    <mat-cell *matCellDef="let item; let i = index">
       {{ getCumulativeDuration(i) }}
-    </div>
+    </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-    <div mat-header-cell *matHeaderCellDef> Aktionen </div>
-    <div mat-cell *matCellDef="let item">
+    <mat-header-cell *matHeaderCellDef> Aktionen </mat-header-cell>
+    <mat-cell *matCellDef="let item">
 
       <ng-container [ngSwitch]="item.type">
         <a *ngSwitchCase="'piece'" [routerLink]="['/pieces', item.pieceId]" target="_blank">Details</a>
@@ -118,12 +117,12 @@
       <button mat-icon-button color="warn" (click)="deleteItem(item)" aria-label="Löschen">
         <mat-icon>delete</mat-icon>
       </button>
-    </div>
+    </mat-cell>
   </ng-container>
 
-  <div mat-header-row *matHeaderRowDef="displayedColumns"></div>
-  <div mat-row *matRowDef="let row; columns: displayedColumns" cdkDrag></div>
-  </div>
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns" cdkDrag></mat-row>
+  </mat-table>
 </div>
 
 <div *ngIf="items.length" class="total-duration">

--- a/choir-app-frontend/src/app/features/programs/program-list.component.html
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.html
@@ -1,23 +1,23 @@
 <h2>Programme</h2>
 <button mat-raised-button color="primary" routerLink="/programs/create">Neues Programm</button>
 
-<div mat-table [dataSource]="programs" *ngIf="programs.length > 0">
+<mat-table [dataSource]="programs" *ngIf="programs.length > 0">
   <ng-container matColumnDef="title">
-    <div mat-header-cell *matHeaderCellDef>Titel</div>
-    <div mat-cell *matCellDef="let program">{{ program.title }}</div>
+    <mat-header-cell *matHeaderCellDef>Titel</mat-header-cell>
+    <mat-cell *matCellDef="let program">{{ program.title }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="actions">
-        <div mat-header-cell *matHeaderCellDef>Aktionen</div>
-    <div mat-cell *matCellDef="let program">
+    <mat-header-cell *matHeaderCellDef>Aktionen</mat-header-cell>
+    <mat-cell *matCellDef="let program">
       <button mat-button [routerLink]="['/programs', program.id]">Bearbeiten</button>
       <button mat-button color="warn" (click)="delete(program)">Löschen</button>
-    </div>
+    </mat-cell>
   </ng-container>
 
-  <div mat-header-row *matHeaderRowDef="['title', 'actions']"></div>
-  <div mat-row *matRowDef="let row; columns: ['title', 'actions']"></div>
-</div>
+  <mat-header-row *matHeaderRowDef="['title', 'actions']"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: ['title', 'actions']"></mat-row>
+</mat-table>
 
 <p *ngIf="programs.length === 0">Keine Programme vorhanden.</p>
 


### PR DESCRIPTION
## Summary
- update Angular templates to use `<mat-table>` and cell/row components
- fix Monthly Plan markup and counter plan HTML structure
- ensure all tables compile with Angular 20 Material

## Testing
- `npm run build`
- `npm test` *(fails: error while loading shared libraries libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b56bb3fc448320b15c9d21ea74f94d