### PR TITLE
Allow linking pieces in posts using Markdown

### DIFF
--- a/choir-app-backend/src/controllers/post.controller.js
+++ b/choir-app-backend/src/controllers/post.controller.js
@@ -14,7 +14,7 @@ async function isChoirAdmin(req) {
 }
 
 exports.create = async (req, res) => {
-  const { title, text, pieceId, expiresAt } = req.body;
+  const { title, text, expiresAt } = req.body;
   if (!title || !text) return res.status(400).send({ message: 'title and text required' });
   try {
     const sanitizedTitle = stripHtml(title);
@@ -23,14 +23,12 @@ exports.create = async (req, res) => {
     const post = await Post.create({
       title: sanitizedTitle,
       text: sanitizedText,
-      pieceId: pieceId || null,
       expiresAt: expDate,
       choirId: req.activeChoirId,
       userId: req.userId
     });
     const full = await Post.findByPk(post.id, { include: [
-      { model: db.user, as: 'author', attributes: ['id','name'] },
-      { model: db.piece, as: 'piece', attributes: ['id','title'] }
+      { model: db.user, as: 'author', attributes: ['id','name'] }
     ] });
 
     const members = await db.user.findAll({
@@ -61,8 +59,7 @@ exports.findAll = async (req, res) => {
     const posts = await Post.findAll({
       where,
       include: [
-        { model: db.user, as: 'author', attributes: ['id','name'] },
-        { model: db.piece, as: 'piece', attributes: ['id','title'] }
+        { model: db.user, as: 'author', attributes: ['id','name'] }
       ],
       order: [['createdAt', 'DESC']]
     });
@@ -86,8 +83,7 @@ exports.findLatest = async (req, res) => {
     const post = await Post.findOne({
       where,
       include: [
-        { model: db.user, as: 'author', attributes: ['id','name'] },
-        { model: db.piece, as: 'piece', attributes: ['id','title'] }
+        { model: db.user, as: 'author', attributes: ['id','name'] }
       ],
       order: [['createdAt', 'DESC']]
     });
@@ -99,7 +95,7 @@ exports.findLatest = async (req, res) => {
 
 exports.update = async (req, res) => {
   const id = req.params.id;
-  const { title, text, pieceId, expiresAt } = req.body;
+  const { title, text, expiresAt } = req.body;
   if (!title || !text) return res.status(400).send({ message: 'title and text required' });
   try {
     const post = await Post.findByPk(id);
@@ -109,10 +105,9 @@ exports.update = async (req, res) => {
     const sanitizedTitle = stripHtml(title);
     const sanitizedText = stripHtml(text);
     const expDate = expiresAt ? new Date(expiresAt) : null;
-    await post.update({ title: sanitizedTitle, text: sanitizedText, pieceId: pieceId || null, expiresAt: expDate });
+    await post.update({ title: sanitizedTitle, text: sanitizedText, expiresAt: expDate });
     const full = await Post.findByPk(id, { include: [
-      { model: db.user, as: 'author', attributes: ['id','name'] },
-      { model: db.piece, as: 'piece', attributes: ['id','title'] }
+      { model: db.user, as: 'author', attributes: ['id','name'] }
     ] });
     res.status(200).send(full);
   } catch (err) {

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -150,8 +150,6 @@ db.choir.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 db.user.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
-db.piece.hasMany(db.post, { as: 'posts' });
-db.post.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
 
 // Library items referencing collections
 db.collection.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'collectionId' });

--- a/choir-app-backend/src/models/post.model.js
+++ b/choir-app-backend/src/models/post.model.js
@@ -8,10 +8,6 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.TEXT,
       allowNull: false
     },
-    pieceId: {
-      type: DataTypes.INTEGER,
-      allowNull: true
-    },
     expiresAt: {
       type: DataTypes.DATE,
       allowNull: true

--- a/choir-app-backend/src/validators/post.validation.js
+++ b/choir-app-backend/src/validators/post.validation.js
@@ -7,6 +7,5 @@ function noHtml(value) {
 exports.postValidation = [
   body('title').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
   body('text').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
-  body('pieceId').optional().isInt(),
   body('expiresAt').optional().isISO8601()
 ];

--- a/choir-app-backend/tests/models.test.js
+++ b/choir-app-backend/tests/models.test.js
@@ -32,7 +32,7 @@ const db = require('../src/models');
     checkFields(db.repertoire_filter, ['name', 'data', 'visibility']);
     checkFields(db.mail_setting, ['host', 'port', 'user', 'pass', 'secure', 'starttls', 'fromAddress']);
     checkFields(db.plan_rule, ['dayOfWeek', 'weeks', 'notes']);
-    checkFields(db.post, ['title', 'text', 'pieceId', 'expiresAt']);
+    checkFields(db.post, ['title', 'text', 'expiresAt']);
     checkFields(db.program, ['title', 'description', 'status', 'startTime']);
     checkFields(db.program_element, ['type', 'position', 'duration']);
     checkFields(db.program_item, ['type', 'sortIndex']);

--- a/choir-app-frontend/src/app/core/models/post.ts
+++ b/choir-app-frontend/src/app/core/models/post.ts
@@ -8,5 +8,4 @@ export interface Post {
   updatedAt: string;
   expiresAt?: string | null;
   author?: { id: number; name: string };
-  piece?: { id: number; title: string };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -777,11 +777,11 @@ export class ApiService {
     return this.postService.getLatestPost();
   }
 
-  createPost(data: { title: string; text: string; pieceId?: number | null; expiresAt?: string | null }): Observable<Post> {
+  createPost(data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
     return this.postService.createPost(data);
   }
 
-  updatePost(id: number, data: { title: string; text: string; pieceId?: number | null; expiresAt?: string | null }): Observable<Post> {
+  updatePost(id: number, data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
     return this.postService.updatePost(id, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/post.service.ts
+++ b/choir-app-frontend/src/app/core/services/post.service.ts
@@ -17,11 +17,11 @@ export class PostService {
     return this.http.get<Post | null>(`${this.apiUrl}/posts/latest`);
   }
 
-  createPost(data: { title: string; text: string; pieceId?: number | null; expiresAt?: string | null }): Observable<Post> {
+  createPost(data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
     return this.http.post<Post>(`${this.apiUrl}/posts`, data);
   }
 
-  updatePost(id: number, data: { title: string; text: string; pieceId?: number | null; expiresAt?: string | null }): Observable<Post> {
+  updatePost(id: number, data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
     return this.http.put<Post>(`${this.apiUrl}/posts/${id}`, data);
   }
 

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.html
@@ -6,15 +6,8 @@
       <input matInput formControlName="title">
     </mat-form-field>
     <mat-form-field appearance="fill" class="full-width">
-      <mat-label>Stück</mat-label>
-      <input type="text" matInput [formControl]="pieceCtrl" [matAutocomplete]="auto">
-      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayPiece.bind(this)">
-        <mat-option *ngFor="let p of filteredPieces$ | async" [value]="p">{{ p.title }}</mat-option>
-      </mat-autocomplete>
-    </mat-form-field>
-    <mat-form-field appearance="fill" class="full-width">
       <mat-label>Text</mat-label>
-      <textarea matInput rows="5" formControlName="text" placeholder="Markdown möglich"></textarea>
+      <textarea matInput rows="5" formControlName="text" placeholder="Markdown möglich" (keydown)="onTextKeyDown($event)"></textarea>
     </mat-form-field>
     <mat-expansion-panel>
       <mat-expansion-panel-header>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -11,9 +11,6 @@
       </mat-card-header>
       <mat-card-content>
         <div [innerHTML]="p.text | markdown"></div>
-        <div *ngIf="p.piece" class="piece-link">
-          <a [routerLink]="['/pieces', p.piece.id]">Zum Stück "{{ p.piece.title }}"</a>
-        </div>
         <div *ngIf="p.expiresAt" class="expires">Sichtbar bis {{ p.expiresAt | date:'shortDate' }}</div>
       </mat-card-content>
       <mat-card-actions *ngIf="canEdit(p)" class="actions">

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -10,6 +10,7 @@ import { AuthService } from '@core/services/auth.service';
 import { PostDialogComponent } from './post-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { MarkdownPipe } from '@shared/pipes/markdown.pipe';
+import { forkJoin } from 'rxjs';
 
 @Component({
   selector: 'app-post-list',
@@ -45,10 +46,28 @@ export class PostListComponent implements OnInit {
   loadPosts(): void {
     this.api.getPosts().subscribe(p => {
       this.posts = p;
+      this.replacePieceReferences();
       const fragment = this.route.snapshot.fragment;
       if (fragment) {
         setTimeout(() => document.getElementById(fragment)?.scrollIntoView({ behavior: 'smooth' }), 0);
       }
+    });
+  }
+
+  private replacePieceReferences(): void {
+    const ids = Array.from(new Set(this.posts.flatMap(post =>
+      Array.from(post.text.matchAll(/\{\{(\d+)\}\}/g)).map(m => +m[1])
+    )));
+    if (!ids.length) return;
+    forkJoin(ids.map(id => this.api.getPieceById(id))).subscribe(pieces => {
+      const map = new Map(pieces.map(p => [p.id, p.title]));
+      this.posts = this.posts.map(post => ({
+        ...post,
+        text: post.text.replace(/\{\{(\d+)\}\}/g, (match, id) => {
+          const title = map.get(+id);
+          return title ? `[${title}](\/pieces\/${id})` : match;
+        })
+      }));
     });
   }
 


### PR DESCRIPTION
## Summary
- Allow inserting piece references in posts with `{{id}}` and show search dialog on `{{`
- Render referenced piece titles as links in post list
- Drop explicit piece field from posts in front- and backend

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run test:backend`


------
https://chatgpt.com/codex/tasks/task_e_68b8a01288ec83209b62ab812e3093fc