### PR TITLE
Support first name placeholders in email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ can also be prefixed with the template type, e.g. `{{invite-link}}` or
 {{month}}
 {{year}}
 {{list}}
+{{first_name}}
 {{surname}}
 {{date}}
 ```

--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -215,7 +215,7 @@ exports.sendPasswordReset = async (req, res) => {
             const token = crypto.randomBytes(32).toString('hex');
             const expiry = new Date(Date.now() + 60 * 60 * 1000);
             await user.update({ resetToken: token, resetTokenExpiry: expiry });
-            await emailService.sendPasswordResetMail(user.email, token, user.name);
+            await emailService.sendPasswordResetMail(user.email, token, user.name, user.firstName);
         }
         res.status(200).send({ message: 'Reset email sent if user exists.' });
     } catch (err) {
@@ -348,7 +348,7 @@ exports.addUserToChoir = async (req, res) => {
             await choir.addUser(user, { through: { rolesInChoir, registrationStatus: 'PENDING', inviteToken: token, inviteExpiry: expiry } });
 
              const invitor = await db.user.findByPk(req.userId);
-            await emailService.sendInvitationMail(email, token, choir.name, expiry, user.name, invitor?.name);
+            await emailService.sendInvitationMail(email, token, choir.name, expiry, user.name, invitor?.name, user.firstName);
 
             res.status(200).send({ message: `An invitation has been sent to ${email}. Valid until ${expiry.toLocaleDateString()}.` });
         }
@@ -510,7 +510,7 @@ exports.sendTestMail = async (req, res) => {
     try {
         const user = await db.user.findByPk(req.userId);
         if (user) {
-            await emailService.sendTestMail(user.email, req.body, user.name);
+            await emailService.sendTestMail(user.email, req.body, user.name, user.firstName);
         }
         res.status(200).send({ message: 'Test mail sent if user exists.' });
     } catch (err) {
@@ -523,7 +523,7 @@ exports.sendMailTemplateTest = async (req, res) => {
         const { type } = req.params;
         const user = await db.user.findByPk(req.userId);
         if (user) {
-            await emailService.sendTemplatePreviewMail(user.email, type, user.name);
+            await emailService.sendTemplatePreviewMail(user.email, type, user.name, user.firstName);
         }
         res.status(200).send({ message: 'Test mail sent if user exists.' });
     } catch (err) {

--- a/choir-app-backend/src/controllers/auth.controller.js
+++ b/choir-app-backend/src/controllers/auth.controller.js
@@ -129,7 +129,7 @@ exports.signin = async (req, res) => {
         const expiry = new Date(Date.now() + 60 * 60 * 1000);
         await user.update({ resetToken: token, resetTokenExpiry: expiry });
         try {
-          await emailService.sendPasswordResetMail(user.email, token, user.name);
+          await emailService.sendPasswordResetMail(user.email, token, user.name, user.firstName);
         } catch (err) {
           logger.error(`Could not send password reset mail to ${email}: ${err.message}`);
         }

--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -163,7 +163,7 @@ exports.inviteUserToChoir = async (req, res, next) => {
             await choir.addUser(user, { through: { rolesInChoir, registrationStatus: 'PENDING', inviteToken: token, inviteExpiry: expiry } });
 
             const invitor = await db.user.findByPk(req.userId);
-            await emailService.sendInvitationMail(email, token, choir.name, expiry, user.name, invitor?.name);
+            await emailService.sendInvitationMail(email, token, choir.name, expiry, user.name, invitor?.name, user.firstName);
 
             res.status(200).send({ message: `An invitation has been sent to ${email}. Valid until ${expiry.toLocaleDateString()}.` });
         }

--- a/choir-app-backend/src/controllers/monthlyPlan.controller.js
+++ b/choir-app-backend/src/controllers/monthlyPlan.controller.js
@@ -211,7 +211,7 @@ exports.requestAvailability = async (req, res) => {
             });
             const map = Object.fromEntries(avail.map(a => [a.date, a.status]));
             const list = dates.map(d => ({ date: d, status: map[d] || 'AVAILABLE' }));
-            await emailService.sendAvailabilityRequestMail(user.email, user.name, plan.year, plan.month, list);
+            await emailService.sendAvailabilityRequestMail(user.email, user.name, user.firstName, plan.year, plan.month, list);
         }
         res.status(200).send({ message: 'Mail sent.' });
     } catch (err) {

--- a/choir-app-backend/src/controllers/password-reset.controller.js
+++ b/choir-app-backend/src/controllers/password-reset.controller.js
@@ -21,7 +21,7 @@ exports.requestPasswordReset = async (req, res) => {
       const token = crypto.randomBytes(32).toString('hex');
       const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
       await user.update({ resetToken: token, resetTokenExpiry: expiry });
-      await emailService.sendPasswordResetMail(user.email, token, user.name);
+      await emailService.sendPasswordResetMail(user.email, token, user.name, user.firstName);
     }
     res.status(200).send({ message: 'If registered, you will receive an email with a reset link.' });
   } catch (err) {

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -109,7 +109,7 @@ exports.getMe = async (req, res) => {
 
         if (email && email !== user.email) {
             try {
-                await emailService.sendEmailChangeMail(email, updateData.emailChangeToken, user.name);
+                await emailService.sendEmailChangeMail(email, updateData.emailChangeToken, user.name, user.firstName);
             } catch (e) {
                 return res.status(500).send({ message: e.message });
             }

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -88,7 +88,7 @@ async function seedDatabase(options = {}) {
                 where: { type: 'email-change' },
                 defaults: {
                     subject: 'Bestätige deine neue E-Mail-Adresse',
-                    body: '<p>Hallo {{surname}},</p><p>bitte bestätige deine neue E-Mail-Adresse über <a href="{{link}}">diesen Link</a>.</p><p>Der Link ist bis {{expiry}} gültig.</p>'
+                    body: '<p>Hallo {{first_name}} {{surname}},</p><p>bitte bestätige deine neue E-Mail-Adresse über <a href="{{link}}">diesen Link</a>.</p><p>Der Link ist bis {{expiry}} gültig.</p>'
                 }
             });
 

--- a/choir-app-backend/tests/email.service.test.js
+++ b/choir-app-backend/tests/email.service.test.js
@@ -29,9 +29,9 @@ const db = require('../src/models');
 
       // Test placeholder fallback when no name is provided
       capturedOptions = undefined;
-      await db.mail_template.create({ type: 'invite', subject: '', body: 'Hallo {{surname}}' });
-      await emailService2.sendInvitationMail('tester@example.com', 'tok', 'Choir', new Date(), undefined, 'Invitor');
-      assert.ok(capturedOptions.html.includes('tester'), 'Fallback to email prefix failed');
+      await db.mail_template.create({ type: 'invite', subject: '', body: 'Hallo {{first_name}} {{surname}}' });
+      await emailService2.sendInvitationMail('tester@example.com', 'tok', 'Choir', new Date(), undefined, 'Invitor', undefined);
+      assert.ok(capturedOptions.html.includes('tester tester'), 'Fallback to email prefix failed');
 
       emailTransporter.sendMail = originalSendMail;
 

--- a/choir-app-backend/tests/emailTemplateManager.test.js
+++ b/choir-app-backend/tests/emailTemplateManager.test.js
@@ -5,13 +5,13 @@ const { replacePlaceholders, buildTemplate } = require('../src/services/emailTem
   try {
     const types = ['invite', 'reset', 'monthly-plan'];
     for (const type of types) {
-      const template = `Hello {{surname}} {{link}} {{link-html}} {{${type}-link}} {{${type}-link-html}}`;
-      const replaced = replacePlaceholders(template, type, { surname: 'Anna', link: 'http://example.com' });
+      const template = `Hello {{first_name}} {{surname}} {{link}} {{link-html}} {{${type}-link}} {{${type}-link-html}}`;
+      const replaced = replacePlaceholders(template, type, { first_name: 'Anna', surname: 'Smith', link: 'http://example.com' });
       assert.ok(!replaced.includes('{{'), `Unreplaced placeholder for ${type}`);
       assert.ok(replaced.includes('<a href="http://example.com">http://example.com</a>'));
     }
 
-    const mail = buildTemplate({ subject: 'Hi {{surname}}', body: '<p>Use {{link}}</p>' }, 'reset', { surname: 'Bob', link: 'http://example.com' });
+    const mail = buildTemplate({ subject: 'Hi {{first_name}}', body: '<p>Use {{link}}</p>' }, 'reset', { first_name: 'Bob', link: 'http://example.com' });
     assert.strictEqual(mail.subject, 'Hi Bob');
     assert.strictEqual(mail.text.trim(), 'Use http://example.com');
   } catch (err) {

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -27,7 +27,7 @@
         ></textarea>
         <p class="hint">
           Folgende Platzhalter werden ersetzt:
-          {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+          {{'{{link}}'}}, {{'{{choir}}'}}, {{'{{invitor}}'}}, {{'{{expiry}}'}}, {{'{{first_name}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
         </p>
       </div>
       <div class="actions">
@@ -61,7 +61,7 @@
           formControlName="resetBody"
         ></textarea>
         <p class="hint">
-          Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+          Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{first_name}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
         </p>
       </div>
       <div class="actions">
@@ -90,7 +90,7 @@
           formControlName="emailChangeBody"
         ></editor>
         <textarea *ngIf="emailChangeHtmlMode" class="html-editor" formControlName="emailChangeBody"></textarea>
-        <p class="hint">Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{expiry}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}</p>
+        <p class="hint">Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{expiry}}'}}, {{'{{first_name}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}</p>
       </div>
       <div class="actions">
         <button mat-raised-button color="accent" type="button" (click)="sendTest('email-change')">Testmail</button>
@@ -123,7 +123,7 @@
           formControlName="availabilityBody"
         ></textarea>
         <p class="hint">
-          Folgende Platzhalter werden ersetzt: {{'{{month}}'}}, {{'{{year}}'}}, {{'{{list}}'}}, {{'{{link}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
+          Folgende Platzhalter werden ersetzt: {{'{{month}}'}}, {{'{{year}}'}}, {{'{{list}}'}}, {{'{{link}}'}}, {{'{{first_name}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}
         </p>
       </div>
       <div class="actions">


### PR DESCRIPTION
## Summary
- Allow `{{first_name}}` placeholder in email templates
- Populate `first_name` when sending mail and expose in admin template editor
- Update tests and seed data for new placeholder

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Cannot find module '@tinymce/tinymce-angular')*


------
https://chatgpt.com/codex/tasks/task_e_68bef02b7dd48320b6b4afeac684bd0e