### PR TITLE
chore: update quill to 2.0.3 to remove deprecated DOMNodeInserted usage

### DIFF
--- a/choir-app-frontend/src/index.html
+++ b/choir-app-frontend/src/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+  <link href="https://cdn.quilljs.com/2.0.3/quill.snow.css" rel="stylesheet">
 </head>
 <body>
   <div id="no-js-message" style="font-family: Roboto, 'Helvetica Neue', sans-serif; padding: 2rem; color:#000;">
@@ -20,7 +20,7 @@
     </p>
   </div>
   <app-root style="display: none;"></app-root>
-  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+  <script src="https://cdn.quilljs.com/2.0.3/quill.js"></script>
   <script>
     const msg = document.getElementById('no-js-message');
     if (msg) {


### PR DESCRIPTION
## Summary
- update Quill CDN to version 2.0.3 to avoid deprecated DOMNodeInserted listener

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run lint` *(fails: lint errors in source files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d632a734832086b0c4ef8753e58a