### PR TITLE
Add PDF export for programs

### DIFF
--- a/choir-app-backend/src/routes/program.routes.js
+++ b/choir-app-backend/src/routes/program.routes.js
@@ -20,6 +20,7 @@ router.use(authJwt.verifyToken);
 
 router.get('/last', wrap(controller.findLastPublished));
 router.get('/', role.requireDirector, wrap(controller.findAll));
+router.get('/:id/pdf', role.requireDirector, wrap(controller.downloadPdf));
 router.get('/:id', role.requireDirector, wrap(controller.findOne));
 router.delete('/:id', role.requireDirector, wrap(controller.delete));
 router.post('/', role.requireDirector, programValidation, validate, wrap(controller.create));

--- a/choir-app-backend/tests/program.controller.test.js
+++ b/choir-app-backend/tests/program.controller.test.js
@@ -133,6 +133,12 @@ const controller = require('../src/controllers/program.controller');
       assert.strictEqual(speechRes.data.speechSpeaker, 'Bob');
       assert.strictEqual(speechRes.data.durationSec, 30);
 
+      // download pdf
+      const pdfRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; }, setHeader() {} };
+      await controller.downloadPdf({ params: { id: res.data.id } }, pdfRes);
+      assert.strictEqual(pdfRes.statusCode, 200);
+      assert.ok(Buffer.isBuffer(pdfRes.data));
+
       // publish program
       const publishReq = { params: { id: res.data.id }, userId: user.id };
       const publishRes = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };

--- a/choir-app-frontend/src/app/core/services/program.service.ts
+++ b/choir-app-frontend/src/app/core/services/program.service.ts
@@ -105,4 +105,8 @@ export class ProgramService {
     deleteItem(programId: string, itemId: string): Observable<void> {
       return this.http.delete<void>(`${this.apiUrl}/programs/${programId}/items/${itemId}`);
     }
+
+  downloadProgramPdf(id: string): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/programs/${id}/pdf`, { responseType: 'blob' });
   }
+}

--- a/choir-app-frontend/src/app/features/program/program-editor.component.html
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.html
@@ -1,6 +1,9 @@
 <div class="program-header">
   <span>Startzeit: {{ startTime ? (startTime | date:'short') : '-' }}</span>
   <button mat-button (click)="editBasics()">Stammdaten bearbeiten</button>
+  <button mat-raised-button color="accent" (click)="downloadPdf()" matTooltip="Als PDF herunterladen">
+    <mat-icon>picture_as_pdf</mat-icon>
+  </button>
 </div>
 
 <button mat-raised-button color="primary" (click)="addPiece()">+ Stück</button>

--- a/choir-app-frontend/src/app/features/program/program-editor.component.ts
+++ b/choir-app-frontend/src/app/features/program/program-editor.component.ts
@@ -362,6 +362,17 @@ export class ProgramEditorComponent implements OnInit {
     });
   }
 
+  downloadPdf() {
+    this.programService.downloadProgramPdf(this.programId).subscribe(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `programm-${this.programId}.pdf`;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  }
+
   getComposer(item: ProgramItem): string | null {
     switch (item.type) {
       case 'piece':


### PR DESCRIPTION
## Summary
- generate program PDFs on the backend
- expose download endpoint and frontend button
- allow Angular client to fetch program PDFs

## Testing
- `npm test --prefix choir-app-backend`
- `npm test` *(fails: chrome: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b91be344ec83209f18b9fa9908a79e