### PR TITLE
Avoid NaN in previousSunday by removing loop

### DIFF
--- a/choir-app-frontend/src/app/shared/util/holiday.ts
+++ b/choir-app-frontend/src/app/shared/util/holiday.ts
@@ -24,9 +24,8 @@ function sameDate(a: Date, b: Date): boolean {
 
 function previousSunday(date: Date): Date {
   const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-  while (d.getUTCDay() !== 0) {
-    d.setUTCDate(d.getUTCDate() - 1);
-  }
+  const diff = d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() - diff);
   return d;
 }
 


### PR DESCRIPTION
## Summary
- simplify previousSunday calculation to subtract weekday offset instead of looping

## Testing
- `npm test` *(fails: ChromeHeadless failed to start: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb48662468832091a730271815fd95