### PR TITLE
Rename PDF title to Musikplan

### DIFF
--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -55,7 +55,7 @@ function monthlyPlanPdf(plan) {
   }
 
   // Title
-  lines.push(`BT /F1 18 Tf ${left} ${y} Td (${escape('Dienstplan ' + plan.month + '/' + plan.year)}) Tj ET`);
+  lines.push(`BT /F1 18 Tf ${left} ${y} Td (${escape('Musikplan ' + plan.month + '/' + plan.year)}) Tj ET`);
   y -= 20;
 
   // Choir name sub heading


### PR DESCRIPTION
## Summary
- rename monthly plan PDF heading to "Musikplan"

## Testing
- `npm test --prefix choir-app-backend` *(fails: aborted due to long runtime)*
- `node choir-app-backend/tests/monthlyPlan.controller.test.js`
- `npm run lint --prefix choir-app-backend` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb33bf148320a2ffad96eda635fd