### PR TITLE
Move calendar to dashboard and show cross-choir events

### DIFF
--- a/choir-app-backend/tests/event.controller.test.js
+++ b/choir-app-backend/tests/event.controller.test.js
@@ -12,6 +12,10 @@ const controller = require('../src/controllers/event.controller');
     const choir = await db.choir.create({ name: 'Test Choir' });
     const user = await db.user.create({ email: 't@example.com', roles: ['USER'] });
     const organist = await db.user.create({ email: 'o@example.com', roles: ['USER'] });
+    await db.user_choir.bulkCreate([
+      { userId: user.id, choirId: choir.id },
+      { userId: organist.id, choirId: choir.id }
+    ]);
     const plan = await db.monthly_plan.create({ choirId: choir.id, year: 2024, month: 1 });
 
     const baseReq = { activeChoirId: choir.id, userId: user.id };
@@ -62,6 +66,7 @@ const controller = require('../src/controllers/event.controller');
 
     // --- Next events tests ---
     const otherUser = await db.user.create({ email: 'other@example.com', roles: ['USER'] });
+    await db.user_choir.create({ userId: otherUser.id, choirId: choir.id });
     await controller.create({ ...baseReq, body: { date: '2099-01-01T10:00:00Z', type: 'SERVICE', pieceIds: [] } }, res);
     const futureId = res.data.event.id;
     await controller.create({ ...baseReq, body: { date: '2099-01-02T10:00:00Z', type: 'REHEARSAL', pieceIds: [], directorId: otherUser.id } }, res);

--- a/choir-app-frontend/src/app/app-routing.module.ts
+++ b/choir-app-frontend/src/app/app-routing.module.ts
@@ -24,7 +24,6 @@ import { MonthlyPlanComponent } from '@features/monthly-plan/monthly-plan.compon
 import { AvailabilityComponent } from '@features/availability/availability.component';
 import { InviteRegistrationComponent } from '@features/user/registration/invite-registration.component';
 import { StatisticsComponent } from '@features/home/stats/statistics.component';
-import { MyCalendarComponent } from '@features/my-calendar/my-calendar.component';
 import { PasswordResetRequestComponent } from '@features/user/password-reset/password-reset-request.component';
 import { PasswordResetComponent } from '@features/user/password-reset/password-reset.component';
 import { EmailConfirmComponent } from '@features/user/email-confirm/email-confirm.component';
