### PR TITLE
Fix date display with timezone awareness

### DIFF
--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.html
@@ -2,7 +2,7 @@
   <ng-container matColumnDef="date">
     <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
     <mat-cell *matCellDef="let a">
-      {{ a.date | date:'EEE dd.MM.yyyy' }}
+      {{ a.date | pureDate | date:'EEE dd.MM.yyyy':'Europe/Berlin':'de-DE' }}
       <span class="holiday" *ngIf="a.holidayHint"> ({{ a.holidayHint }})</span>
     </mat-cell>
   </ng-container>

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
@@ -4,11 +4,13 @@ import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { UserAvailability } from '@core/models/user-availability';
 import { getHolidayName } from '@shared/util/holiday';
+import { PureDatePipe } from '@shared/pipes/pure-date.pipe';
+import { parseDateOnly } from '@shared/util/date';
 
 @Component({
   selector: 'app-availability-table',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [CommonModule, MaterialModule, PureDatePipe],
   templateUrl: './availability-table.component.html',
   styleUrls: ['./availability-table.component.scss']
 })
@@ -28,7 +30,7 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
     this.api.getAvailabilities(this.year, this.month)
       .subscribe(a => this.availabilities = a.map(v => ({
         ...v,
-        holidayHint: getHolidayName(new Date(v.date)) || undefined
+        holidayHint: getHolidayName(parseDateOnly(v.date)) || undefined
       })));
   }
 
@@ -37,11 +39,11 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
     if (i >= 0) this.availabilities[i].status = status;
 
     this.api.setAvailability(date, status).subscribe(updated => {
-      if (i >= 0) this.availabilities[i] = {
-        ...updated,
-        holidayHint: getHolidayName(new Date(updated.date)) || undefined
-      };
-    });
+        if (i >= 0) this.availabilities[i] = {
+          ...updated,
+          holidayHint: getHolidayName(parseDateOnly(updated.date)) || undefined
+        };
+      });
   }
 
   cellClass(status: string): string {

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -37,7 +37,7 @@
     <ng-container matColumnDef="date">
       <mat-header-cell *matHeaderCellDef>Datum</mat-header-cell>
       <mat-cell *matCellDef="let ev" [matTooltip]="timestamp(ev.date)">
-        {{ ev.date | date:'shortDate' }}
+        {{ ev.date | pureDate | date:'shortDate':'Europe/Berlin':'de-DE' }}
         <span class="holiday" *ngIf="ev.holidayHint"> ({{ ev.holidayHint }})</span>
       </mat-cell>
     </ng-container>
@@ -103,7 +103,7 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">{{ d | date:'dd.MM.' }}</th>
+            <th *ngFor="let d of counterPlanDates" [matTooltip]="timestamp(d)">{{ d | date:'dd.MM.':'Europe/Berlin':'de-DE' }}</th>
           </tr>
         </thead>
         <tbody>
@@ -125,7 +125,7 @@
       <div *ngIf="isChoirAdmin" class="member-availabilities">
         <h3>Verfügbarkeiten aller Mitglieder</h3>
         <div *ngFor="let ev of entries">
-          <h4>{{ ev.date | date:'EEE dd.MM.yyyy' }}</h4>
+          <h4>{{ ev.date | pureDate | date:'EEE dd.MM.yyyy':'Europe/Berlin':'de-DE' }}</h4>
           <p><strong>verfügbar:</strong> {{ memberNamesByAvailability(ev.date, 'AVAILABLE') }}</p>
           <p><strong>nach Absprache:</strong> {{ memberNamesByAvailability(ev.date, 'MAYBE') }}</p>
           <p><strong>nicht verfügbar:</strong> {{ memberNamesByAvailability(ev.date, 'UNAVAILABLE') }}</p>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -19,11 +19,13 @@ import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/co
 import { AvailabilityTableComponent } from './availability-table/availability-table.component';
 import { getHolidayName } from '@shared/util/holiday';
 import { Router, ActivatedRoute } from '@angular/router';
+import { PureDatePipe } from '@shared/pipes/pure-date.pipe';
+import { parseDateOnly } from '@shared/util/date';
 
 @Component({
   selector: 'app-monthly-plan',
   standalone: true,
-  imports: [CommonModule, FormsModule, MaterialModule, AvailabilityTableComponent],
+  imports: [CommonModule, FormsModule, MaterialModule, AvailabilityTableComponent, PureDatePipe],
   templateUrl: './monthly-plan.component.html',
   styleUrls: ['./monthly-plan.component.scss']
 })
@@ -48,7 +50,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   private userSub?: Subscription;
 
   timestamp(date: string | Date): string {
-    return new Date(date).getTime().toString();
+    return parseDateOnly(date).getTime().toString();
   }
 
   private updateDisplayedColumns(): void {
@@ -57,7 +59,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   private sortEntries(): void {
-    this.entries.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    this.entries.sort((a, b) => parseDateOnly(a.date).getTime() - parseDateOnly(b.date).getTime());
   }
 
 
@@ -77,10 +79,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   private dateKey(date: string): string {
-    const d = new Date(date);
-    const year = d.getFullYear();
-    const month = d.getMonth() + 1;
-    const day = d.getDate();
+    const d = parseDateOnly(date);
+    const year = d.getUTCFullYear();
+    const month = d.getUTCMonth() + 1;
+    const day = d.getUTCDate();
     return `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
   }
 
@@ -117,7 +119,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     }
     const dateKeys = Array.from(dateMap.keys()).sort();
     this.counterPlanDateKeys = dateKeys;
-    this.counterPlanDates = dateKeys.map(k => new Date(dateMap.get(k)!));
+    this.counterPlanDates = dateKeys.map(k => parseDateOnly(dateMap.get(k)!));
 
     const persons: UserInChoir[] = [];
     [...this.directors, ...this.organists].forEach(u => {
@@ -194,7 +196,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
         this.plan = plan;
         this.entries = (plan?.entries || []).map(e => ({
           ...e,
-          holidayHint: getHolidayName(new Date(e.date)) || undefined
+          holidayHint: getHolidayName(parseDateOnly(e.date)) || undefined
         }));
         this.sortEntries();
         this.updateDisplayedColumns();

--- a/choir-app-frontend/src/app/shared/pipes/pure-date.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/pure-date.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { parseDateOnly } from '@shared/util/date';
+
+@Pipe({
+  name: 'pureDate',
+  standalone: true
+})
+export class PureDatePipe implements PipeTransform {
+  transform(value: string | Date | null | undefined): Date | null {
+    if (!value) return null;
+    return parseDateOnly(value);
+  }
+}

--- a/choir-app-frontend/src/app/shared/util/date.ts
+++ b/choir-app-frontend/src/app/shared/util/date.ts
@@ -1,0 +1,10 @@
+export function parseDateOnly(input: string | Date): Date {
+  if (input instanceof Date) {
+    return new Date(Date.UTC(
+      input.getUTCFullYear(),
+      input.getUTCMonth(),
+      input.getUTCDate()
+    ));
+  }
+  return new Date(`${input}T00:00:00Z`);
+}


### PR DESCRIPTION
## Summary
- format all displayed dates in the Europe/Berlin timezone
- remove UTC offset display and update date parsing to use UTC
- compute date keys using UTC getters to avoid client timezone shifts

## Testing
- `npm test`
- `npm run lint` *(fails: Lint errors in frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ec2a82c8320b0679eff5ded3a26