### PR TITLE
Add admin mail log for sent emails

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -238,6 +238,24 @@ exports.getLoginAttempts = async (req, res) => {
     }
 };
 
+exports.getMailLogs = async (req, res) => {
+    try {
+        const logs = await db.mail_log.findAll({ order: [['createdAt', 'DESC']] });
+        res.status(200).send(logs);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.clearMailLogs = async (req, res) => {
+    try {
+        await db.mail_log.destroy({ where: {} });
+        res.status(200).send({ message: 'Deleted' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
 // Recalculate repertoire statuses for all choirs based on past events
 exports.recalculatePieceStatuses = async (req, res) => {
     try {

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -39,6 +39,7 @@ db.repertoire_filter = require("./repertoire_filter.model.js")(sequelize, Sequel
 db.login_attempt = require("./login_attempt.model.js")(sequelize, Sequelize);
 db.mail_setting = require("./mail_setting.model.js")(sequelize, Sequelize);
 db.mail_template = require("./mail_template.model.js")(sequelize, Sequelize);
+db.mail_log = require("./mail_log.model.js")(sequelize, Sequelize);
 db.system_setting = require("./system_setting.model.js")(sequelize, Sequelize);
 db.post = require("./post.model.js")(sequelize, Sequelize);
 db.library_item = require("./library_item.model.js")(sequelize, Sequelize);

--- a/choir-app-backend/src/models/mail_log.model.js
+++ b/choir-app-backend/src/models/mail_log.model.js
@@ -1,0 +1,17 @@
+module.exports = (sequelize, DataTypes) => {
+  const MailLog = sequelize.define('mail_log', {
+    recipients: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    },
+    subject: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    body: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    }
+  });
+  return MailLog;
+};

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -34,6 +34,8 @@ router.put("/users/:id", wrap(controller.updateUser));
 router.delete("/users/:id", wrap(controller.deleteUser));
 router.post("/users/:id/send-password-reset", wrap(controller.sendPasswordReset));
 router.get("/login-attempts", wrap(controller.getLoginAttempts));
+router.get('/mail-logs', wrap(controller.getMailLogs));
+router.delete('/mail-logs', wrap(controller.clearMailLogs));
 
 router.get('/logs', wrap(controller.listLogs));
 router.get('/logs/:filename', wrap(controller.getLog));

--- a/choir-app-backend/src/services/emailTransporter.js
+++ b/choir-app-backend/src/services/emailTransporter.js
@@ -44,7 +44,22 @@ async function sendMail(options, overrideSettings) {
     mailOptions.to = 'no-reply@nak-chorleiter.de';
   }
 
-  return transporter.sendMail(mailOptions);
+  const result = await transporter.sendMail(mailOptions);
+
+  try {
+    const db = require('../models');
+    if (db && db.mail_log) {
+      await db.mail_log.create({
+        recipients: recipients.join(', '),
+        subject: mailOptions.subject,
+        body: mailOptions.text || mailOptions.html || ''
+      }).catch(() => {});
+    }
+  } catch (err) {
+    // Ignore logging errors
+  }
+
+  return result;
 }
 
 module.exports = { emailDisabled, createTransporter, getFromAddress, sendMail };

--- a/choir-app-frontend/src/app/core/models/mail-log.ts
+++ b/choir-app-frontend/src/app/core/models/mail-log.ts
@@ -1,0 +1,7 @@
+export interface MailLog {
+  id: number;
+  recipients: string;
+  subject?: string | null;
+  body?: string | null;
+  createdAt: string;
+}

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -11,6 +11,7 @@ import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
 import { SystemAdminEmail } from '../models/system-admin-email';
 import { UploadOverview } from '../models/backend-file';
+import { MailLog } from '../models/mail-log';
 
 @Injectable({ providedIn: 'root' })
 export class AdminService {
@@ -94,6 +95,14 @@ export class AdminService {
 
   deleteLog(filename: string): Observable<any> {
     return this.http.delete(`${this.apiUrl}/admin/logs/${encodeURIComponent(filename)}`);
+  }
+
+  getMailLogs(): Observable<MailLog[]> {
+    return this.http.get<MailLog[]>(`${this.apiUrl}/admin/mail-logs`);
+  }
+
+  clearMailLogs(): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/admin/mail-logs`);
   }
 
   listUploadFiles(): Observable<UploadOverview> {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -43,6 +43,7 @@ import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
 import { SystemAdminEmail } from '../models/system-admin-email';
 import { UploadOverview } from '../models/backend-file';
+import { MailLog } from '../models/mail-log';
 import { FilterPresetService } from './filter-preset.service';
 import { UserAvailability } from '../models/user-availability';
 import { MemberAvailability } from '../models/member-availability';
@@ -694,6 +695,14 @@ export class ApiService {
 
   deleteLog(filename: string): Observable<any> {
     return this.adminService.deleteLog(filename);
+  }
+
+  getMailLogs(): Observable<MailLog[]> {
+    return this.adminService.getMailLogs();
+  }
+
+  clearMailLogs(): Observable<any> {
+    return this.adminService.clearMailLogs();
   }
 
   listUploadFiles(): Observable<UploadOverview> {

--- a/choir-app-frontend/src/app/features/admin/mail-logs/mail-logs.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-logs/mail-logs.component.html
@@ -1,0 +1,24 @@
+<div class="mail-logs">
+  <button mat-raised-button color="warn" (click)="clearLogs()" *ngIf="logs.length">Logs löschen</button>
+  <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+    <ng-container matColumnDef="createdAt">
+      <th mat-header-cell *matHeaderCellDef>Datum</th>
+      <td mat-cell *matCellDef="let log">{{ log.createdAt | date:'short' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="recipients">
+      <th mat-header-cell *matHeaderCellDef>Empfänger</th>
+      <td mat-cell *matCellDef="let log">{{ log.recipients }}</td>
+    </ng-container>
+    <ng-container matColumnDef="subject">
+      <th mat-header-cell *matHeaderCellDef>Betreff</th>
+      <td mat-cell *matCellDef="let log">{{ log.subject }}</td>
+    </ng-container>
+    <ng-container matColumnDef="body">
+      <th mat-header-cell *matHeaderCellDef>Inhalt</th>
+      <td mat-cell *matCellDef="let log">{{ log.body }}</td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</div>

--- a/choir-app-frontend/src/app/features/admin/mail-logs/mail-logs.component.scss
+++ b/choir-app-frontend/src/app/features/admin/mail-logs/mail-logs.component.scss
@@ -1,0 +1,6 @@
+.mail-logs {
+  table {
+    width: 100%;
+    margin-top: 1rem;
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/mail-logs/mail-logs.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-logs/mail-logs.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from 'src/app/core/services/api.service';
+import { MatTableDataSource } from '@angular/material/table';
+import { MailLog } from 'src/app/core/models/mail-log';
+
+@Component({
+  selector: 'app-mail-logs',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './mail-logs.component.html',
+  styleUrls: ['./mail-logs.component.scss']
+})
+export class MailLogsComponent implements OnInit {
+  logs: MailLog[] = [];
+  displayedColumns = ['createdAt', 'recipients', 'subject', 'body'];
+  dataSource = new MatTableDataSource<MailLog>();
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.loadLogs();
+  }
+
+  loadLogs(): void {
+    this.api.getMailLogs().subscribe(data => {
+      this.logs = data;
+      this.dataSource.data = data;
+    });
+  }
+
+  clearLogs(): void {
+    this.api.clearMailLogs().subscribe(() => {
+      this.logs = [];
+      this.dataSource.data = [];
+    });
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/protocols/protocols.component.html
+++ b/choir-app-frontend/src/app/features/admin/protocols/protocols.component.html
@@ -5,4 +5,7 @@
   <mat-tab label="Logs">
     <app-log-viewer></app-log-viewer>
   </mat-tab>
+  <mat-tab label="Mails">
+    <app-mail-logs></app-mail-logs>
+  </mat-tab>
 </mat-tab-group>

--- a/choir-app-frontend/src/app/features/admin/protocols/protocols.component.ts
+++ b/choir-app-frontend/src/app/features/admin/protocols/protocols.component.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { LoginAttemptsComponent } from '../login-attempts/login-attempts.component';
 import { LogViewerComponent } from '../log-viewer/log-viewer.component';
+import { MailLogsComponent } from '../mail-logs/mail-logs.component';
 
 @Component({
   selector: 'app-protocols',
   standalone: true,
-  imports: [CommonModule, MaterialModule, LoginAttemptsComponent, LogViewerComponent],
+  imports: [CommonModule, MaterialModule, LoginAttemptsComponent, LogViewerComponent, MailLogsComponent],
   templateUrl: './protocols.component.html',
   styleUrls: ['./protocols.component.scss']
 })


### PR DESCRIPTION
## Summary
- store each sent email in new `mail_logs` table with recipients and content
- expose admin API and Angular UI to list and clear mail logs
- log emails on send and show them in new admin "Mails" tab

## Testing
- `npm run lint --prefix choir-app-backend` *(fails: no-unused-vars etc.)*
- `npm test --prefix choir-app-backend`
- `npm run lint --prefix choir-app-frontend` *(fails: multiple lint errors)*
- `npm test --prefix choir-app-frontend` *(fails: missing ChromeHeadless dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f69da3e4832097658d45e74b8d72