### PR TITLE
feat: show published concert program on dashboard

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -15,6 +15,13 @@
       <h2>Letzter Gottesdienst</h2>
       <h3>{{ program.title }}</h3>
       <p *ngIf="program.startTime">{{ program.startTime | date:'shortDate' }}</p>
+      <mat-list>
+        <mat-list-item *ngFor="let item of program.items">
+          <div matLine *ngIf="getItemComposer(item)">{{ getItemComposer(item) }}</div>
+          <div matLine>{{ getItemTitle(item) }}</div>
+          <div matLine *ngIf="getItemSubtitle(item)">{{ getItemSubtitle(item) }}</div>
+        </mat-list-item>
+      </mat-list>
     </mat-card>
   </ng-container>
   <ng-template #lastService>

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -10,7 +10,7 @@ import { MaterialModule } from '@modules/material.module';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '@core/services/api.service';
 import { CreateEventResponse, Event } from '@core/models/event';
-import { Program } from '@core/models/program';
+import { Program, ProgramItem } from '@core/models/program';
 import { EventDialogComponent } from '../../events/event-dialog/event-dialog.component';
 import { Piece } from '@core/models/piece';
 import { EventCardComponent } from '../event-card/event-card.component';
@@ -227,6 +227,43 @@ export class DashboardComponent implements OnInit {
 
   openLatestPost(post: Post): void {
     this.router.navigate(['/posts'], { fragment: `post-${post.id}` });
+  }
+
+  getItemComposer(item: ProgramItem): string | null {
+    switch (item.type) {
+      case 'piece':
+        return item.pieceComposerSnapshot ?? null;
+      case 'speech':
+        return item.speechSpeaker ?? null;
+      default:
+        return null;
+    }
+  }
+
+  getItemTitle(item: ProgramItem): string {
+    switch (item.type) {
+      case 'piece':
+        return item.pieceTitleSnapshot || '';
+      case 'speech':
+        return item.speechTitle || '';
+      case 'break':
+        return item.breakTitle || 'Pause';
+      case 'slot':
+        return item.slotLabel || '';
+      default:
+        return '';
+    }
+  }
+
+  getItemSubtitle(item: ProgramItem): string | null {
+    switch (item.type) {
+      case 'piece':
+        return item.instrument || item.performerNames || null;
+      case 'speech':
+        return item.speechSource || null;
+      default:
+        return null;
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- display items of last published program on dashboard
- add helpers for program item formatting

## Testing
- `npm test`
- `npm test --prefix choir-app-backend`
- `npm run lint` *(fails: multiple lint errors across frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68b821f3d7b48320a88595b2f32b9461