### PR TITLE
feat: enable source maps and debug logging toggle

### DIFF
--- a/choir-app-frontend/angular.json
+++ b/choir-app-frontend/angular.json
@@ -62,6 +62,12 @@
                   "inlineCritical": false
                 },
                 "fonts": true
+              },
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "vendor": false,
+                "hidden": true
               }
             },
             "localdata": {
@@ -91,6 +97,12 @@
                   "inlineCritical": false
                 },
                 "fonts": true
+              },
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "vendor": false,
+                "hidden": true
               }
             },
             "development": {

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -9,6 +9,7 @@ import { Choir } from '../models/choir';
 import { SwitchChoirResponse } from '../models/auth';
 import { ThemeService } from './theme.service';
 import { UserPreferencesService } from './user-preferences.service';
+import { DebugLogService } from './debug-log.service';
 
 const TOKEN_KEY = 'auth-token';
 const USER_KEY = 'user';
@@ -35,7 +36,8 @@ export class AuthService {
   constructor(private http: HttpClient,
               private router: Router,
               private theme: ThemeService,
-              private prefs: UserPreferencesService) {
+              private prefs: UserPreferencesService,
+              private logger: DebugLogService) {
     this.migrateStorage();
     this.loggedIn.next(this.hasToken());
 
@@ -208,12 +210,12 @@ export class AuthService {
   }
 
   setCurrentUser(user: User): void {
-    console.debug('AuthService.setCurrentUser called', user);
+    this.logger.log('AuthService.setCurrentUser called', user);
     localStorage.setItem(USER_KEY, JSON.stringify(user));
     this.currentUserSubject.next(user);
     this.activeChoir$.next(user.activeChoir || null);
     const choirs = user.availableChoirs || [];
-    console.debug('AuthService.setCurrentUser updated choirs', {
+    this.logger.log('AuthService.setCurrentUser updated choirs', {
       active: user.activeChoir,
       available: choirs
     });

--- a/choir-app-frontend/src/app/core/services/debug-log.service.ts
+++ b/choir-app-frontend/src/app/core/services/debug-log.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+
+const STORAGE_KEY = 'debug-logs-enabled';
+
+@Injectable({ providedIn: 'root' })
+export class DebugLogService {
+  private enabled = localStorage.getItem(STORAGE_KEY) === 'true';
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(value: boolean): void {
+    this.enabled = value;
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }
+
+  log(...args: unknown[]): void {
+    if (this.enabled) {
+      // eslint-disable-next-line no-console
+      console.debug(...args);
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.html
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.html
@@ -1,3 +1,7 @@
+<mat-slide-toggle [(ngModel)]="debugLogs" (change)="onToggleDebugLogs()">
+  Zusätzliche Konsolenlogs
+</mat-slide-toggle>
+
 <h2>Primäre Palette</h2>
 <mat-table [dataSource]="primaryColors" class="mat-elevation-z8">
   <ng-container matColumnDef="name">

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.ts
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
+import { DebugLogService } from '@core/services/debug-log.service';
 
 interface PaletteColor {
   name: string;
@@ -11,15 +13,19 @@ interface PaletteColor {
 @Component({
   selector: 'app-develop',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [CommonModule, MaterialModule, FormsModule],
   templateUrl: './develop.component.html',
   styleUrls: ['./develop.component.scss']
 })
 export class DevelopComponent implements OnInit {
   primaryColors: PaletteColor[] = [];
   accentColors: PaletteColor[] = [];
+  debugLogs = false;
+
+  constructor(private logger: DebugLogService) {}
 
   ngOnInit(): void {
+    this.debugLogs = this.logger.isEnabled();
     this.primaryColors = [
       { name: '50', hex: '#e0f1fa', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 50)' },
       { name: '100', hex: '#b3dff4', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-primary, 100)' },
@@ -55,5 +61,10 @@ export class DevelopComponent implements OnInit {
       { name: 'A700', hex: '#ffe3d3', scss: 'mat.m2-get-color-from-palette(nak.$choir-app-accent, A700)' },
       { name: 'default-contrast', hex: '#000000', scss: 'mat.m2-get-contrast-color-from-palette(nak.$choir-app-accent, default)' }
     ];
+  }
+
+  onToggleDebugLogs(): void {
+    this.logger.setEnabled(this.debugLogs);
+    this.logger.log('Debug logging', this.debugLogs ? 'enabled' : 'disabled');
   }
 }

--- a/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.ts
+++ b/choir-app-frontend/src/app/layout/choir-switcher/choir-switcher.component.ts
@@ -5,6 +5,7 @@ import { tap } from 'rxjs/operators';
 import { MaterialModule } from '@modules/material.module';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { Choir } from 'src/app/core/models/choir';
+import { DebugLogService } from '@core/services/debug-log.service';
 
 @Component({
   selector: 'app-choir-switcher',
@@ -17,12 +18,12 @@ export class ChoirSwitcherComponent {
   availableChoirs$: Observable<Choir[]>;
   activeChoir$: Observable<Choir | null>;
 
-  constructor(private authService: AuthService) {
+  constructor(private authService: AuthService, private logger: DebugLogService) {
     this.availableChoirs$ = this.authService.availableChoirs$.pipe(
-      tap(choirs => console.debug('ChoirSwitcher available choirs', choirs))
+      tap(choirs => this.logger.log('ChoirSwitcher available choirs', choirs))
     );
     this.activeChoir$ = this.authService.activeChoir$.pipe(
-      tap(choir => console.debug('ChoirSwitcher active choir', choir))
+      tap(choir => this.logger.log('ChoirSwitcher active choir', choir))
     );
   }
 


### PR DESCRIPTION
## Summary
- generate production source maps for frontend builds
- add DebugLogService and admin toggle to enable detailed console logs
- route selected logs through new debug logger

## Testing
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b75292d3d48320af97a5a781d4fb85