### PR TITLE
Fix UTC date parsing for monthly plan

### DIFF
--- a/choir-app-backend/src/utils/date.utils.js
+++ b/choir-app-backend/src/utils/date.utils.js
@@ -1,20 +1,20 @@
 function isoDateString(date) {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
 }
 
 
 function shortWeekdayDateString(date) {
     const weekdays = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'];
-    return `${weekdays[date.getDay()]}, ${date.getDate()}.`;
+    return `${weekdays[date.getUTCDay()]}, ${date.getUTCDate()}.`;
 }
 
 function germanDateString(date) {
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const year = date.getFullYear();
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const year = date.getUTCFullYear();
     return `${day}.${month}.${year}`;
 }
 

--- a/choir-app-frontend/src/app/shared/util/date.ts
+++ b/choir-app-frontend/src/app/shared/util/date.ts
@@ -1,10 +1,16 @@
 export function parseDateOnly(input: string | Date): Date {
+  let d: Date;
   if (input instanceof Date) {
-    return new Date(Date.UTC(
-      input.getUTCFullYear(),
-      input.getUTCMonth(),
-      input.getUTCDate()
-    ));
+    d = input;
+  } else {
+    // allow both plain dates (YYYY-MM-DD) and full ISO strings
+    d = /^\d{4}-\d{2}-\d{2}$/.test(input)
+      ? new Date(`${input}T00:00:00Z`)
+      : new Date(input);
   }
-  return new Date(`${input}T00:00:00Z`);
+  return new Date(Date.UTC(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate()
+  ));
 }


### PR DESCRIPTION
## Summary
- accept ISO datetime strings when parsing dates in the frontend
- use UTC-based helpers for date string formatting on the backend

## Testing
- `npm test` (fails: segmentation fault)
- `npm test --prefix choir-app-backend` (no output)
- `npm run check --prefix choir-app-backend`
- `npm run lint` (fails: lint errors)

------
https://chatgpt.com/codex/tasks/task_e_68bbc12a4c6c832090587ba12ba12281