### PR TITLE
Fix Dienstplan menu visibility

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -69,6 +69,12 @@ describe('MainLayoutComponent', () => {
     expect(homeVisible).toBeTrue();
   });
 
+  it('shows dienstplan by default when module setting is missing', async () => {
+    const dienstplanItem = component.navItems.find(i => i.key === 'dienstplan');
+    const visible = await firstValueFrom(dienstplanItem!.visibleSubject!);
+    expect(visible).toBeTrue();
+  });
+
   it('shows dienstplan for organists even if singers cannot see it', async () => {
     authServiceMock.currentUser$.next({ roles: ['singer', 'organist'] });
     authServiceMock.activeChoir$.next({ modules: { dienstplan: true, singerMenu: { dienstplan: false } } });

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -128,7 +128,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
     );
 
     this.dienstplanEnabled$ = this.authService.activeChoir$.pipe(
-      map(c => !!c?.modules?.dienstplan)
+      map(c => c?.modules?.dienstplan !== false)
     );
 
     this.isLoggedIn$.pipe(


### PR DESCRIPTION
## Summary
- Ensure Dienstplan menu remains visible unless explicitly disabled
- Add regression test for default Dienstplan visibility

## Testing
- `npm test`
- `npm run lint` *(fails: Lint errors found in the listed files)*

------
https://chatgpt.com/codex/tasks/task_e_68b6098a078083209adc290d314081da