### PR TITLE
feat: add draft and publish flow for posts

### DIFF
--- a/choir-app-backend/src/controllers/post.controller.js
+++ b/choir-app-backend/src/controllers/post.controller.js
@@ -14,7 +14,7 @@ async function isChoirAdmin(req) {
 }
 
 exports.create = async (req, res) => {
-  const { title, text, expiresAt } = req.body;
+  const { title, text, expiresAt, sendTest, publish } = req.body;
   if (!title || !text) return res.status(400).send({ message: 'title and text required' });
   try {
     const sanitizedTitle = stripHtml(title);
@@ -25,18 +25,26 @@ exports.create = async (req, res) => {
       text: sanitizedText,
       expiresAt: expDate,
       choirId: req.activeChoirId,
-      userId: req.userId
+      userId: req.userId,
+      published: !!publish
     });
     const full = await Post.findByPk(post.id, { include: [
       { model: db.user, as: 'author', attributes: ['id','name'] }
     ] });
 
-    const members = await db.user.findAll({
-      include: [{ model: db.choir, where: { id: req.activeChoirId } }]
-    });
-    const emails = members.map(u => u.email).filter(e => e);
-    if (emails.length > 0) {
-      await emailService.sendPostNotificationMail(emails, sanitizedTitle, sanitizedText);
+    if (publish) {
+      const members = await db.user.findAll({
+        include: [{ model: db.choir, where: { id: req.activeChoirId } }]
+      });
+      const emails = members.map(u => u.email).filter(e => e);
+      if (emails.length > 0) {
+        await emailService.sendPostNotificationMail(emails, sanitizedTitle, sanitizedText);
+      }
+    } else if (sendTest) {
+      const author = await db.user.findByPk(req.userId);
+      if (author?.email) {
+        await emailService.sendPostNotificationMail([author.email], sanitizedTitle, sanitizedText);
+      }
     }
 
     res.status(201).send(full);
@@ -50,10 +58,20 @@ exports.findAll = async (req, res) => {
     const admin = await isChoirAdmin(req);
     const where = { choirId: req.activeChoirId };
     if (!admin) {
-      where[Op.or] = [
-        { expiresAt: null },
-        { expiresAt: { [Op.gt]: new Date() } },
-        { userId: req.userId }
+      where[Op.and] = [
+        {
+          [Op.or]: [
+            { expiresAt: null },
+            { expiresAt: { [Op.gt]: new Date() } },
+            { userId: req.userId }
+          ]
+        },
+        {
+          [Op.or]: [
+            { published: true },
+            { userId: req.userId }
+          ]
+        }
       ];
     }
     const posts = await Post.findAll({
@@ -74,10 +92,20 @@ exports.findLatest = async (req, res) => {
     const admin = await isChoirAdmin(req);
     const where = { choirId: req.activeChoirId };
     if (!admin) {
-      where[Op.or] = [
-        { expiresAt: null },
-        { expiresAt: { [Op.gt]: new Date() } },
-        { userId: req.userId }
+      where[Op.and] = [
+        {
+          [Op.or]: [
+            { expiresAt: null },
+            { expiresAt: { [Op.gt]: new Date() } },
+            { userId: req.userId }
+          ]
+        },
+        {
+          [Op.or]: [
+            { published: true },
+            { userId: req.userId }
+          ]
+        }
       ];
     }
     const post = await Post.findOne({
@@ -95,7 +123,7 @@ exports.findLatest = async (req, res) => {
 
 exports.update = async (req, res) => {
   const id = req.params.id;
-  const { title, text, expiresAt } = req.body;
+  const { title, text, expiresAt, sendTest } = req.body;
   if (!title || !text) return res.status(400).send({ message: 'title and text required' });
   try {
     const post = await Post.findByPk(id);
@@ -109,6 +137,36 @@ exports.update = async (req, res) => {
     const full = await Post.findByPk(id, { include: [
       { model: db.user, as: 'author', attributes: ['id','name'] }
     ] });
+    if (sendTest) {
+      const author = await db.user.findByPk(req.userId);
+      if (author?.email) {
+        await emailService.sendPostNotificationMail([author.email], sanitizedTitle, sanitizedText);
+      }
+    }
+    res.status(200).send(full);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.publish = async (req, res) => {
+  const id = req.params.id;
+  try {
+    const post = await Post.findByPk(id);
+    if (!post || post.choirId !== req.activeChoirId) return res.status(404).send({ message: 'Post not found' });
+    const admin = await isChoirAdmin(req);
+    if (post.userId !== req.userId && !admin) return res.status(403).send({ message: 'Not allowed' });
+    await post.update({ published: true });
+    const full = await Post.findByPk(id, { include: [
+      { model: db.user, as: 'author', attributes: ['id','name'] }
+    ] });
+    const members = await db.user.findAll({
+      include: [{ model: db.choir, where: { id: req.activeChoirId } }]
+    });
+    const emails = members.map(u => u.email).filter(e => e);
+    if (emails.length > 0) {
+      await emailService.sendPostNotificationMail(emails, full.title, full.text);
+    }
     res.status(200).send(full);
   } catch (err) {
     res.status(500).send({ message: err.message });

--- a/choir-app-backend/src/models/post.model.js
+++ b/choir-app-backend/src/models/post.model.js
@@ -11,6 +11,11 @@ module.exports = (sequelize, DataTypes) => {
     expiresAt: {
       type: DataTypes.DATE,
       allowNull: true
+    },
+    published: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
     }
   });
   return Post;

--- a/choir-app-backend/src/routes/post.routes.js
+++ b/choir-app-backend/src/routes/post.routes.js
@@ -13,5 +13,6 @@ router.get('/', wrap(controller.findAll));
 router.post('/', role.requireDirector, postValidation, validate, wrap(controller.create));
 router.put('/:id', postValidation, validate, wrap(controller.update));
 router.delete('/:id', wrap(controller.remove));
+router.post('/:id/publish', wrap(controller.publish));
 
 module.exports = router;

--- a/choir-app-backend/src/validators/post.validation.js
+++ b/choir-app-backend/src/validators/post.validation.js
@@ -7,5 +7,7 @@ function noHtml(value) {
 exports.postValidation = [
   body('title').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
   body('text').isString().notEmpty().custom(noHtml).withMessage('HTML not allowed'),
-  body('expiresAt').optional().isISO8601()
+  body('expiresAt').optional().isISO8601(),
+  body('sendTest').optional().isBoolean(),
+  body('publish').optional().isBoolean()
 ];

--- a/choir-app-backend/tests/post.controller.test.js
+++ b/choir-app-backend/tests/post.controller.test.js
@@ -19,10 +19,11 @@ const controller = require('../src/controllers/post.controller');
     const past = new Date(now.getTime() - 86400000);
 
     // create posts directly to avoid email side effects
-    const p1 = await db.post.create({ title: 'p1', text: 't1', choirId: choir.id, userId: user1.id });
-    const p2 = await db.post.create({ title: 'p2', text: 't2', choirId: choir.id, userId: user2.id, expiresAt: future });
-    const p3 = await db.post.create({ title: 'p3', text: 't3', choirId: choir.id, userId: user2.id, expiresAt: past });
-    const p4 = await db.post.create({ title: 'p4', text: 't4', choirId: choir.id, userId: user1.id, expiresAt: past });
+    const p1 = await db.post.create({ title: 'p1', text: 't1', choirId: choir.id, userId: user1.id, published: true });
+    const p2 = await db.post.create({ title: 'p2', text: 't2', choirId: choir.id, userId: user2.id, expiresAt: future, published: true });
+    const p3 = await db.post.create({ title: 'p3', text: 't3', choirId: choir.id, userId: user2.id, expiresAt: past, published: true });
+    const p4 = await db.post.create({ title: 'p4', text: 't4', choirId: choir.id, userId: user1.id, expiresAt: past, published: true });
+    const p5 = await db.post.create({ title: 'p5', text: 't5', choirId: choir.id, userId: user2.id, published: false });
 
     const res = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
 
@@ -38,6 +39,12 @@ const controller = require('../src/controllers/post.controller');
     const ids3 = res.data.map(p => p.id).sort();
     assert.deepStrictEqual(ids3, [p1.id, p2.id].sort());
 
+    // user2 should see p1, p2, p3, p5 (own draft)
+    await controller.findAll({ activeChoirId: choir.id, userId: user2.id, userRoles: [] }, res);
+    assert.strictEqual(res.statusCode, 200);
+    const ids2 = res.data.map(p => p.id).sort();
+    assert.deepStrictEqual(ids2, [p1.id, p2.id, p3.id, p5.id].sort());
+
     // latest for user3 should be p2
     await controller.findLatest({ activeChoirId: choir.id, userId: user3.id, userRoles: [] }, res);
     assert.strictEqual(res.statusCode, 200);
@@ -47,6 +54,11 @@ const controller = require('../src/controllers/post.controller');
     await controller.findLatest({ activeChoirId: choir.id, userId: user1.id, userRoles: [] }, res);
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.data.id, p4.id);
+
+    // latest for user2 should be p5 (own unpublished)
+    await controller.findLatest({ activeChoirId: choir.id, userId: user2.id, userRoles: [] }, res);
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.data.id, p5.id);
 
     console.log('post.controller tests passed');
     await db.sequelize.close();

--- a/choir-app-frontend/src/app/core/models/post.ts
+++ b/choir-app-frontend/src/app/core/models/post.ts
@@ -7,5 +7,6 @@ export interface Post {
   createdAt: string;
   updatedAt: string;
   expiresAt?: string | null;
+  published: boolean;
   author?: { id: number; name: string };
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -777,12 +777,16 @@ export class ApiService {
     return this.postService.getLatestPost();
   }
 
-  createPost(data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
+  createPost(data: { title: string; text: string; expiresAt?: string | null; sendTest?: boolean }): Observable<Post> {
     return this.postService.createPost(data);
   }
 
-  updatePost(id: number, data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
+  updatePost(id: number, data: { title: string; text: string; expiresAt?: string | null; sendTest?: boolean }): Observable<Post> {
     return this.postService.updatePost(id, data);
+  }
+
+  publishPost(id: number): Observable<Post> {
+    return this.postService.publishPost(id);
   }
 
   deletePost(id: number): Observable<any> {

--- a/choir-app-frontend/src/app/core/services/post.service.ts
+++ b/choir-app-frontend/src/app/core/services/post.service.ts
@@ -17,12 +17,16 @@ export class PostService {
     return this.http.get<Post | null>(`${this.apiUrl}/posts/latest`);
   }
 
-  createPost(data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
+  createPost(data: { title: string; text: string; expiresAt?: string | null; sendTest?: boolean }): Observable<Post> {
     return this.http.post<Post>(`${this.apiUrl}/posts`, data);
   }
 
-  updatePost(id: number, data: { title: string; text: string; expiresAt?: string | null }): Observable<Post> {
+  updatePost(id: number, data: { title: string; text: string; expiresAt?: string | null; sendTest?: boolean }): Observable<Post> {
     return this.http.put<Post>(`${this.apiUrl}/posts/${id}`, data);
+  }
+
+  publishPost(id: number): Observable<Post> {
+    return this.http.post<Post>(`${this.apiUrl}/posts/${id}/publish`, {});
   }
 
   deletePost(id: number): Observable<any> {

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.html
@@ -28,6 +28,7 @@
       <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-datepicker #picker></mat-datepicker>
     </mat-form-field>
+    <mat-checkbox formControlName="sendTest">Test-E-Mail an mich senden</mat-checkbox>
   </form>
 </div>
 <div mat-dialog-actions>

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.ts
@@ -26,7 +26,8 @@ export class PostDialogComponent {
     this.form = this.fb.group({
       title: ['', Validators.required],
       text: ['', Validators.required],
-      expiresAt: [null]
+      expiresAt: [null],
+      sendTest: [false]
     });
     if (data?.post) {
       this.isEdit = true;
@@ -77,7 +78,7 @@ export class PostDialogComponent {
   save(): void {
     if (this.form.valid) {
       const expiresAt = this.form.value.expiresAt ? this.form.value.expiresAt.toISOString() : null;
-      this.dialogRef.close({ title: this.form.value.title, text: this.form.value.text, expiresAt });
+      this.dialogRef.close({ title: this.form.value.title, text: this.form.value.text, expiresAt, sendTest: this.form.value.sendTest });
     }
   }
 

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -7,13 +7,14 @@
     <mat-card *ngFor="let p of posts" class="post" id="post-{{ p.id }}">
       <mat-card-header>
         <mat-card-title>{{ p.title }}</mat-card-title>
-        <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }}</mat-card-subtitle>
+        <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }} <span *ngIf="!p.published">(Entwurf)</span></mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
         <div [innerHTML]="p.text | markdown"></div>
         <div *ngIf="p.expiresAt" class="expires">Sichtbar bis {{ p.expiresAt | date:'shortDate' }}</div>
       </mat-card-content>
       <mat-card-actions *ngIf="canEdit(p)" class="actions">
+        <button mat-button color="accent" (click)="publishPost(p)" *ngIf="!p.published">Veröffentlichen</button>
         <button mat-icon-button (click)="editPost(p)" matTooltip="Bearbeiten"><mat-icon>edit</mat-icon></button>
         <button mat-icon-button (click)="deletePost(p)" matTooltip="Löschen"><mat-icon>delete</mat-icon></button>
       </mat-card-actions>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -99,6 +99,13 @@ export class PostListComponent implements OnInit {
     });
   }
 
+  publishPost(post: Post): void {
+    this.api.publishPost(post.id).subscribe({
+      next: () => { this.snackBar.open('Beitrag veröffentlicht', 'OK', { duration: 3000 }); this.loadPosts(); },
+      error: () => this.snackBar.open('Fehler beim Veröffentlichen', 'Schließen', { duration: 4000 })
+    });
+  }
+
   deletePost(post: Post): void {
     const data: ConfirmDialogData = { title: 'Beitrag löschen?', message: 'Möchten Sie diesen Beitrag wirklich löschen?' };
     const ref = this.dialog.open(ConfirmDialogComponent, { data });


### PR DESCRIPTION
## Summary
- allow saving posts as drafts and sending test emails before publishing
- add publish endpoint and button to make posts visible to choir members
- adjust queries and tests for draft awareness

## Testing
- `node tests/post.controller.test.js`
- `npm test` (frontend) *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e99f5bf88320838ac8d52399ca78