### PR TITLE
Fix statistics table injector error

### DIFF
--- a/choir-app-frontend/src/app/features/home/stats/statistics.component.html
+++ b/choir-app-frontend/src/app/features/home/stats/statistics.component.html
@@ -67,29 +67,29 @@
       </mat-card-header>
       <mat-card-content>
         <div class="table-wrapper mat-elevation-z4">
-          <mat-table [dataSource]="rehearsalDataSource">
+          <table mat-table [dataSource]="rehearsalDataSource">
             <ng-container matColumnDef="title">
-              <mat-header-cell *matHeaderCellDef> Titel </mat-header-cell>
-              <mat-cell *matCellDef="let piece">
+              <th mat-header-cell *matHeaderCellDef> Titel </th>
+              <td mat-cell *matCellDef="let piece">
                 <a [routerLink]="['/pieces', piece.id]" class="title-link">{{ piece.title }}</a>
-              </mat-cell>
+              </td>
             </ng-container>
             <ng-container matColumnDef="composer">
-              <mat-header-cell *matHeaderCellDef> Komponist/Ursprung </mat-header-cell>
-              <mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</mat-cell>
+              <th mat-header-cell *matHeaderCellDef> Komponist/Ursprung </th>
+              <td mat-cell *matCellDef="let piece">{{ piece.composer?.name || piece.origin }}</td>
             </ng-container>
             <ng-container matColumnDef="reference">
-              <mat-header-cell *matHeaderCellDef> Sammlung </mat-header-cell>
-              <mat-cell *matCellDef="let piece">{{ formatReference(piece) }}</mat-cell>
+              <th mat-header-cell *matHeaderCellDef> Sammlung </th>
+              <td mat-cell *matCellDef="let piece">{{ formatReference(piece) }}</td>
             </ng-container>
-            <mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></mat-header-row>
-            <mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></mat-row>
-            <mat-row *matNoDataRow>
-              <mat-cell [attr.colspan]="displayedRehearsalColumns.length">
+            <tr mat-header-row *matHeaderRowDef="displayedRehearsalColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedRehearsalColumns;"></tr>
+            <tr class="mat-row" *matNoDataRow>
+              <td class="mat-cell" [attr.colspan]="displayedRehearsalColumns.length">
                 Keine Stücke in Probe.
-              </mat-cell>
-            </mat-row>
-          </mat-table>
+              </td>
+            </tr>
+          </table>
         </div>
       </mat-card-content>
     </mat-card>


### PR DESCRIPTION
## Summary
- replace `<mat-table>` usage with native `<table mat-table>` and corresponding `<th>/<td>` elements in statistics component to ensure MatTable injection

## Testing
- `npm run build`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb62c32c8320a79fba3fec436b35