### PR TITLE
fix: preserve duration field in program editor

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -73,7 +73,7 @@
       <input
         matInput
         [(ngModel)]="item.durationStr"
-        (ngModelChange)="onDurationChange(item)"
+        (blur)="onDurationChange(item)"
         placeholder="mm:ss"
       />
     </mat-cell>


### PR DESCRIPTION
## Summary
- avoid clearing duration on focus in program editor table by saving on blur

## Testing
- `npm test --prefix choir-app-frontend` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run lint --prefix choir-app-frontend` *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f5b34ab883209ba4fee31508a515