### PR TITLE
Handle event availabilities and expose participation view

### DIFF
--- a/choir-app-backend/tests/availability.controller.test.js
+++ b/choir-app-backend/tests/availability.controller.test.js
@@ -25,6 +25,11 @@ const controller = require('../src/controllers/availability.controller');
     const mayDates = res.data.map(a => a.date);
     assert.ok(!mayDates.includes('2025-05-29'));
 
+    await db.event.create({ choirId: choir.id, date: new Date('2025-05-17'), type: 'SERVICE' });
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 5 } }, res);
+    const mayWithEvent = res.data.map(a => a.date);
+    assert.ok(mayWithEvent.includes('2025-05-17'));
+
   await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 12 } }, res);
   const decDates = res.data.map(a => a.date);
   assert.ok(!decDates.includes('2025-12-25'));

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -286,6 +286,12 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
         visibleSubject: this.visibleFor('availability', this.isLoggedIn$),
       },
       {
+        key: 'participation',
+        displayName: 'Beteiligung',
+        route: '/participation',
+        visibleSubject: this.visibleFor('participation', this.isLoggedIn$),
+      },
+      {
         key: 'posts',
         displayName: 'Beiträge',
         route: '/posts',


### PR DESCRIPTION
## Summary
- include choir events when fetching user availability dates
- verify availability endpoint includes event dates
- add navigation entry for participation overview

## Testing
- `node tests/availability.controller.test.js`
- `npm test` *(frontend, fails: libatk-bridge-2.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ce1dc708320ac185fa83a78da48