### PR TITLE
feat: add composer/author edit buttons

### DIFF
--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.html
@@ -56,6 +56,10 @@
                 <mat-label>Komponist</mat-label>
                 <input type="text" matInput [formControl]="composerCtrl" [matAutocomplete]="autoComposer">
                 <input type="hidden" formControlName="composerId" />
+                <button mat-icon-button matSuffix type="button" aria-label="Komponist bearbeiten"
+                        *ngIf="pieceForm.get('composerId')?.value" (click)="openEditComposerDialog()">
+                  <mat-icon>edit</mat-icon>
+                </button>
                 <mat-autocomplete #autoComposer="matAutocomplete" [displayWith]="displayComposer" (optionSelected)="onComposerSelected($event)">
                   <mat-option *ngFor="let composer of filteredComposers$ | async" [value]="composer">
                     <ng-container *ngIf="!composer.isNew; else addNew">
@@ -123,6 +127,10 @@
                 <mat-label>Dichter</mat-label>
                 <input type="text" matInput [formControl]="authorCtrl" [matAutocomplete]="autoAuthor" />
                 <input type="hidden" formControlName="authorId" />
+                <button mat-icon-button matSuffix type="button" aria-label="Dichter bearbeiten"
+                        *ngIf="pieceForm.get('authorId')?.value" (click)="openEditAuthorDialog()">
+                  <mat-icon>edit</mat-icon>
+                </button>
                 <mat-autocomplete #autoAuthor="matAutocomplete" [displayWith]="displayAuthor" (optionSelected)="onAuthorSelected($event)">
                   <mat-option *ngFor="let author of filteredAuthors$ | async" [value]="author">
                     <ng-container *ngIf="!author.isNew; else addNewAuthorTpl">

--- a/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-dialog/piece-dialog.component.ts
@@ -248,6 +248,76 @@ export class PieceDialogComponent implements OnInit {
         });
     }
 
+    openEditComposerDialog(): void {
+        const composer = this.composerCtrl.value;
+        if (!composer || typeof composer === 'string') return;
+
+        const ref = this.dialog.open(ComposerDialogComponent, {
+            width: '500px',
+            data: { role: 'composer', record: composer }
+        });
+
+        ref.afterClosed().subscribe(result => {
+            if (result) {
+                this.apiService.updateComposer(composer.id, result).subscribe({
+                    next: updated => {
+                        this.refreshComposers$.next();
+                        const idx = this.allComposers.findIndex(c => c.id === updated.id);
+                        if (idx !== -1) this.allComposers[idx] = updated;
+                        this.composerCtrl.setValue(updated);
+                        this.pieceForm.get('composerId')?.setValue(updated.id);
+                    },
+                    error: err => {
+                        if (err.status === 409 && confirm('Komponist existiert bereits. Trotzdem speichern?')) {
+                            this.apiService.updateComposer(composer.id, result, true).subscribe(updated => {
+                                this.refreshComposers$.next();
+                                const idx = this.allComposers.findIndex(c => c.id === updated.id);
+                                if (idx !== -1) this.allComposers[idx] = updated;
+                                this.composerCtrl.setValue(updated);
+                                this.pieceForm.get('composerId')?.setValue(updated.id);
+                            });
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    openEditAuthorDialog(): void {
+        const author = this.authorCtrl.value;
+        if (!author || typeof author === 'string') return;
+
+        const ref = this.dialog.open(ComposerDialogComponent, {
+            width: '500px',
+            data: { role: 'author', record: author }
+        });
+
+        ref.afterClosed().subscribe(result => {
+            if (result) {
+                this.apiService.updateAuthor(author.id, result).subscribe({
+                    next: updated => {
+                        this.refreshAuthors$.next();
+                        const idx = this.allAuthors.findIndex(a => a.id === updated.id);
+                        if (idx !== -1) this.allAuthors[idx] = updated;
+                        this.authorCtrl.setValue(updated);
+                        this.pieceForm.get('authorId')?.setValue(updated.id);
+                    },
+                    error: err => {
+                        if (err.status === 409 && confirm('Dichter existiert bereits. Trotzdem speichern?')) {
+                            this.apiService.updateAuthor(author.id, result, true).subscribe(updated => {
+                                this.refreshAuthors$.next();
+                                const idx = this.allAuthors.findIndex(a => a.id === updated.id);
+                                if (idx !== -1) this.allAuthors[idx] = updated;
+                                this.authorCtrl.setValue(updated);
+                                this.pieceForm.get('authorId')?.setValue(updated.id);
+                            });
+                        }
+                    }
+                });
+            }
+        });
+    }
+
     openAddCategoryDialog(): void {
         const dialogRef = this.dialog.open(CategoryDialogComponent, {
             width: '400px',


### PR DESCRIPTION
## Summary
- Add edit icon buttons to composer and author fields in piece dialog
- Implement dialog handlers to update selected composer/author data

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `npm run lint` *(fails: 653 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68beec2fc49c83208c2b9d4eaecbb72e