### PR TITLE
feat: arrange program editor like booklet

### DIFF
--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -21,7 +21,7 @@
   >
   <ng-container matColumnDef="move">
     <mat-header-cell *matHeaderCellDef></mat-header-cell>
-    <mat-cell *matCellDef="let item; let i = index">
+    <mat-cell *matCellDef="let item; let i = index" class="move-cell">
       <button
         mat-icon-button
         (click)="moveUp(i)"
@@ -44,60 +44,45 @@
     </mat-cell>
   </ng-container>
 
-  <ng-container matColumnDef="title">
-    <mat-header-cell *matHeaderCellDef> Titel </mat-header-cell>
-    <mat-cell *matCellDef="let item">
-      <ng-container [ngSwitch]="item.type">
-        <span *ngSwitchCase="'piece'">{{ item.pieceTitleSnapshot }}</span>
-        <span *ngSwitchCase="'speech'">{{ item.speechTitle }}</span>
-        <span *ngSwitchCase="'break'">{{ item.breakTitle || 'Pause' }}</span>
-        <span *ngSwitchCase="'slot'">{{ item.slotLabel }}</span>
-      </ng-container>
-    </mat-cell>
-  </ng-container>
-
-  <ng-container matColumnDef="composer">
-    <mat-header-cell *matHeaderCellDef> Komponist / Sprecher </mat-header-cell>
-    <mat-cell *matCellDef="let item">
-      <ng-container [ngSwitch]="item.type">
-        <span *ngSwitchCase="'piece'">{{ item.pieceComposerSnapshot }}</span>
-        <span *ngSwitchCase="'speech'">{{ item.speechSpeaker }}</span>
-        <span *ngSwitchCase="'slot'"></span>
-      </ng-container>
-    </mat-cell>
-  </ng-container>
-
-  <ng-container matColumnDef="duration">
-    <mat-header-cell *matHeaderCellDef> Dauer (mm:ss) </mat-header-cell>
-    <mat-cell *matCellDef="let item">
-      <input
-        matInput
-        [(ngModel)]="item.durationStr"
-        (blur)="onDurationChange(item)"
-        placeholder="mm:ss"
-      />
-    </mat-cell>
-  </ng-container>
-
-  <ng-container matColumnDef="note">
-    <mat-header-cell *matHeaderCellDef> Notiz </mat-header-cell>
-    <mat-cell *matCellDef="let item">
-      <input matInput [(ngModel)]="item.note" (blur)="onNoteChange(item)" />
+  <ng-container matColumnDef="details">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let item" class="details-cell">
+      <div class="program-block">
+        <div class="composer" *ngIf="getComposer(item)">{{ getComposer(item) }}</div>
+        <div class="title">
+          <ng-container [ngSwitch]="item.type">
+            <span *ngSwitchCase="'piece'">{{ item.pieceTitleSnapshot }}</span>
+            <span *ngSwitchCase="'speech'">{{ item.speechTitle }}</span>
+            <span *ngSwitchCase="'break'">{{ item.breakTitle || 'Pause' }}</span>
+            <span *ngSwitchCase="'slot'">{{ item.slotLabel }}</span>
+          </ng-container>
+        </div>
+        <div class="subtitle">
+          <span *ngIf="getSubtitle(item)">{{ getSubtitle(item) }}</span>
+          <span *ngIf="getSubtitle(item)" class="separator">|</span>
+          <input
+            matInput
+            class="note-input"
+            [(ngModel)]="item.note"
+            (blur)="onNoteChange(item)"
+            placeholder="Notiz"
+          />
+        </div>
+        <div class="duration">
+          <input
+            matInput
+            [(ngModel)]="item.durationStr"
+            (blur)="onDurationChange(item)"
+            placeholder="mm:ss"
+          />
+        </div>
+      </div>
     </mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="time">
