### PR TITLE
Show composer and collection in global search results

### DIFF
--- a/choir-app-backend/src/controllers/search.controller.js
+++ b/choir-app-backend/src/controllers/search.controller.js
@@ -16,7 +16,14 @@ exports.search = async (req, res) => {
         { origin: like }
       ]
     },
-    include: [{ model: db.composer, as: 'composer', attributes: ['name'] }],
+    include: [
+      { model: db.composer, as: 'composer', attributes: ['name'] },
+      {
+        model: db.collection,
+        attributes: ['id', 'prefix', 'singleEdition', 'title'],
+        through: { attributes: ['numberInCollection'] }
+      }
+    ],
     limit: 10
   });
 

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.html
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.html
@@ -6,6 +6,9 @@
     <li *ngFor="let p of results.pieces">
       <a [routerLink]="['/pieces', p.id]">{{ p.title }}</a>
       <span *ngIf="p.choir_repertoire?.rating"> (Bewertung: {{ p.choir_repertoire?.rating }})</span>
+      <div>
+        {{ p.composer?.name || p.origin }}<span *ngIf="getCollectionRef(p) as ref">, {{ ref }}</span>
+      </div>
     </li>
   </ul>
 </section>

--- a/choir-app-frontend/src/app/features/search-results/search-results.component.ts
+++ b/choir-app-frontend/src/app/features/search-results/search-results.component.ts
@@ -29,4 +29,12 @@ export class SearchResultsComponent implements OnInit {
       }
     });
   }
+
+  getCollectionRef(piece: Piece): string | null {
+    const ref = piece.collections?.find(c => !c.singleEdition);
+    if (ref) {
+      return `${ref.prefix || ''}${ref.collection_piece.numberInCollection}`;
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- Include collections when searching pieces in backend
- Display composer and collection reference beneath each piece title in global search results

## Testing
- `npm test`
- `npm run test:backend`


------
https://chatgpt.com/codex/tasks/task_e_68b9e16c1dc88320ac335c5ccee52a99