### PR TITLE
feat(admin): add deploy endpoint

### DIFF
--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -53,5 +53,8 @@ router.put('/frontend-url', wrap(controller.updateFrontendUrl));
 router.get('/system-admin-email', wrap(controller.getSystemAdminEmail));
 router.put('/system-admin-email', wrap(controller.updateSystemAdminEmail));
 
+// Entwicklertools
+router.post('/develop/deploy', wrap(controller.pullAndDeploy));
+
 module.exports = router;
 


### PR DESCRIPTION
## Summary
- allow admins to pull latest git changes and optionally start deployment
- expose /admin/develop/deploy endpoint for deployment tools

## Testing
- `npm test`
- `npm run lint` *(fails: 'adoptedCollectionIds' is assigned a value but never used and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8469413083208e7e4dea732f7afb