### PR TITLE
Fix mat-table no-data rows

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -54,9 +54,11 @@
       </ng-container>
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
       <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-      <mat-row *matNoDataRow>
-        <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
-      </mat-row>
+      <ng-container matNoDataRow>
+        <mat-row>
+          <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
+        </mat-row>
+      </ng-container>
     </mat-table>
   </div>
 </div>

--- a/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-piece-changes/manage-piece-changes.component.html
@@ -20,7 +20,9 @@
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-    <mat-row *matNoDataRow>
-        <mat-cell colspan="3">Keine Vorschläge vorhanden.</mat-cell>
-    </mat-row>
+    <ng-container matNoDataRow>
+        <mat-row>
+            <mat-cell colspan="3">Keine Vorschläge vorhanden.</mat-cell>
+        </mat-row>
+    </ng-container>
 </mat-table>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -172,11 +172,13 @@
           </ng-container>
           <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
           <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-          <mat-row class="mat-row" *matNoDataRow>
-            <mat-cell class="mat-cell" [attr.colspan]="displayedColumns.length">
-              Keine Mitglieder gefunden.
-            </mat-cell>
-          </mat-row>
+          <ng-container matNoDataRow>
+            <mat-row class="mat-row">
+              <mat-cell class="mat-cell" [attr.colspan]="displayedColumns.length">
+                Keine Mitglieder gefunden.
+              </mat-cell>
+            </mat-row>
+          </ng-container>
         </mat-table>
       </div>
     </mat-card-content>
@@ -207,11 +209,13 @@
           </ng-container>
           <mat-header-row *matHeaderRowDef="displayedCollectionColumns"></mat-header-row>
           <mat-row *matRowDef="let row; columns: displayedCollectionColumns;"></mat-row>
-          <mat-row class="mat-row" *matNoDataRow>
-            <mat-cell class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
-              Keine Sammlungen vorhanden.
-            </mat-cell>
-          </mat-row>
+          <ng-container matNoDataRow>
+            <mat-row class="mat-row">
+              <mat-cell class="mat-cell" [attr.colspan]="displayedCollectionColumns.length">
+                Keine Sammlungen vorhanden.
+              </mat-cell>
+            </mat-row>
+          </ng-container>
         </mat-table>
       </div>
     </mat-card-content>

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -32,8 +32,10 @@
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-    <mat-row *matNoDataRow>
-      <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
-    </mat-row>
+    <ng-container matNoDataRow>
+      <mat-row>
+        <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
+      </mat-row>
+    </ng-container>
   </mat-table>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.html
@@ -92,11 +92,13 @@
 
     <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openCollection(row)" [class.selected]="selectedCollection?.id === row.id"></mat-row>
-    <mat-row *matNoDataRow>
-      <mat-cell [attr.colspan]="displayedColumns.length">
-        Es wurden noch keine Sammlungen erstellt.
-      </mat-cell>
-    </mat-row>
+    <ng-container matNoDataRow>
+      <mat-row>
+        <mat-cell [attr.colspan]="displayedColumns.length">
+          Es wurden noch keine Sammlungen erstellt.
+        </mat-cell>
+      </mat-row>
+    </ng-container>
   </mat-table>
   </div>
   <mat-paginator [pageSizeOptions]="pageSizeOptions"

--- a/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
+++ b/choir-app-frontend/src/app/features/collections/piece-list/collection-piece-list.component.html
@@ -40,9 +40,11 @@
 
       <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
       <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="openPiece(row)"></mat-row>
-      <mat-row *matNoDataRow>
-        <mat-cell [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</mat-cell>
-      </mat-row>
+      <ng-container matNoDataRow>
+        <mat-row>
+          <mat-cell [attr.colspan]="displayedColumns.length">Keine Stücke gefunden.</mat-cell>
+        </mat-row>
+      </ng-container>
     </mat-table>
   </div>
   <mat-paginator [length]="totalPieces" [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" showFirstLastButtons></mat-paginator>

--- a/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
+++ b/choir-app-frontend/src/app/features/events/event-dialog/event-dialog.component.html
@@ -90,9 +90,11 @@
 
       <mat-header-row *matHeaderRowDef="pieceColumns"></mat-header-row>
       <mat-row *matRowDef="let row; columns: pieceColumns;"></mat-row>
-      <mat-row class="mat-row" *matNoDataRow>
-        <mat-cell class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</mat-cell>
-      </mat-row>
+      <ng-container matNoDataRow>
+        <mat-row class="mat-row">
+          <mat-cell class="mat-cell" [attr.colspan]="pieceColumns.length">Für dieses Ereignis wurden noch keine Stücke ausgewählt.</mat-cell>
+        </mat-row>
+      </ng-container>
     </mat-table>
 
   </form>

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.html
@@ -69,9 +69,11 @@
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selectEvent(row)"></mat-row>
-    <mat-row *matNoDataRow>
-      <mat-cell [attr.colspan]="displayedColumns.length">Keine Events gefunden.</mat-cell>
-    </mat-row>
+    <ng-container matNoDataRow>
+      <mat-row>
+        <mat-cell [attr.colspan]="displayedColumns.length">Keine Events gefunden.</mat-cell>
+      </mat-row>
+    </ng-container>
   </mat-table>
 
   <mat-paginator [pageSizeOptions]="pageSizeOptions"

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.html
@@ -192,11 +192,13 @@
                 (mouseleave)="onRowMouseLeave()"></mat-row>
 
             <!-- Row shown when there is no matching data. -->
-            <mat-row class="mat-row" *matNoDataRow>
-              <mat-cell class="mat-cell" [attr.colspan]="displayedColumns.length">
-                Keine Stücken passend zu den Filtern gefunden.
-              </mat-cell>
-            </mat-row>
+            <ng-container matNoDataRow>
+              <mat-row class="mat-row">
+                <mat-cell class="mat-cell" [attr.colspan]="displayedColumns.length">
+                  Keine Stücken passend zu den Filtern gefunden.
+                </mat-cell>
+              </mat-row>
+            </ng-container>
           </mat-table>
         </div>
 

--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -28,8 +28,10 @@
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-    <mat-row *matNoDataRow>
-      <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
-    </mat-row>
+    <ng-container matNoDataRow>
+      <mat-row>
+        <mat-cell [attr.colspan]="displayedColumns.length">Keine Mitglieder gefunden.</mat-cell>
+      </mat-row>
+    </ng-container>
   </mat-table>
 </div>


### PR DESCRIPTION
## Summary
- replace deprecated `*matNoDataRow` syntax with `<ng-container matNoDataRow>` across all Angular Material tables to prevent injector errors

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b727bdf6ac8320832161045e9ce634