### PR TITLE
Render Markdown for latest post on dashboard

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -53,7 +53,7 @@
   role="link">
   <h2>Neuster Beitrag</h2>
   <h3>{{ post.title }}</h3>
-  <p>{{ post.text }}</p>
+  <div [innerHTML]="post.text | markdown"></div>
   <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
 </div>
 

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -14,6 +14,7 @@ import { Program, ProgramItem } from '@core/models/program';
 import { EventDialogComponent } from '../../events/event-dialog/event-dialog.component';
 import { Piece } from '@core/models/piece';
 import { EventCardComponent } from '../event-card/event-card.component';
+import { MarkdownPipe } from '@shared/pipes/markdown.pipe';
 import { AuthService } from '@core/services/auth.service';
 import { Choir } from '@core/models/choir';
 import { PieceChange } from '@core/models/piece-change';
@@ -31,7 +32,8 @@ import { LibraryItem } from '@core/models/library-item';
     RouterModule,
     MaterialModule,
     FormsModule,
-    EventCardComponent
+    EventCardComponent,
+    MarkdownPipe
   ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss']


### PR DESCRIPTION
## Summary
- Display latest post on dashboard using Markdown formatting for line breaks and styling
- Import MarkdownPipe in dashboard component to enable Markdown rendering

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eb7030248320835fb7a150f90f47