### PR TITLE
Allow non-admins to store piece duration

### DIFF
--- a/choir-app-backend/tests/piece.controller.test.js
+++ b/choir-app-backend/tests/piece.controller.test.js
@@ -77,6 +77,18 @@ const controller = require('../src/controllers/piece.controller');
   const unchanged = await db.piece.findByPk(created.id);
   assert.strictEqual(unchanged.title, 'Test Piece');
 
+  // non-admin duration update should modify the record
+  statusCode = undefined;
+  await controller.update({
+    params: { id: created.id },
+    body: { durationSec: 123 },
+    userRoles: ['user'],
+    userId: user.id
+  }, res);
+  assert.strictEqual(statusCode, 200, 'non-admin duration update returns 200');
+  const durationUpdated = await db.piece.findByPk(created.id);
+  assert.strictEqual(durationUpdated.durationSec, 123);
+
   // admin update should modify the record
   statusCode = undefined;
   await controller.update({


### PR DESCRIPTION
## Summary
- permit updating a piece's duration without admin rights
- cover non-admin duration update in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b725fa48548320b68a7771e4020a61