### PR TITLE
Allow creating posts without expiration date

### DIFF
--- a/choir-app-backend/src/validators/post.validation.js
+++ b/choir-app-backend/src/validators/post.validation.js
@@ -7,5 +7,5 @@ function noHtml(value) {
 exports.postValidation = [
   body('title').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
   body('text').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
-  body('expiresAt').optional().isISO8601()
+  body('expiresAt').optional({ checkFalsy: true }).isISO8601()
 ];


### PR DESCRIPTION
## Summary
- permit `expiresAt` to be omitted or empty when validating post creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9eab7cce083209df251d999dc5a9f