### PR TITLE
feat: stream deploy logs and add local script

### DIFF
--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -54,7 +54,7 @@ router.get('/system-admin-email', wrap(controller.getSystemAdminEmail));
 router.put('/system-admin-email', wrap(controller.updateSystemAdminEmail));
 
 // Entwicklertools
-router.post('/develop/deploy', wrap(controller.pullAndDeploy));
+router.get('/develop/deploy', wrap(controller.pullAndDeploy));
 
 module.exports = router;
 

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.html
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.html
@@ -1,3 +1,12 @@
+<div class="deploy-actions">
+  <button mat-raised-button color="primary" (click)="openDeployConsole(true)">
+    Pull &amp; Deploy
+  </button>
+  <button mat-button (click)="openDeployConsole(false)">
+    Nur Pull
+  </button>
+</div>
+
 <mat-slide-toggle [(ngModel)]="debugLogs" (change)="onToggleDebugLogs()">
   Zusätzliche Konsolenlogs
 </mat-slide-toggle>

--- a/choir-app-frontend/src/app/features/admin/develop/develop.component.scss
+++ b/choir-app-frontend/src/app/features/admin/develop/develop.component.scss
@@ -9,3 +9,9 @@
 h2 {
   margin-top: 2rem;
 }
+
+.deploy-actions {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}

--- a/deploy-server.sh
+++ b/deploy-server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Simple deployment script for local server
+
+echo "Building Angular frontend..."
+npm --prefix choir-app-frontend run build
+
+echo "Checking backend..."
+npm --prefix choir-app-backend run check
+
+# Install backend dependencies and restart process manager
+npm --prefix choir-app-backend install >/dev/null 2>&1 || true
+
+echo "Restarting backend..."
+pm2 restart chorleiter-api || true
+
+echo "Deployment completed."


### PR DESCRIPTION
## Summary
- stream `git pull` and deploy script output directly to HTTP response
- add simple `deploy-server.sh` script that builds and restarts locally
- expose deploy endpoint as GET for easy access from frontend

## Testing
- `npm run check-backend`
- `npm test --prefix choir-app-backend` *(fails: process terminated after long execution)*

------
https://chatgpt.com/codex/tasks/task_e_68bedcf2aa6c8320a8cd11b4c2012948