### PR TITLE
feat: replace piece refs in markdown pipe

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -53,7 +53,7 @@
   role="link">
   <h2>Neuster Beitrag</h2>
   <h3>{{ post.title }}</h3>
-  <div [innerHTML]="post.text | markdown"></div>
+  <div [innerHTML]="post.text | markdown | async"></div>
   <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
 </div>
 

--- a/choir-app-frontend/src/app/features/posts/post-dialog.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-dialog.component.html
@@ -21,7 +21,7 @@
       <p><code>- Liste</code></p>
     </mat-expansion-panel>
     <h3>Vorschau</h3>
-    <div class="preview" [innerHTML]="form.get('text')?.value | markdown"></div>
+    <div class="preview" [innerHTML]="form.get('text')?.value | markdown | async"></div>
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Ablaufdatum</mat-label>
       <input matInput [matDatepicker]="picker" formControlName="expiresAt">

--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -10,7 +10,7 @@
         <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }} <span *ngIf="!p.published">(Entwurf)</span></mat-card-subtitle>
       </mat-card-header>
       <mat-card-content>
-        <div [innerHTML]="p.text | markdown"></div>
+        <div [innerHTML]="p.text | markdown | async"></div>
         <div *ngIf="p.expiresAt" class="expires">Sichtbar bis {{ p.expiresAt | date:'shortDate' }}</div>
       </mat-card-content>
       <mat-card-actions *ngIf="canEdit(p)" class="actions">

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -10,7 +10,6 @@ import { AuthService } from '@core/services/auth.service';
 import { PostDialogComponent } from './post-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { MarkdownPipe } from '@shared/pipes/markdown.pipe';
-import { forkJoin } from 'rxjs';
 
 @Component({
   selector: 'app-post-list',
@@ -46,28 +45,10 @@ export class PostListComponent implements OnInit {
   loadPosts(): void {
     this.api.getPosts().subscribe(p => {
       this.posts = p;
-      this.replacePieceReferences();
       const fragment = this.route.snapshot.fragment;
       if (fragment) {
         setTimeout(() => document.getElementById(fragment)?.scrollIntoView({ behavior: 'smooth' }), 0);
       }
-    });
-  }
-
-  private replacePieceReferences(): void {
-    const ids = Array.from(new Set(this.posts.flatMap(post =>
-      Array.from(post.text.matchAll(/\{\{(\d+)\}\}/g)).map(m => +m[1])
-    )));
-    if (!ids.length) return;
-    forkJoin(ids.map(id => this.api.getPieceById(id))).subscribe(pieces => {
-      const map = new Map(pieces.map(p => [p.id, p.title]));
-      this.posts = this.posts.map(post => ({
-        ...post,
-        text: post.text.replace(/\{\{(\d+)\}\}/g, (match, id) => {
-          const title = map.get(+id);
-          return title ? `[${title}](\/pieces\/${id})` : match;
-        })
-      }));
     });
   }
 

--- a/choir-app-frontend/src/app/shared/pipes/markdown.pipe.ts
+++ b/choir-app-frontend/src/app/shared/pipes/markdown.pipe.ts
@@ -1,18 +1,38 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { ApiService } from '@core/services/api.service';
+import { Piece } from '@core/models/piece';
+import { forkJoin, map, Observable, of } from 'rxjs';
 
 @Pipe({
   name: 'markdown',
   standalone: true
 })
 export class MarkdownPipe implements PipeTransform {
-  constructor(private sanitizer: DomSanitizer) {}
-  transform(value: string): SafeHtml {
-    if (!value) return '';
-    const html = marked.parse(value) as string;
-    const sanitized = DOMPurify.sanitize(html);
-    return this.sanitizer.bypassSecurityTrustHtml(sanitized);
+  private pieceCache = new Map<number, string>();
+  private sanitizer = inject(DomSanitizer);
+  private api = inject(ApiService);
+
+  transform(value: string): Observable<SafeHtml> {
+    if (!value) return of('');
+
+    const ids = Array.from(new Set(Array.from(value.matchAll(/\{\{(\d+)\}\}/g)).map(m => +m[1])));
+    const missing = ids.filter(id => !this.pieceCache.has(id));
+    const pieces$ = missing.length ? forkJoin(missing.map(id => this.api.getPieceById(id))) : of<Piece[]>([]);
+
+    return pieces$.pipe(
+      map((pieces: Piece[]) => {
+        pieces.forEach(p => this.pieceCache.set(p.id, p.title));
+        const replaced = value.replace(/\{\{(\d+)\}\}/g, (match, id) => {
+          const title = this.pieceCache.get(+id);
+          return title ? `[${title}](/pieces/${id})` : match;
+        });
+        const html = marked.parse(replaced) as string;
+        const sanitized = DOMPurify.sanitize(html);
+        return this.sanitizer.bypassSecurityTrustHtml(sanitized);
+      })
+    );
   }
 }


### PR DESCRIPTION
## Summary
- replace `{{id}}` placeholders with piece links inside MarkdownPipe
- remove manual reference replacement from post list
- update templates to await async markdown pipe

## Testing
- `npm run lint --prefix choir-app-frontend` *(fails: 679 errors)*
- `npm test --prefix choir-app-frontend` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f4492bf48320acf27ef0ab59c298