### PR TITLE
feat: replace piece placeholders in emails

### DIFF
--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -14,12 +14,23 @@ async function sendTemplateMail(type, to, replacements = {}, overrideSettings) {
   await sendMail({ to, subject, html, text }, overrideSettings);
 }
 
-function buildPostEmail(text, choirName) {
-  const body = marked.parse(text);
+async function buildPostEmail(text, choirName) {
+  const linkBase = await getFrontendUrl();
+  const ids = Array.from(new Set(Array.from(text.matchAll(/\{\{(\d+)\}\}/g)).map(m => +m[1])));
+  let replaced = text;
+  if (ids.length) {
+    const pieces = await db.piece.findAll({ where: { id: ids } });
+    const titles = new Map(pieces.map(p => [p.id, p.title]));
+    replaced = text.replace(/\{\{(\d+)\}\}/g, (match, id) => {
+      const title = titles.get(+id);
+      return title ? `[${title}](${linkBase}/pieces/${id})` : match;
+    });
+  }
+  const body = marked.parse(replaced);
   const signatureHtml = `<p>--<br>${choirName}<br><a href="https://nak-chorleiter.de">nak-chorleiter.de</a></p>`;
   const html = `${body}${signatureHtml}`;
   const textSignature = `\n\n--\n${choirName}\nhttps://nak-chorleiter.de`;
-  const plainText = `${text}${textSignature}`;
+  const plainText = `${replaced}${textSignature}`;
   return { html, text: plainText };
 }
 
@@ -176,7 +187,7 @@ exports.sendPieceChangeProposalMail = async (to, piece, proposer, link) => {
 exports.sendPostNotificationMail = async (recipients, title, text, choirName) => {
   if (emailDisabled() || !Array.isArray(recipients) || recipients.length === 0) return;
   try {
-    const { html, text: plainText } = buildPostEmail(text, choirName);
+    const { html, text: plainText } = await buildPostEmail(text, choirName);
     await sendMail({ to: recipients, subject: title, text: plainText, html });
   } catch (err) {
     logger.error(`Error sending post mail: ${err.message}`);

--- a/choir-app-backend/tests/email.service.test.js
+++ b/choir-app-backend/tests/email.service.test.js
@@ -1,19 +1,27 @@
 const assert = require('assert');
 process.env.DB_DIALECT = 'sqlite';
 process.env.DB_NAME = ':memory:';
+const db = require('../src/models');
 const { buildPostEmail } = require('../src/services/email.service');
 
 (async () => {
   try {
-    const { html, text } = buildPostEmail('**Hallo** Welt', 'Testchor');
-    assert.ok(html.includes('<strong>Hallo</strong> Welt'), 'Markdown not converted');
+    await db.sequelize.sync({ force: true });
+    await db.piece.create({ id: 1, title: 'Teststück' });
+    const { html, text } = await buildPostEmail('**Hallo** {{1}}', 'Testchor');
+    assert.ok(html.includes('<strong>Hallo</strong>'), 'Markdown not converted');
     assert.ok(html.includes('Testchor'), 'Choir name missing in html');
     assert.ok(html.includes('https://nak-chorleiter.de'), 'Link missing in html');
+    assert.ok(html.includes('<a href="https://nak-chorleiter.de/pieces/1">Teststück</a>'), 'Piece link missing in html');
     assert.ok(text.includes('Testchor'), 'Choir name missing in text');
     assert.ok(text.includes('https://nak-chorleiter.de'), 'Link missing in text');
+    assert.ok(text.includes('[Teststück](https://nak-chorleiter.de/pieces/1)'), 'Piece link missing in text');
     console.log('email.service tests passed');
+    await db.sequelize.close();
   } catch (err) {
     console.error(err);
+    await db.sequelize.close();
     process.exit(1);
   }
 })();
+


### PR DESCRIPTION
## Summary
- expand post email builder to resolve `{{id}}` piece placeholders to titled links
- test piece placeholder rendering in plain text and HTML

## Testing
- `npm test --prefix choir-app-backend`

------
https://chatgpt.com/codex/tasks/task_e_68b9fd6e6cd883209d266a79a8892855