@@ -126,12 +125,6 @@ export const routes: Routes = [
                 component: MonthlyPlanComponent,
                 canActivate: [AuthGuard],
                 data: { title: 'Dienstplan' }
-            },
-            {
-                path: 'termine',
-                component: MyCalendarComponent,
-                canActivate: [AuthGuard],
-                data: { title: 'Meine Termine' }
             },
             {
                 path: 'availability',

--- a/choir-app-frontend/src/app/core/models/event.ts
+++ b/choir-app-frontend/src/app/core/models/event.ts
@@ -51,6 +51,8 @@ export interface Event {
   finalized?: boolean;
   version?: number;
   monthlyPlan?: { year: number; month: number; finalized: boolean; version: number } | null;
+  choirId?: number;
+  choir?: { id: number; name: string };
   pieces: EventPiece[];
 }
 

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -355,8 +355,8 @@ export class ApiService {
     return this.eventService.createEvent(eventData);
   }
 
-  getEvents(type?: 'SERVICE' | 'REHEARSAL'): Observable<Event[]> {
-    return this.eventService.getEvents(type);
+  getEvents(type?: 'SERVICE' | 'REHEARSAL', allChoirs: boolean = false): Observable<Event[]> {
+    return this.eventService.getEvents(type, allChoirs);
   }
 
   getNextEvents(limit?: number, mine?: boolean): Observable<Event[]> {

--- a/choir-app-frontend/src/app/core/services/event.service.ts
+++ b/choir-app-frontend/src/app/core/services/event.service.ts
@@ -20,9 +20,10 @@ export class EventService {
     return this.http.post<CreateEventResponse>(`${this.apiUrl}/events`, eventData);
   }
 
-  getEvents(type?: 'SERVICE' | 'REHEARSAL'): Observable<Event[]> {
+  getEvents(type?: 'SERVICE' | 'REHEARSAL', allChoirs: boolean = false): Observable<Event[]> {
     let params = new HttpParams();
     if (type) params = params.set('type', type);
+    if (allChoirs) params = params.set('allChoirs', 'true');
     return this.http.get<Event[]>(`${this.apiUrl}/events`, { params });
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -38,7 +38,6 @@ export class ManageChoirComponent implements OnInit {
   singerMenu: Record<string, boolean> = {
     events: true,
     dienstplan: true,
-    termine: true,
     availability: true,
     posts: true,
     stats: true,
@@ -50,7 +49,6 @@ export class ManageChoirComponent implements OnInit {
   menuOptions = [
     { key: 'events', label: 'Ereignisse' },
     { key: 'dienstplan', label: 'Dienstplan' },
-    { key: 'termine', label: 'Meine Termine' },
     { key: 'availability', label: 'Verfügbarkeiten' },
     { key: 'posts', label: 'Beiträge' },
     { key: 'stats', label: 'Statistik' },

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -6,9 +6,12 @@
     <mat-icon>add</mat-icon>
   </button>
   <button mat-icon-button color="accent" routerLink="/events" matTooltip="Alle Ereignisse">
-    <mat-icon>list</mat-icon>  </button>
+    <mat-icon>list</mat-icon>
+  </button>
 </div>
 
+<div class="dashboard-container">
+  <div class="main-content">
 <div class="dashboard-grid">
   <ng-container *ngIf="lastProgram$ | async as program; else lastService">
     <mat-card class="program-card">
@@ -45,6 +48,25 @@
   <!-- Verwenden Sie die neue Komponente für die Probe -->
   <app-event-card cardTitle="Letzte Probe" [event]="lastRehearsal$ | async">
   </app-event-card>
+  </div>
+  <aside class="calendar-block">
+    <div class="upcoming-section">
+      <h2>Nächste Termine</h2>
+      <mat-slide-toggle [(ngModel)]="showOnlyMine" (change)="onToggleMine()">
+        Nur meine Termine
+      </mat-slide-toggle>
+      <mat-list>
+        <mat-list-item *ngFor="let ev of nextEvents$ | async" [ngStyle]="{ 'border-left': '4px solid ' + (choirColors[ev.choirId] || 'transparent'), 'padding-left': '8px' }">
+          <a href="#" (click)="openEvent(ev); $event.preventDefault()">
+            {{ ev.date | date:'shortDate' }} - {{ ev.choir?.name }} -
+            {{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}
+          </a>
+        </mat-list-item>
+      </mat-list>
+    </div>
+    <app-my-calendar></app-my-calendar>
+  </aside>
+</div>
 </div>
 
 <div
@@ -57,21 +79,6 @@
   <h3>{{ post.title }}</h3>
   <div [innerHTML]="post.text | markdown | async"></div>
   <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
-</div>
-
-<div class="upcoming-section">
-  <h2>Nächste Termine</h2>
-  <mat-slide-toggle [(ngModel)]="showOnlyMine" (change)="onToggleMine()">
-    Nur meine Termine
-  </mat-slide-toggle>
-  <mat-list>
-    <mat-list-item *ngFor="let ev of nextEvents$ | async">
-      <a href="#" (click)="openEvent(ev); $event.preventDefault()">
-        {{ ev.date | date:'shortDate' }} -
-        {{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}
-      </a>
-    </mat-list-item>
-  </mat-list>
 </div>
 
 <ng-container *ngIf="borrowedItems$ | async as borrowed">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
@@ -38,6 +38,35 @@ mat-card-content h3 {
   }
 }
 
+.dashboard-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-block {
+  margin-top: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .dashboard-container {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .main-content {
+    flex: 1;
+    margin-right: 2rem;
+  }
+  .calendar-block {
+    width: 320px;
+    margin-top: 0;
+  }
+}
+
+.upcoming-section mat-list-item {
+  border-left: 4px solid transparent;
+  margin-bottom: 4px;
+}
+
 .item-container {
   width: 95%;
   text-align: center;

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -23,6 +23,7 @@ import { HelpService } from '@core/services/help.service';
 import { HelpWizardComponent } from '@shared/components/help-wizard/help-wizard.component';
 import { UserService } from '@core/services/user.service';
 import { LibraryItem } from '@core/models/library-item';
+import { MyCalendarComponent } from '@features/my-calendar/my-calendar.component';
 
 @Component({
   selector: 'app-dashboard',
@@ -33,7 +34,8 @@ import { LibraryItem } from '@core/models/library-item';
     MaterialModule,
     FormsModule,
     EventCardComponent,
-    MarkdownPipe
+    MarkdownPipe,
+    MyCalendarComponent
   ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss']
@@ -53,6 +55,8 @@ export class DashboardComponent implements OnInit {
   showOnlyMine = false;
   isAdmin$: Observable<boolean | false>;
   isSingerOnly$: Observable<boolean>;
+  choirColors: Record<number, string> = {};
+  private colorPalette = ['#e57373', '#64b5f6', '#81c784', '#ba68c8', '#ffb74d', '#4dd0e1', '#9575cd', '#4db6ac'];
 
   constructor(
     private apiService: ApiService,
@@ -72,6 +76,11 @@ export class DashboardComponent implements OnInit {
           !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
       })
     );
+    this.authService.availableChoirs$.subscribe(choirs => {
+      choirs.forEach((c, idx) => {
+        this.choirColors[c.id] = this.colorPalette[idx % this.colorPalette.length];
+      });
+    });
   }
 
   ngOnInit(): void {

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.html
@@ -13,6 +13,7 @@
     <h3>{{ selectedDate | date:'longDate' }}</h3>
     <mat-list>
       <mat-list-item *ngFor="let ev of eventsForSelectedDate">
+        <span class="choir-dot" *ngIf="$any(ev).choirId" [style.background]="choirColors[$any(ev).choirId]"></span>
         <ng-container [ngSwitch]="$any(ev).entryType">
           <ng-container *ngSwitchCase="'PLAN'">
             <div matLine>
@@ -29,6 +30,7 @@
           <ng-container *ngSwitchDefault>
             <div matLine *ngIf="$any(ev).type !== 'HOLIDAY'; else holidayLabel">
               <a [routerLink]="['/events']" [queryParams]="{ eventId: $any(ev).id }" class="event-link">
+                {{ $any(ev).choir?.name }} -
                 {{ $any(ev).type === 'SERVICE' ? 'Gottesdienst' : ($any(ev).type === 'REHEARSAL' ? 'Probe' : $any(ev).name) }}
               </a>
             </div>

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.scss
@@ -47,6 +47,14 @@
     max-width: 360px;
   }
 
+  .choir-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 8px;
+  }
+
   .me {
     font-weight: bold;
   }

--- a/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
+++ b/choir-app-frontend/src/app/features/my-calendar/my-calendar.component.ts
@@ -48,6 +48,8 @@ export class MyCalendarComponent implements OnInit {
     private loadedPlanMonths = new Set<string>();
     allPlanEntries: PlanEntry[] = [];
     isAdmin = false;
+    choirColors: Record<number, string> = {};
+    private colorPalette = ['#e57373', '#64b5f6', '#81c784', '#ba68c8', '#ffb74d', '#4dd0e1', '#9575cd', '#4db6ac'];
 
     @ViewChild('eventList') eventList?: ElementRef<HTMLElement>;
     @ViewChild(MatCalendar) calendar?: MatCalendar<Date>;
@@ -64,6 +66,11 @@ export class MyCalendarComponent implements OnInit {
 
     ngOnInit(): void {
         this.auth.isAdmin$.subscribe((v) => (this.isAdmin = v));
+        this.auth.availableChoirs$.subscribe((choirs) => {
+            choirs.forEach((c, idx) => {
+                this.choirColors[c.id] = this.colorPalette[idx % this.colorPalette.length];
+            });
+        });
         this.loadEvents();
         const year = this.selectedDate.getFullYear();
         [year - 1, year, year + 1].forEach((y) => {
@@ -92,7 +99,7 @@ export class MyCalendarComponent implements OnInit {
     }
 
     private loadEvents(): void {
-        this.api.getEvents().subscribe((events) => {
+        this.api.getEvents(undefined, true).subscribe((events) => {
             this.events = events;
             this.eventMap = {};
             for (const ev of events) {

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -274,12 +274,6 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
         visibleSubject: this.visibleFor('dienstplan', dienstplanVisible$),
       },
       {
-        key: 'termine',
-        displayName: 'Meine Termine',
-        route: '/termine',
-        visibleSubject: this.visibleFor('termine', this.isLoggedIn$),
-      },
-      {
         key: 'availability',
         displayName: 'Verfügbarkeiten',
         route: '/availability',

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.html
@@ -28,7 +28,6 @@
         <ul>
           <li *ngIf="menuVisible('dashboard') | async">Dashboard</li>
           <li *ngIf="menuVisible('dienstplan') | async">Dienstplan</li>
-          <li *ngIf="menuVisible('termine') | async">Meine Termine</li>
           <li *ngIf="menuVisible('posts') | async">Beiträge</li>
           <li *ngIf="menuVisible('repertoire') | async">Repertoire</li>
           <li *ngIf="menuVisible('collections') | async">Sammlungen</li>
@@ -44,9 +43,9 @@
         <button mat-flat-button color="primary" matStepperNext>Weiter</button>
       </div>
     </mat-step>
-    <mat-step *ngIf="(isSingerOnly$ | async) && (menuVisible('termine') | async)">
+    <mat-step *ngIf="isSingerOnly$ | async">
       <ng-template matStepLabel>Kalender</ng-template>
-      <p>Unter &bdquo;Meine Termine&ldquo; kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
+      <p>Auf dem Dashboard findest du einen Kalender. Dort kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
       <div>
         <button mat-button matStepperPrevious>Zur&uuml;ck</button>
         <button mat-flat-button color="primary" matStepperNext>Weiter</button>
@@ -54,7 +53,7 @@
     </mat-step>
     <mat-step *ngIf="!(isSingerOnly$ | async)">
       <ng-template matStepLabel>Kalender</ng-template>
-      <p>Unter &bdquo;Meine Termine&ldquo; kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
+      <p>Auf dem Dashboard findest du einen Kalender. Dort kannst du deine Ereignisse als ICS-Datei herunterladen oder direkt in den Google Kalender &uuml;bernehmen.</p>
       <div>
         <button mat-button matStepperPrevious>Zur&uuml;ck</button>
         <button mat-flat-button color="primary" matStepperNext>Weiter</button>


### PR DESCRIPTION
## Summary
- Display the calendar directly on the dashboard with a color-coded list of upcoming events
- Support events from all choirs and mark each event with its choir color
- Remove obsolete "Meine Termine" page and related navigation entries

## Testing
- `node tests/event.controller.test.js`
- `npm test` *(fails: ChromeHeadless missing libatk-bridge-2.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc87464ec08320ad706197319e2be4