### PR TITLE
Show first names in dialogs and tables

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
@@ -6,7 +6,7 @@
       <input type="text" matInput formControlName="user" [matAutocomplete]="auto" cdkFocusInitial>
       <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn.bind(this)">
         <mat-option *ngFor="let u of filteredUsers | async" [value]="u">
-          {{u.name}} ({{u.email}})
+          {{u.name}}, {{u.firstName}} ({{u.email}})
         </mat-option>
       </mat-autocomplete>
     </mat-form-field>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
@@ -43,14 +43,15 @@ export class AddMemberDialogComponent implements OnInit {
   }
 
   displayFn(user: User): string {
-    return user ? `${user.name} (${user.email})` : '';
+    return user ? `${user.name}, ${user.firstName} (${user.email})` : '';
   }
 
   private filterUsers(value: string | undefined): User[] {
     const filterValue = (value || '').toLowerCase();
     return this.users.filter(u =>
       u.email.toLowerCase().includes(filterValue) ||
-      (u.name && u.name.toLowerCase().includes(filterValue))
+      (u.name && u.name.toLowerCase().includes(filterValue)) ||
+      (u.firstName && u.firstName.toLowerCase().includes(filterValue))
     );
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.html
@@ -24,7 +24,7 @@
     <mat-table [dataSource]="dataSource" class="member-table">
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-        <mat-cell *matCellDef="let user">{{user.name}}</mat-cell>
+        <mat-cell *matCellDef="let user">{{user.name}}, {{ user.firstName }}</mat-cell>
       </ng-container>
       <ng-container matColumnDef="email">
         <mat-header-cell *matHeaderCellDef>E-Mail</mat-header-cell>

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -72,7 +72,7 @@ export class ChoirDialogComponent implements OnInit {
     if (!this.data?.id) return;
     const data: ConfirmDialogData = {
       title: 'Mitglied entfernen?',
-      message: `Soll ${user.name} (${user.email}) aus diesem Chor entfernt werden?`
+      message: `Soll ${user.name}, ${user.firstName} (${user.email}) aus diesem Chor entfernt werden?`
     };
     const ref = this.dialog.open(ConfirmDialogComponent, { data });
     ref.afterClosed().subscribe(conf => {

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -14,7 +14,7 @@
 >
   <ng-container matColumnDef="name">
     <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-    <mat-cell *matCellDef="let element">{{ element.name }}</mat-cell>
+    <mat-cell *matCellDef="let element">{{ element.name }}, {{ element.firstName }}</mat-cell>
   </ng-container>
 
   <ng-container matColumnDef="email">
@@ -76,7 +76,7 @@
 <mat-accordion *ngIf="isHandset$ | async">
   <mat-expansion-panel *ngFor="let element of dataSource.filteredData">
     <mat-expansion-panel-header>
-      <mat-panel-title>{{ element.name }}</mat-panel-title>
+      <mat-panel-title>{{ element.name }}, {{ element.firstName }}</mat-panel-title>
       <mat-panel-description>{{ element.email }}</mat-panel-description>
     </mat-expansion-panel-header>
     <div class="mobile-user-row">

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -43,6 +43,7 @@ export class ManageUsersComponent implements OnInit {
       const term = filter.trim().toLowerCase();
       return (
         (data.name && data.name.toLowerCase().includes(term)) ||
+        (data.firstName && data.firstName.toLowerCase().includes(term)) ||
         data.email.toLowerCase().includes(term)
       );
     };

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -1,10 +1,16 @@
 <h1 mat-dialog-title>{{ title }}</h1>
 <div mat-dialog-content>
   <form [formGroup]="form" id="user-form" (ngSubmit)="onSave()">
-    <mat-form-field appearance="outline">
-      <mat-label>Name</mat-label>
-      <input matInput formControlName="name" cdkFocusInitial>
-    </mat-form-field>
+    <div class="name-row">
+      <mat-form-field appearance="outline">
+        <mat-label>Vorname</mat-label>
+        <input matInput formControlName="firstName" cdkFocusInitial>
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name">
+      </mat-form-field>
+    </div>
     <mat-form-field appearance="outline">
       <mat-label>E-Mail</mat-label>
       <input matInput formControlName="email">

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.scss
@@ -1,3 +1,12 @@
 mat-form-field {
   display: block;
 }
+
+.name-row {
+  display: flex;
+  gap: 1rem;
+
+  mat-form-field {
+    flex: 1;
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -23,6 +23,7 @@ export class UserDialogComponent {
   ) {
     this.title = data ? 'Benutzer bearbeiten' : 'Benutzer hinzufügen';
     this.form = this.fb.group({
+      firstName: [data?.firstName || '', Validators.required],
       name: [data?.name || '', Validators.required],
       email: [data?.email || '', [Validators.required, Validators.email]],
       street: [data?.street || ''],

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -117,7 +117,7 @@
           <!-- Name Column -->
           <ng-container matColumnDef="name">
             <mat-header-cell *matHeaderCellDef> Name </mat-header-cell>
-            <mat-cell *matCellDef="let user"> {{user.name}} </mat-cell>
+            <mat-cell *matCellDef="let user"> {{user.name}}, {{ user.firstName }} </mat-cell>
           </ng-container>
           <!-- Email Column -->
           <ng-container matColumnDef="email">

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -229,7 +229,7 @@ export class ManageChoirComponent implements OnInit {
     }
     const dialogData: ConfirmDialogData = {
       title: 'Mitglied entfernen?',
-      message: `Soll ${user.name} (${user.email}) aus diesem Chor entfernt werden? Dies kann nicht rückgängig gemacht werden.`
+      message: `Soll ${user.name}, ${user.firstName} (${user.email}) aus diesem Chor entfernt werden? Dies kann nicht rückgängig gemacht werden.`
     };
 
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
@@ -241,7 +241,7 @@ export class ManageChoirComponent implements OnInit {
         const opts = this.adminChoirId ? { choirId: this.adminChoirId } : undefined;
         this.apiService.removeUserFromChoir(user.id, opts).subscribe({
           next: () => {
-            this.snackBar.open(`${user.name} wurde aus dem Chor entfernt.`, 'OK', { duration: 3000 });
+            this.snackBar.open(`${user.name}, ${user.firstName} wurde aus dem Chor entfernt.`, 'OK', { duration: 3000 });
             this.reloadData(); // Aktualisieren Sie die Datenquelle der Tabelle
           },
           error: (err) => this.snackBar.open('Fehler beim Entfernen des Mitglieds.', 'Schließen')

--- a/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
+++ b/choir-app-frontend/src/app/features/choir-members/choir-members.component.html
@@ -2,7 +2,7 @@
   <mat-table [dataSource]="dataSource">
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-      <mat-cell *matCellDef="let m">{{ m.name }}</mat-cell>
+      <mat-cell *matCellDef="let m">{{ m.name }}, {{ m.firstName }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="voice">

--- a/choir-app-frontend/src/app/features/library/loan-cart.component.html
+++ b/choir-app-frontend/src/app/features/library/loan-cart.component.html
@@ -54,7 +54,7 @@
   <mat-card *ngIf="(user$ | async) as user">
     <mat-card-title>Kontakt</mat-card-title>
     <mat-card-content>
-      <p>{{user.name}}</p>
+      <p>{{user.name}}, {{user.firstName}}</p>
       <p>{{user.email}}</p>
     </mat-card-content>
   </mat-card>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.html
@@ -47,12 +47,12 @@
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else directorText">
           <mat-select [value]="ev.director?.id || null" (selectionChange)="updateDirector(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
-            <mat-option *ngFor="let m of availableForDate(directors, ev.date)" [value]="m.id">{{ m.name }}</mat-option>
+            <mat-option *ngFor="let m of availableForDate(directors, ev.date)" [value]="m.id">{{ m.name }}, {{ m.firstName }}</mat-option>
           </mat-select>
           <mat-icon *ngIf="ev.director?.id && isMaybe(ev.director.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-container>
         <ng-template #directorText>
-          {{ ev.director?.name }}
+          {{ ev.director?.name }}, {{ ev.director?.firstName }}
           <mat-icon *ngIf="ev.director?.id && isMaybe(ev.director.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-template>
       </mat-cell>
@@ -63,12 +63,12 @@
         <ng-container *ngIf="isChoirAdmin && !plan.finalized; else organistText">
           <mat-select [value]="ev.organist?.id || null" (selectionChange)="updateOrganist(ev, $event.value)">
             <mat-option [value]="null">--</mat-option>
-            <mat-option *ngFor="let m of availableForDate(organists, ev.date)" [value]="m.id">{{ m.name }}</mat-option>
+            <mat-option *ngFor="let m of availableForDate(organists, ev.date)" [value]="m.id">{{ m.name }}, {{ m.firstName }}</mat-option>
           </mat-select>
           <mat-icon *ngIf="ev.organist?.id && isMaybe(ev.organist.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-container>
         <ng-template #organistText>
-          {{ ev.organist?.name }}
+          {{ ev.organist?.name }}, {{ ev.organist?.firstName }}
           <mat-icon *ngIf="ev.organist?.id && isMaybe(ev.organist.id, ev.date)" class="warning-icon" color="warn" matTooltip="Nur nach Absprache verfügbar">warning</mat-icon>
         </ng-template>
       </mat-cell>
@@ -108,7 +108,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let row of counterPlanRows">
-            <td>{{ row.user.name }}</td>
+            <td>{{ row.user.name }}, {{ row.user.firstName }}</td>
             <td *ngFor="let key of counterPlanDateKeys">{{ row.assignments[key] }}</td>
           </tr>
         </tbody>

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -108,7 +108,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   }
 
   memberNamesByAvailability(date: string, status: string): string {
-    return this.membersByAvailability(date, status).map(m => m.name).join(', ') || '—';
+    return this.membersByAvailability(date, status).map(m => `${m.name}, ${m.firstName}`).join(', ') || '—';
   }
 
   private updateCounterPlan(): void {

--- a/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/request-availability-dialog/request-availability-dialog.component.html
@@ -3,7 +3,7 @@
   <p>Empfänger auswählen:</p>
   <mat-selection-list (selectionChange)="toggle($event.options[0].value, $event.options[0].selected)">
     <mat-list-option *ngFor="let m of data.members" [value]="m.id">
-      {{ m.name }} ({{ m.email }})
+      {{ m.name }}, {{ m.firstName }} ({{ m.email }})
     </mat-list-option>
   </mat-selection-list>
 </div>

--- a/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
+++ b/choir-app-frontend/src/app/features/monthly-plan/send-plan-dialog/send-plan-dialog.component.html
@@ -3,7 +3,7 @@
   <p>Empfänger auswählen:</p>
   <mat-selection-list (selectionChange)="toggle($event.options[0].value, $event.options[0].selected)">
     <mat-list-option *ngFor="let m of data.members" [value]="m.id">
-      {{ m.name }} ({{ m.email }})
+      {{ m.name }}, {{ m.firstName }} ({{ m.email }})
     </mat-list-option>
   </mat-selection-list>
   <mat-form-field appearance="outline" class="extra-emails">

--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -2,7 +2,7 @@
   <mat-table [dataSource]="members">
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-      <mat-cell *matCellDef="let m">{{ m.name }}</mat-cell>
+      <mat-cell *matCellDef="let m">{{ m.name }}, {{ m.firstName }}</mat-cell>
     </ng-container>
 
     <ng-container matColumnDef="voice">

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -120,7 +120,8 @@ export class ParticipationComponent implements OnInit {
       const va = this.voiceOrder.indexOf(this.voiceOf(a).toUpperCase());
       const vb = this.voiceOrder.indexOf(this.voiceOf(b).toUpperCase());
       if (va !== vb) return va - vb;
-      return a.name.localeCompare(b.name);
+      const ln = a.name.localeCompare(b.name);
+      return ln !== 0 ? ln : (a.firstName || '').localeCompare(b.firstName || '');
     });
   }
 

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -13,17 +13,19 @@
           <mat-card-title>Persönliche Daten</mat-card-title>
         </mat-card-header>
         <mat-card-content>
-          <mat-form-field appearance="outline">
-            <mat-label>Vorname</mat-label>
-            <input matInput formControlName="firstName">
-            <mat-error *ngIf="profileForm.get('firstName')?.hasError('required')">Vorname ist erforderlich.</mat-error>
-          </mat-form-field>
+          <div class="name-row">
+            <mat-form-field appearance="outline">
+              <mat-label>Vorname</mat-label>
+              <input matInput formControlName="firstName">
+              <mat-error *ngIf="profileForm.get('firstName')?.hasError('required')">Vorname ist erforderlich.</mat-error>
+            </mat-form-field>
 
-          <mat-form-field appearance="outline">
-            <mat-label>Nachname</mat-label>
-            <input matInput formControlName="name">
-            <mat-error *ngIf="profileForm.get('name')?.hasError('required')">Nachname ist erforderlich.</mat-error>
-          </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Nachname</mat-label>
+              <input matInput formControlName="name">
+              <mat-error *ngIf="profileForm.get('name')?.hasError('required')">Nachname ist erforderlich.</mat-error>
+            </mat-form-field>
+          </div>
 
           <mat-form-field appearance="outline">
             <mat-label>E-Mail-Adresse</mat-label>

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.scss
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.scss
@@ -9,6 +9,15 @@
     gap: 1.5rem;
 }
 
+.name-row {
+    display: flex;
+    gap: 1rem;
+
+    mat-form-field {
+        flex: 1;
+    }
+}
+
 .admin-info {
     margin-bottom: 1rem;
     font-weight: 500;


### PR DESCRIPTION
## Summary
- Display full names in member tables as `Name, Vorname`
- Add separate first and last name fields side by side in user dialogs and profile form
- Include first names in monthly plan helpers and selection dialogs

## Testing
- `npm test` *(failed: libXcomposite.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d5cd41288320a4a88b680ff1e46d