### PR TITLE
feat: enable editing program items

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -153,9 +153,9 @@ exports.addPieceItem = async (req, res) => {
     if (!piece) return res.status(404).send({ message: 'piece not found' });
 
     if (slotId) {
-      const slot = await db.program_item.findOne({ where: { id: slotId, programId: id, type: 'slot' } });
-      if (!slot) return res.status(404).send({ message: 'slot not found' });
-      const updated = await slot.update({
+      const existing = await db.program_item.findOne({ where: { id: slotId, programId: id } });
+      if (!existing) return res.status(404).send({ message: 'item not found' });
+      const updated = await existing.update({
         type: 'piece',
         durationSec: typeof durationSec === 'number' ? durationSec : null,
         note: note || null,
@@ -197,9 +197,9 @@ exports.addFreePieceItem = async (req, res) => {
     id = program.id;
 
     if (slotId) {
-      const slot = await db.program_item.findOne({ where: { id: slotId, programId: id, type: 'slot' } });
-      if (!slot) return res.status(404).send({ message: 'slot not found' });
-      const updated = await slot.update({
+      const existing = await db.program_item.findOne({ where: { id: slotId, programId: id } });
+      if (!existing) return res.status(404).send({ message: 'item not found' });
+      const updated = await existing.update({
         type: 'piece',
         durationSec: typeof durationSec === 'number' ? durationSec : null,
         note: note || null,
@@ -244,9 +244,9 @@ exports.addSpeechItem = async (req, res) => {
     id = program.id;
 
     if (slotId) {
-      const slot = await db.program_item.findOne({ where: { id: slotId, programId: id, type: 'slot' } });
-      if (!slot) return res.status(404).send({ message: 'slot not found' });
-      const updated = await slot.update({
+      const existing = await db.program_item.findOne({ where: { id: slotId, programId: id } });
+      if (!existing) return res.status(404).send({ message: 'item not found' });
+      const updated = await existing.update({
         type: 'speech',
         durationSec: typeof durationSec === 'number' ? durationSec : null,
         note: note || null,
@@ -291,9 +291,9 @@ exports.addBreakItem = async (req, res) => {
     id = program.id;
 
     if (slotId) {
-      const slot = await db.program_item.findOne({ where: { id: slotId, programId: id, type: 'slot' } });
-      if (!slot) return res.status(404).send({ message: 'slot not found' });
-      const updated = await slot.update({
+      const existing = await db.program_item.findOne({ where: { id: slotId, programId: id } });
+      if (!existing) return res.status(404).send({ message: 'item not found' });
+      const updated = await existing.update({
         type: 'break',
         durationSec: typeof durationSec === 'number' ? durationSec : null,
         note: note || null,

--- a/choir-app-frontend/src/app/features/program/program-break-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-break-dialog.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 
 @Component({
@@ -11,14 +11,28 @@ import { MaterialModule } from '@modules/material.module';
   templateUrl: './program-break-dialog.component.html',
   styleUrls: ['./program-break-dialog.component.scss'],
 })
-export class ProgramBreakDialogComponent {
+export class ProgramBreakDialogComponent implements OnInit {
   breakForm: FormGroup;
 
-  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<ProgramBreakDialogComponent>) {
+  constructor(
+    private fb: FormBuilder,
+    private dialogRef: MatDialogRef<ProgramBreakDialogComponent>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: { duration?: string | null; note?: string | null } | null
+  ) {
     this.breakForm = this.fb.group({
       duration: ['', Validators.required],
       note: [''],
     });
+  }
+
+  ngOnInit(): void {
+    if (this.data) {
+      this.breakForm.patchValue({
+        duration: this.data.duration ?? '',
+        note: this.data.note ?? '',
+      });
+    }
   }
 
   save() {

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -113,6 +113,14 @@
           <button mat-button (click)="fillSlotWithBreak(item)">Pause</button>
         </ng-container>
       </ng-container>
+      <button
+        *ngIf="item.type !== 'slot'"
+        mat-icon-button
+        (click)="editItem(item)"
+        aria-label="Bearbeiten"
+      >
+        <mat-icon>edit</mat-icon>
+      </button>
 
       <button mat-icon-button color="warn" (click)="deleteItem(item)" aria-label="Löschen">
         <mat-icon>delete</mat-icon>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -101,6 +101,100 @@ export class ProgramEditorComponent implements OnInit {
     });
   }
 
+  editItem(item: ProgramItem) {
+    if (item.type === 'piece') {
+      if (item.pieceId) {
+        this.editPiece(item);
+      } else {
+        this.editFreePiece(item);
+      }
+    } else if (item.type === 'speech') {
+      this.editSpeech(item);
+    } else if (item.type === 'break') {
+      this.editBreak(item);
+    }
+  }
+
+  private editPiece(item: ProgramItem) {
+    const dialogRef = this.dialog.open(ProgramPieceDialogComponent, {
+      width: '600px',
+      data: { title: item.pieceTitleSnapshot, composer: item.pieceComposerSnapshot },
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService
+          .addPieceItem(this.programId, { ...result, slotId: item.id })
+          .subscribe(updated => {
+            const enh = this.enhanceItem(updated);
+            this.items = this.items.map(i => (i.id === item.id ? enh : i));
+          });
+      }
+    });
+  }
+
+  private editFreePiece(item: ProgramItem) {
+    const dialogRef = this.dialog.open(ProgramFreePieceDialogComponent, {
+      width: '600px',
+      data: {
+        title: item.pieceTitleSnapshot,
+        composer: item.pieceComposerSnapshot,
+        instrument: item.instrument,
+        performerNames: item.performerNames,
+        duration: item.durationStr,
+      },
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService
+          .addFreePieceItem(this.programId, { ...result, slotId: item.id })
+          .subscribe(updated => {
+            const enh = this.enhanceItem(updated);
+            this.items = this.items.map(i => (i.id === item.id ? enh : i));
+          });
+      }
+    });
+  }
+
+  private editSpeech(item: ProgramItem) {
+    const dialogRef = this.dialog.open(ProgramSpeechDialogComponent, {
+      width: '600px',
+      data: {
+        title: item.speechTitle,
+        source: item.speechSource,
+        speaker: item.speechSpeaker,
+        text: item.speechText,
+        duration: item.durationStr,
+      },
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService
+          .addSpeechItem(this.programId, { ...result, slotId: item.id })
+          .subscribe(updated => {
+            const enh = this.enhanceItem(updated);
+            this.items = this.items.map(i => (i.id === item.id ? enh : i));
+          });
+      }
+    });
+  }
+
+  private editBreak(item: ProgramItem) {
+    const dialogRef = this.dialog.open(ProgramBreakDialogComponent, {
+      width: '400px',
+      data: { duration: item.durationStr, note: item.note ?? '' },
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.programService
+          .addBreakItem(this.programId, { ...result, slotId: item.id })
+          .subscribe(updated => {
+            const enh = this.enhanceItem(updated);
+            this.items = this.items.map(i => (i.id === item.id ? enh : i));
+          });
+      }
+    });
+  }
+
   editBasics() {
     const dialogRef = this.dialog.open(ProgramBasicsDialogComponent, {
       width: '600px',

--- a/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-free-piece-dialog.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators, FormControl } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { Composer } from '@core/models/composer';
@@ -23,7 +23,15 @@ export class ProgramFreePieceDialogComponent implements OnInit {
   constructor(
     private fb: FormBuilder,
     private dialogRef: MatDialogRef<ProgramFreePieceDialogComponent>,
-    private api: ApiService
+    private api: ApiService,
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      title?: string;
+      composer?: string;
+      instrument?: string | null;
+      performerNames?: string | null;
+      duration?: string | null;
+    } | null
   ) {
     this.form = this.fb.group({
       title: ['', Validators.required],
@@ -43,6 +51,15 @@ export class ProgramFreePieceDialogComponent implements OnInit {
         map(name => this.allComposers.filter(c => c.name.toLowerCase().includes(name)))
       );
     });
+    if (this.data) {
+      this.form.patchValue({
+        title: this.data.title ?? '',
+        instrument: this.data.instrument ?? '',
+        performerNames: this.data.performerNames ?? '',
+        duration: this.data.duration ?? '',
+      });
+      this.composerCtrl.setValue(this.data.composer ?? '');
+    }
   }
 
   save() {

--- a/choir-app-frontend/src/app/features/program/program-piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-piece-dialog.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, FormsModule, FormControl } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { SearchService } from '@core/services/search.service';
@@ -35,7 +35,9 @@ export class ProgramPieceDialogComponent implements OnInit {
     private fb: FormBuilder,
     private api: ApiService,
     private search: SearchService,
-    private dialogRef: MatDialogRef<ProgramPieceDialogComponent>
+    private dialogRef: MatDialogRef<ProgramPieceDialogComponent>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: { title?: string; composer?: string } | null
   ) {
     this.searchForm = this.fb.group({
       title: [''],
@@ -53,7 +55,13 @@ export class ProgramPieceDialogComponent implements OnInit {
         map(value => (value || '').toLowerCase()),
         map(name => this.allComposers.filter(c => c.name.toLowerCase().includes(name)))
       );
+      if (this.data) {
+        this.composerCtrl.setValue(this.data.composer ?? '');
+      }
     });
+    if (this.data) {
+      this.searchForm.patchValue({ title: this.data.title ?? '' });
+    }
     this.loadPieces();
   }
 

--- a/choir-app-frontend/src/app/features/program/program-speech-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-speech-dialog.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 
 @Component({
@@ -11,10 +11,21 @@ import { MaterialModule } from '@modules/material.module';
   templateUrl: './program-speech-dialog.component.html',
   styleUrls: ['./program-speech-dialog.component.scss'],
 })
-export class ProgramSpeechDialogComponent {
+export class ProgramSpeechDialogComponent implements OnInit {
   form: FormGroup;
 
-  constructor(private fb: FormBuilder, private dialogRef: MatDialogRef<ProgramSpeechDialogComponent>) {
+  constructor(
+    private fb: FormBuilder,
+    private dialogRef: MatDialogRef<ProgramSpeechDialogComponent>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      title?: string;
+      source?: string;
+      speaker?: string;
+      text?: string;
+      duration?: string | null;
+    } | null
+  ) {
     this.form = this.fb.group({
       title: ['', Validators.required],
       source: [''],
@@ -22,6 +33,18 @@ export class ProgramSpeechDialogComponent {
       text: [''],
       duration: ['', Validators.pattern(/^\d{1,2}:\d{2}$/)],
     });
+  }
+
+  ngOnInit(): void {
+    if (this.data) {
+      this.form.patchValue({
+        title: this.data.title ?? '',
+        source: this.data.source ?? '',
+        speaker: this.data.speaker ?? '',
+        text: this.data.text ?? '',
+        duration: this.data.duration ?? '',
+      });
+    }
   }
 
   save() {


### PR DESCRIPTION
## Summary
- allow updating existing program entries by reusing creation dialogs
- add edit action for program items and prefill dialogs with current data
- support item updates on backend using existing add endpoints

## Testing
- `npm test` (backend) *(fails: Expected values to be strictly equal: 500 !== 200)*
- `npm test` (frontend) *(fails: ChromeHeadless failed 2 times (cannot start))*

------
https://chatgpt.com/codex/tasks/task_e_68b6045086dc8320a4bfb10358948dd8