### PR TITLE
fix: address sass deprecation and template typing

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -56,7 +56,7 @@
         Nur meine Termine
       </mat-slide-toggle>
       <mat-list>
-        <mat-list-item *ngFor="let ev of nextEvents$ | async" [ngStyle]="{ 'border-left': '4px solid ' + (choirColors[ev.choirId] || 'transparent'), 'padding-left': '8px' }">
+        <mat-list-item *ngFor="let ev of nextEvents$ | async" [ngStyle]="{ 'border-left': '4px solid ' + ((ev.choirId != null ? choirColors[ev.choirId] : undefined) || 'transparent'), 'padding-left': '8px' }">
           <a href="#" (click)="openEvent(ev); $event.preventDefault()">
             {{ ev.date | date:'shortDate' }} - {{ ev.choir?.name }} -
             {{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .dashboard-header {
   display: flex;
   justify-content: space-between;
@@ -79,7 +81,7 @@ mat-card-content h3 {
  .clickable {
     cursor: pointer;
     &:hover {
-      background-color: darken(#eee, 5%);
+      background-color: color.adjust(#eee, $lightness: -5%);
     }
   }
 


### PR DESCRIPTION
## Summary
- replace deprecated `darken` call with `color.adjust` and import Sass color module
- guard against undefined `choirId` when choosing event color

## Testing
- `npm test` *(fails: /root/.cache/puppeteer/chrome/linux-138.0.7204.94/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run lint` *(fails: Lint errors found in the listed files.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc8e7f71a08320a22a463b70b3ba0b