### PR TITLE
Render post emails as HTML with choir signature

### DIFF
--- a/choir-app-backend/package-lock.json
+++ b/choir-app-backend/package-lock.json
@@ -19,6 +19,7 @@
         "express-validator": "^6.15.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.0",
+        "marked": "^12.0.2",
         "multer": "^2.0.1",
         "nodemailer": "^7.0.3",
         "pg": "^8.9.0",
@@ -2563,6 +2564,18 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/choir-app-backend/package.json
+++ b/choir-app-backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.enrich.test.js && node tests/creator.duplicate.test.js && node tests/join.controller.test.js && node tests/program.controller.test.js && node tests/post.controller.test.js && node tests/emailTemplateManager.test.js && node tests/emailTransporter.test.js && node tests/frontend-url.test.js && node tests/user.controller.test.js && node tests/admin.controller.test.js && node tests/program.validation.test.js",
+    "test": "node tests/models.test.js && node tests/piece.controller.test.js && node tests/event.controller.test.js && node tests/monthlyPlan.controller.test.js && node tests/import.controller.test.js && node tests/search.controller.test.js && node tests/choir-management.controller.test.js && node tests/holiday.service.test.js && node tests/availability.controller.test.js && node tests/piece.validation.test.js && node tests/collection.validation.test.js && node tests/library.controller.test.js && node tests/loan-request.controller.test.js && node tests/creator.enrich.test.js && node tests/creator.duplicate.test.js && node tests/join.controller.test.js && node tests/program.controller.test.js && node tests/post.controller.test.js && node tests/emailTemplateManager.test.js && node tests/email.service.test.js && node tests/emailTransporter.test.js && node tests/frontend-url.test.js && node tests/user.controller.test.js && node tests/admin.controller.test.js && node tests/program.validation.test.js",
     "check": "node --check server.js",
     "lint": "eslint src/**/*.js",
     "init": "node scripts/init.js",
@@ -25,6 +25,7 @@
     "express-validator": "^6.15.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.0",
+    "marked": "^12.0.2",
     "multer": "^2.0.1",
     "nodemailer": "^7.0.3",
     "pg": "^8.9.0",

--- a/choir-app-backend/src/controllers/post.controller.js
+++ b/choir-app-backend/src/controllers/post.controller.js
@@ -34,9 +34,10 @@ exports.create = async (req, res) => {
     const members = await db.user.findAll({
       include: [{ model: db.choir, where: { id: req.activeChoirId } }]
     });
+    const choir = await db.choir.findByPk(req.activeChoirId);
     const emails = members.map(u => u.email).filter(e => e);
-    if (emails.length > 0) {
-      await emailService.sendPostNotificationMail(emails, sanitizedTitle, sanitizedText);
+    if (emails.length > 0 && choir) {
+      await emailService.sendPostNotificationMail(emails, sanitizedTitle, sanitizedText, choir.name);
     }
 
     res.status(201).send(full);

--- a/choir-app-backend/tests/email.service.test.js
+++ b/choir-app-backend/tests/email.service.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_NAME = ':memory:';
+const { buildPostEmail } = require('../src/services/email.service');
+
+(async () => {
+  try {
+    const { html, text } = buildPostEmail('**Hallo** Welt', 'Testchor');
+    assert.ok(html.includes('<strong>Hallo</strong> Welt'), 'Markdown not converted');
+    assert.ok(html.includes('Testchor'), 'Choir name missing in html');
+    assert.ok(html.includes('https://nak-chorleiter.de'), 'Link missing in html');
+    assert.ok(text.includes('Testchor'), 'Choir name missing in text');
+    assert.ok(text.includes('https://nak-chorleiter.de'), 'Link missing in text');
+    console.log('email.service tests passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- convert post notification emails to HTML using Markdown parsing
- append choir name and nak-chorleiter.de link as signature
- add unit test for post email markup

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b9ee2529748320829c3e32693616e4