### PR TITLE
Fix test post sending without choir name

### DIFF
--- a/choir-app-backend/src/controllers/post.controller.js
+++ b/choir-app-backend/src/controllers/post.controller.js
@@ -45,7 +45,8 @@ exports.create = async (req, res) => {
     } else if (sendTest) {
       const author = await db.user.findByPk(req.userId);
       if (author?.email) {
-        await emailService.sendPostNotificationMail([author.email], sanitizedTitle, sanitizedText. choir.name);
+        const choir = await db.choir.findByPk(req.activeChoirId);
+        await emailService.sendPostNotificationMail([author.email], sanitizedTitle, sanitizedText, choir?.name);
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent crash when creating a test post without choir info by loading choir before sending email

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f87d1b8c8320b2f30d26378fb1a6