### PR TITLE
Track failed login attempts since last success

### DIFF
--- a/choir-app-backend/tests/auth.controller.test.js
+++ b/choir-app-backend/tests/auth.controller.test.js
@@ -19,8 +19,8 @@ const emailService = require('../src/services/email.service');
     let mailSent = false;
     emailService.sendPasswordResetMail = async () => { mailSent = true; };
 
-    const makeReqRes = (password) => {
-      const req = { body: { email: 'u@example.com', password }, ip: '127.0.0.1', get: () => '' };
+    const makeReqRes = (email, password) => {
+      const req = { body: { email, password }, ip: '127.0.0.1', get: () => '' };
       const res = {
         status(code) { this.statusCode = code; return this; },
         send(data) { this.data = data; }
@@ -29,30 +29,61 @@ const emailService = require('../src/services/email.service');
     };
 
     // first wrong
-    let { req, res } = makeReqRes('wrong');
+    let { req, res } = makeReqRes('u@example.com', 'wrong');
     await controller.signin(req, res);
     assert.strictEqual(res.statusCode, 401);
 
     // second wrong
-    ({ req, res } = makeReqRes('wrong'));
+    ({ req, res } = makeReqRes('u@example.com', 'wrong'));
     await controller.signin(req, res);
     assert.strictEqual(res.statusCode, 401);
 
     // third wrong -> lock
-    ({ req, res } = makeReqRes('wrong'));
+    ({ req, res } = makeReqRes('u@example.com', 'wrong'));
     await controller.signin(req, res);
     assert.strictEqual(res.statusCode, 403);
     assert.strictEqual(mailSent, true);
     assert.strictEqual(res.data.resetMailSent, true);
 
     // correct password after lock -> still blocked
-    ({ req, res } = makeReqRes('pass'));
+    ({ req, res } = makeReqRes('u@example.com', 'pass'));
     await controller.signin(req, res);
     assert.strictEqual(res.statusCode, 403);
     assert.strictEqual(res.data.resetMailSent, true);
 
     const attempts = await db.login_attempt.count({ where: { email: 'u@example.com' } });
     assert.strictEqual(attempts, 4);
+
+    // ensure failed attempts are counted only since the last successful login
+    const user2 = await db.user.create({ name: 'User2', email: 'u2@example.com', password: bcrypt.hashSync('pass', 8) });
+    await user2.addChoir(choir);
+
+    mailSent = false;
+
+    ({ req, res } = makeReqRes('u2@example.com', 'wrong'));
+    await controller.signin(req, res);
+    assert.strictEqual(res.statusCode, 401);
+
+    ({ req, res } = makeReqRes('u2@example.com', 'pass'));
+    await controller.signin(req, res);
+    assert.strictEqual(res.statusCode, 200);
+
+    ({ req, res } = makeReqRes('u2@example.com', 'wrong'));
+    await controller.signin(req, res);
+    assert.strictEqual(res.statusCode, 401);
+
+    ({ req, res } = makeReqRes('u2@example.com', 'wrong'));
+    await controller.signin(req, res);
+    assert.strictEqual(res.statusCode, 401);
+
+    ({ req, res } = makeReqRes('u2@example.com', 'wrong'));
+    await controller.signin(req, res);
+    assert.strictEqual(res.statusCode, 403);
+    assert.strictEqual(mailSent, true);
+    assert.strictEqual(res.data.resetMailSent, true);
+
+    const attempts2 = await db.login_attempt.count({ where: { email: 'u2@example.com' } });
+    assert.strictEqual(attempts2, 5);
 
     await db.sequelize.close();
   } catch (err) {


### PR DESCRIPTION
## Summary
- Only count password failures since the last successful login
- Add regression tests to ensure failed attempts reset after a successful login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd7bd3de048320a90fe1657032db90