### PR TITLE
fix: handle uuid migration for published_from

### DIFF
--- a/choir-app-backend/src/init/fixProgramPublishedFromIdColumn.js
+++ b/choir-app-backend/src/init/fixProgramPublishedFromIdColumn.js
@@ -11,7 +11,10 @@ async function fixProgramPublishedFromIdColumn() {
         await db.sequelize.query('ALTER TABLE "programs" ALTER COLUMN "published_from_id" DROP NOT NULL', { transaction });
         await db.sequelize.query('ALTER TABLE "programs" ALTER COLUMN "published_from_id" DROP DEFAULT', { transaction });
         await db.sequelize.query('UPDATE "programs" SET "published_from_id" = NULL', { transaction });
-        await db.sequelize.query('ALTER TABLE "programs" ALTER COLUMN "published_from_id" TYPE UUID USING "published_from_id"::uuid', { transaction });
+        await db.sequelize.query(
+          'ALTER TABLE "programs" ALTER COLUMN "published_from_id" TYPE UUID USING CAST(NULL AS UUID)',
+          { transaction }
+        );
       });
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- handle UUID migration for programs.published_from_id by casting to NULL

## Testing
- `cd choir-app-backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b9659172208320811f44626434cdef