### PR TITLE
Format PDF dates with German weekday

### DIFF
--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -1,4 +1,4 @@
-const { isoDateString } = require('../utils/date.utils');
+const { shortWeekdayDateString } = require('../utils/date.utils');
 
 function escape(text) {
   return text.replace(/[\\()]/g, c => '\\' + c);
@@ -91,7 +91,7 @@ function monthlyPlanPdf(plan) {
 
   for (const e of plan.entries) {
     const cells = [
-      wrapText(isoDateString(new Date(e.date)), 12, colWidths[0]),
+      wrapText(shortWeekdayDateString(new Date(e.date)), 12, colWidths[0]),
       wrapText(e.director?.name || '', 12, colWidths[1]),
       wrapText(e.organist?.name || '', 12, colWidths[2]),
       wrapText(e.notes || '', 12, colWidths[3])

--- a/choir-app-backend/src/utils/date.utils.js
+++ b/choir-app-backend/src/utils/date.utils.js
@@ -5,6 +5,11 @@ function isoDateString(date) {
     return `${year}-${month}-${day}`;
 }
 
+function shortWeekdayDateString(date) {
+    const weekdays = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'];
+    return `${weekdays[date.getDay()]}, ${date.getDate()}.`;
+}
+
 function datesForRule(year, month, rule) {
     const dates = [];
     const d = new Date(Date.UTC(year, month - 1, 1));
@@ -20,4 +25,4 @@ function datesForRule(year, month, rule) {
     return dates;
 }
 
-module.exports = { isoDateString, datesForRule };
+module.exports = { isoDateString, shortWeekdayDateString, datesForRule };


### PR DESCRIPTION
## Summary
- show two-letter German weekday with day number in monthly-plan PDF
- utility helper for weekday-based date formatting

## Testing
- `npm run lint --prefix choir-app-backend` (fails: no-unused-vars in unrelated files)
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b5fe1b3638832091c8bcc7e6fae640