-    <mat-header-cell *matHeaderCellDef> Uhrzeit </mat-header-cell>
-    <mat-cell *matCellDef="let item; let i = index">
-      {{ getPlannedTime(i) }}
-    </mat-cell>
-  </ng-container>
-
-  <ng-container matColumnDef="sum">
-    <mat-header-cell *matHeaderCellDef> Summe </mat-header-cell>
-    <mat-cell *matCellDef="let item; let i = index">
-      {{ getCumulativeDuration(i) }}
-    </mat-cell>
+    <mat-header-cell *matHeaderCellDef>Uhrzeit</mat-header-cell>
+    <mat-cell *matCellDef="let item; let i = index">{{ getPlannedTime(i) }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="actions">

--- a/choir-app-frontend/src/app/features/program/program-editor.component.scss
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.scss
@@ -10,8 +10,9 @@
   margin-bottom: 8px;
 }
 
-.program-table .mat-column-duration {
-  width: 5em;
+
+.program-table .mat-column-time {
+  width: 4em;
 }
 
 .table-container {
@@ -26,6 +27,40 @@
   cursor: move;
   vertical-align: middle;
   margin-left: 4px;
+}
+
+.move-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.program-block {
+  text-align: center;
+}
+
+.program-block .title {
+  font-weight: bold;
+}
+
+.program-block .subtitle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.separator {
+  margin: 0 4px;
+}
+
+.note-input {
+  text-align: center;
+}
+
+.duration input {
+  width: 5em;
+  text-align: center;
 }
 
 .total-duration {

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -30,8 +30,7 @@ export class ProgramEditorComponent implements OnInit {
   programDescription = '';
   items: ProgramItem[] = [];
 
-  private readonly baseColumns = ['move', 'title', 'composer', 'duration', 'note', 'sum', 'actions'];
-  private readonly columnsWithTime = ['move', 'title', 'composer', 'duration', 'note', 'time', 'sum', 'actions'];
+  displayedColumns: string[] = ['move', 'details', 'time', 'actions'];
 
   constructor(
     private dialog: MatDialog,
@@ -53,9 +52,6 @@ export class ProgramEditorComponent implements OnInit {
     }
   }
 
-  get displayedColumns(): string[] {
-    return this.startTime ? this.columnsWithTime : this.baseColumns;
-  }
 
   addPiece() {
     const dialogRef = this.dialog.open(ProgramPieceDialogComponent, { width: '600px' });
@@ -311,13 +307,6 @@ export class ProgramEditorComponent implements OnInit {
 
   }
 
-  getCumulativeDuration(index: number): string {
-    const total = this.items
-      .slice(0, index + 1)
-      .reduce((sum, item) => sum + (item.durationSec || 0), 0);
-    return this.formatDuration(total);
-  }
-
   getTotalDuration(): string {
     const total = this.items.reduce((sum, item) => sum + (item.durationSec || 0), 0);
     return this.formatDuration(total);
@@ -371,6 +360,28 @@ export class ProgramEditorComponent implements OnInit {
     this.programService.deleteItem(this.programId, item.id).subscribe(() => {
       this.items = this.items.filter(i => i.id !== item.id);
     });
+  }
+
+  getComposer(item: ProgramItem): string | null {
+    switch (item.type) {
+      case 'piece':
+        return item.pieceComposerSnapshot ?? null;
+      case 'speech':
+        return item.speechSpeaker ?? null;
+      default:
+        return null;
+    }
+  }
+
+  getSubtitle(item: ProgramItem): string | null {
+    switch (item.type) {
+      case 'piece':
+        return item.instrument || item.performerNames || null;
+      case 'speech':
+        return item.speechSource || null;
+      default:
+        return null;
+    }
   }
 
   private enhanceItem(item: ProgramItem): ProgramItem {


### PR DESCRIPTION
## Summary
- display each program item like a program booklet with centered composer, bold title and note line
- expose helper methods and column set for new layout
- style program editor rows and handle column to match block design

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b722e5b2fc8320a5ae376d684108ba