### PR TITLE
feat: allow publishing programs

### DIFF
--- a/choir-app-backend/src/controllers/program.controller.js
+++ b/choir-app-backend/src/controllers/program.controller.js
@@ -70,6 +70,20 @@ exports.findAll = async (req, res) => {
   }
 };
 
+// Retrieve the most recently published program for the active choir
+exports.findLastPublished = async (req, res) => {
+  try {
+    const program = await Program.findOne({
+      where: { choirId: req.activeChoirId, status: 'published' },
+      order: [['publishedAt', 'DESC']],
+      include: [{ model: db.program_item, as: 'items', separate: true, order: [['sortIndex', 'ASC']] }],
+    });
+    res.status(200).send(program);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
 // Retrieve a single program with its items
 exports.findOne = async (req, res) => {
   const { id } = req.params;

--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -18,6 +18,7 @@ const router = require('express').Router();
 
 router.use(authJwt.verifyToken);
 
+router.get('/last', wrap(controller.findLastPublished));
 router.get('/', role.requireDirector, wrap(controller.findAll));
 router.get('/:id', role.requireDirector, wrap(controller.findOne));
 router.delete('/:id', role.requireDirector, wrap(controller.delete));

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -141,6 +141,12 @@ const controller = require('../src/controllers/program.controller');
       assert.strictEqual(publishRes.data.status, 'published');
       assert.ok(publishRes.data.publishedAt);
 
+      const lastReq = { activeChoirId: choir.id };
+      const lastRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
+      await controller.findLastPublished(lastReq, lastRes);
+      assert.strictEqual(lastRes.statusCode, 200);
+      assert.strictEqual(lastRes.data.id, publishRes.data.id);
+
       // modifying after publish should create a revision
       const afterReq = {
         params: { id: publishRes.data.id },

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -793,6 +793,10 @@ export class ApiService {
     return this.programService.createProgram(data);
   }
 
+  getLastProgram(): Observable<Program | null> {
+    return this.programService.getLastPublishedProgram();
+  }
+
   // --- Filter Preset Methods ---
   getRepertoireFilters(): Observable<RepertoireFilter[]> {
     return this.filterPresetService.getPresets();

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -31,6 +31,14 @@ export class ProgramService {
     return this.http.delete<void>(`${this.apiUrl}/programs/${id}`);
   }
 
+  publishProgram(id: string): Observable<Program> {
+    return this.http.post<Program>(`${this.apiUrl}/programs/${id}/publish`, {});
+  }
+
+  getLastPublishedProgram(): Observable<Program | null> {
+    return this.http.get<Program | null>(`${this.apiUrl}/programs/last`);
+  }
+
   addPieceItem(
     programId: string,
     data: { pieceId: string; title: string; composer?: string; durationSec?: number; note?: string; slotId?: string }

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -10,8 +10,17 @@
 </div>
 
 <div class="dashboard-grid">
-  <app-event-card cardTitle="Letzter Gottesdienst" [event]="lastService$ | async">
-  </app-event-card>
+  <ng-container *ngIf="lastProgram$ | async as program; else lastService">
+    <mat-card class="program-card">
+      <h2>Letzter Gottesdienst</h2>
+      <h3>{{ program.title }}</h3>
+      <p *ngIf="program.startTime">{{ program.startTime | date:'shortDate' }}</p>
+    </mat-card>
+  </ng-container>
+  <ng-template #lastService>
+    <app-event-card cardTitle="Letzter Gottesdienst" [event]="lastService$ | async">
+    </app-event-card>
+  </ng-template>
 
   <!-- Verwenden Sie die neue Komponente für die Probe -->
   <app-event-card cardTitle="Letzte Probe" [event]="lastRehearsal$ | async">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -10,6 +10,7 @@ import { MaterialModule } from '@modules/material.module';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '@core/services/api.service';
 import { CreateEventResponse, Event } from '@core/models/event';
+import { Program } from '@core/models/program';
 import { EventDialogComponent } from '../../events/event-dialog/event-dialog.component';
 import { Piece } from '@core/models/piece';
 import { EventCardComponent } from '../event-card/event-card.component';
@@ -41,6 +42,7 @@ export class DashboardComponent implements OnInit {
 
   lastService$!: Observable<Event | null>;
   lastRehearsal$!: Observable<Event | null>;
+  lastProgram$!: Observable<Program | null>;
   activeChoir$: Observable<Choir | null>;
   pieceChanges$!: Observable<PieceChange[]>;
   nextEvents$!: Observable<Event[]>;
@@ -74,6 +76,10 @@ export class DashboardComponent implements OnInit {
     // Diese Streams werden jedes Mal neu ausgeführt, wenn `refresh$` einen neuen Wert ausgibt.
     this.lastService$ = this.refresh$.pipe(
       switchMap(() => this.apiService.getLastEvent('SERVICE'))
+    );
+
+    this.lastProgram$ = this.refresh$.pipe(
+      switchMap(() => this.apiService.getLastProgram())
     );
 
     this.lastRehearsal$ = this.refresh$.pipe(

--- a/choir-app-frontend/src/app/features/programs/program-list.component.html
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.html
@@ -10,6 +10,7 @@
     <mat-header-cell *matHeaderCellDef>Aktionen</mat-header-cell>
     <mat-cell *matCellDef="let program">
       <button mat-button [routerLink]="['/programs', program.id]">Bearbeiten</button>
+      <button mat-button (click)="publish(program)" *ngIf="program.status === 'draft'">Veröffentlichen</button>
       <button mat-button color="warn" (click)="delete(program)">Löschen</button>
     </mat-cell>
   </ng-container>

--- a/choir-app-frontend/src/app/features/programs/program-list.component.ts
+++ b/choir-app-frontend/src/app/features/programs/program-list.component.ts
@@ -26,5 +26,12 @@ export class ProgramListComponent implements OnInit {
     });
   }
 
+  publish(program: Program): void {
+    this.programService.publishProgram(program.id).subscribe(updated => {
+      const index = this.programs.findIndex(p => p.id === program.id);
+      if (index !== -1) this.programs[index] = updated;
+    });
+  }
+
 }
 


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch the latest published program
- expose program publishing in frontend and list page
- show most recent published program on dashboard instead of last service

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend` *(fails: ChromeHeadless failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_68b7232483d483208383d3d97d40ee84