### PR TITLE
Add Stand date to monthly plan PDF

### DIFF
--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -1,4 +1,4 @@
-const { isoDateString } = require('../utils/date.utils');
+const { isoDateString, germanDateString } = require('../utils/date.utils');
 
 function escape(text) {
   return text.replace(/[\\()]/g, c => '\\' + c);
@@ -114,6 +114,8 @@ function monthlyPlanPdf(plan) {
   lines.push(`${col3} ${topLine} m ${col3} ${bottomLine} l S`);
   lines.push(`${col4} ${topLine} m ${col4} ${bottomLine} l S`);
   lines.push(`${right} ${topLine} m ${right} ${bottomLine} l S`);
+  const standDate = germanDateString(plan.updatedAt ? new Date(plan.updatedAt) : new Date());
+  lines.push(`BT /F1 12 Tf ${left} ${y - 12} Td (${escape('Stand: ' + standDate)}) Tj ET`);
   const content = lines.join('\n');
   const objects = [];
   objects.push('<< /Type /Catalog /Pages 2 0 R >>'); //1

--- a/choir-app-backend/src/utils/date.utils.js
+++ b/choir-app-backend/src/utils/date.utils.js
@@ -5,6 +5,13 @@ function isoDateString(date) {
     return `${year}-${month}-${day}`;
 }
 
+function germanDateString(date) {
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    return `${day}.${month}.${year}`;
+}
+
 function datesForRule(year, month, rule) {
     const dates = [];
     const d = new Date(Date.UTC(year, month - 1, 1));
@@ -20,4 +27,4 @@ function datesForRule(year, month, rule) {
     return dates;
 }
 
-module.exports = { isoDateString, datesForRule };
+module.exports = { isoDateString, datesForRule, germanDateString };


### PR DESCRIPTION
## Summary
- add germanDateString utility for dd.mm.yyyy formatting
- include "Stand" date below monthly plan table in PDF output

## Testing
- `npm run lint --prefix choir-app-backend` *(fails: no-unused-vars etc.)*
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b5fa691fdc8320b8c01d3d740cda99