### PR TITLE
Use BCC for multi-recipient emails

### DIFF
--- a/choir-app-backend/tests/emailTransporter.test.js
+++ b/choir-app-backend/tests/emailTransporter.test.js
@@ -11,13 +11,22 @@ const { sendMail } = require('../src/services/emailTransporter');
 
 (async () => {
   try {
-    const result = await sendMail(
+    let result = await sendMail(
       { to: 'a@b.c', subject: 'sub', html: '<p>hi</p>', text: 'hi' },
       { host: 'smtp.example.com', port: 25, user: 'u', pass: 'p', fromAddress: 'from@example.com' }
     );
     assert.strictEqual(createdOptions.host, 'smtp.example.com');
     assert.strictEqual(result.to, 'a@b.c');
     assert.strictEqual(result.from.address, 'from@example.com');
+    assert.strictEqual(result.bcc, undefined);
+
+    const recipients = ['one@example.com', 'two@example.com', 'three@example.com'];
+    result = await sendMail(
+      { to: recipients, subject: 'sub', html: '<p>hi</p>', text: 'hi' },
+      { host: 'smtp.example.com', port: 25, user: 'u', pass: 'p', fromAddress: 'from@example.com' }
+    );
+    assert.strictEqual(result.to, 'no-reply@nak-chorleiter.de');
+    assert.deepStrictEqual(result.bcc, recipients);
   } catch (err) {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Send emails with more than two recipients via BCC and direct main recipient to no-reply@nak-chorleiter.de
- Test BCC logic in email transporter

## Testing
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_68b926278a288320bc10cba3a1ffd98a