### PR TITLE
Place drag handle before move arrows

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -22,6 +22,9 @@
   <ng-container matColumnDef="move">
     <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let item; let i = index">
+      <span class="drag-handle" cdkDragHandle aria-label="Greifen">
+        <mat-icon>drag_indicator</mat-icon>
+      </span>
       <button
         mat-icon-button
         (click)="moveUp(i)"
@@ -38,9 +41,6 @@
       >
         <mat-icon>arrow_downward</mat-icon>
       </button>
-      <span class="drag-handle" cdkDragHandle aria-label="Greifen">
-        <mat-icon>drag_indicator</mat-icon>
-      </span>
     </mat-cell>
   </ng-container>
 

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -25,7 +25,7 @@
 .drag-handle {
   cursor: move;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-right: 4px;
 }
 
 .total-duration {


### PR DESCRIPTION
## Summary
- Move program editor drag handle before up/down arrow buttons for clearer access
- Adjust drag handle spacing to use a right margin instead of left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b722167f2c8320a6460faa61f67008