### PR TITLE
Fix missing body in post notification emails

### DIFF
--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -187,7 +187,7 @@ exports.sendPieceChangeProposalMail = async (to, piece, proposer, link) => {
 exports.sendPostNotificationMail = async (recipients, title, text, choirName, from) => {
   if (emailDisabled() || !Array.isArray(recipients) || recipients.length === 0) return;
   try {
-    const { html, text: plainText } = buildPostEmail(text, choirName);
+    const { html, text: plainText } = await buildPostEmail(text, choirName);
     const options = { to: recipients, subject: title, text: plainText, html };
     if (from) options.from = from;
     await sendMail(options);


### PR DESCRIPTION
## Summary
- ensure post notification emails await Markdown rendering before sending

## Testing
- `npm test` *(fails: could not capture full output; no errors observed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba043fb2888320a109f4b854e0a3dd