### PR TITLE
feat: use CKEditor for mail templates

### DIFF
--- a/choir-app-frontend/angular.json
+++ b/choir-app-frontend/angular.json
@@ -28,11 +28,6 @@
                 "glob": "**/*",
                 "input": "public",
                 "output": "/"
-              },
-              {
-                "glob": "**/*",
-                "input": "node_modules/tinymce",
-                "output": "tinymce/"
               }
             ],
             "styles": [
@@ -149,11 +144,6 @@
               {
                 "glob": "**/*",
                 "input": "public"
-              },
-              {
-                "glob": "**/*",
-                "input": "node_modules/tinymce",
-                "output": "tinymce/"
               }
             ],
             "styles": [

--- a/choir-app-frontend/package-lock.json
+++ b/choir-app-frontend/package-lock.json
@@ -17,11 +17,11 @@
         "@angular/material": "^20.0.3",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
-        "@tinymce/tinymce-angular": "^9.1.0",
+        "@ckeditor/ckeditor5-angular": "^10.0.0",
+        "@ckeditor/ckeditor5-build-classic": "^41.4.2",
         "dompurify": "^3.1.6",
         "marked": "^12.0.2",
         "rxjs": "~7.8.0",
-        "tinymce": "^8.0.2",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
       },
@@ -2674,6 +2674,13983 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-41.4.2.tgz",
+      "integrity": "sha512-yXVVEy+lEmyvYwTxn76Ff53fK/qJphf9stoBF4kFKKK/Tfi59EMog2Ctk3iIkLLyt74KmxzvuCXZwE00wDqfLA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-46.0.3.tgz",
+      "integrity": "sha512-P0qegTFO9u5gbR7Ig/JI0vGdWFtxzM08KPCbeYTpQtdI9+DrKdvWFo0LVB7LJjR6OKuUPCtnulGgCyhuzNT7lw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-angular": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-angular/-/ckeditor5-angular-10.0.0.tgz",
+      "integrity": "sha512-wYSpr1lXcQqS+i3EGZHE4uT43VulZRlrhq6mEtPXLFxtUYlX1NElPnjl7yqZyaaBuM2FY864VC0RS2zed5s0lw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-integrations-common": "^2.2.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16.0.0",
+        "@angular/core": ">=16.0.0",
+        "@angular/forms": ">=16.0.0",
+        "ckeditor5": ">=46.0.0-alpha.0 || ^0.0.0-nightly",
+        "rxjs": ">=6.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-41.4.2.tgz",
+      "integrity": "sha512-Ukit63jHiAuLyfESdLSc6ya12xKJxDP83krZFiMY5bfXssg0z39CGuHOZlwaI9r7bBjWWMGJJeaC/9i/6L9y7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-46.0.3.tgz",
+      "integrity": "sha512-SStt6opEniy0i5N5QMsAttpxhPvlmQ5UgmfvVmkyBnvOGwFwSmIFjxAXdTsAhvKdDaKrsjeCpv/j6L6llYk7dw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-41.4.2.tgz",
+      "integrity": "sha512-+Y+M9/JRX3xSHX/E5zFwzuKPzEeeuL61wcig1DuEz7GvK5sRLJcbdVQmiJnfDh3iOcf/ob1nahNgHAEoCno0Dw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-basic-styles/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-41.4.2.tgz",
+      "integrity": "sha512-tkEKd3pmDO8QWm243FRDRUv5COayXYZJpMFUL6blw3m6IXb4ujcXKn61A+UwUO+kM0NGTuepHZJkFSuV1/90sw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-block-quote/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-46.0.3.tgz",
+      "integrity": "sha512-f1usHplw2Ndhm1AiyjWfOWoaSQehMqBaXTa94OXlvO6ci1RIijdFm+DKn4Lgh/vSjv4vo25eQReTmEM0KaysvA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-link": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-image": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.0.3.tgz",
+      "integrity": "sha512-9XcJVJxG+fqzwTupf7EATKeVZ+tXqeWiHLip4w/vMejjX026CPjiB3rKA2K5/H25TKDrvsMBBm22RqpK25dzCw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-undo": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-link": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-46.0.3.tgz",
+      "integrity": "sha512-s2wBD0QQ2Pz8wzTbh3YN83QbYRVbGp3qLwgN+8x7Y/bOuFE4AxR+JhDo14ekdXelXYxIeGJAqG2Z4SQj8v2rXQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-image": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon/-/ckeditor5-build-balloon-41.4.2.tgz",
+      "integrity": "sha512-4FLvd2OV4UgPva0/+xHT4ZuEzKLxB9M6D04/G0YFFwvbPiy71zH0iEMj132Wd0fdEJ0fwjF1HfDzhNgI9BPhPA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-balloon-block/-/ckeditor5-build-balloon-block-41.4.2.tgz",
+      "integrity": "sha512-p2pXJcS0hNuDZXyMi0frSwLZBm1hGGEEajJtAvKdg+pKZvvrIabQzvjtrkUf5P6Lbhl/z1/v2h0pBa76025Q5Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon-block/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-balloon/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-classic": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-41.4.2.tgz",
+      "integrity": "sha512-fdsxmEPdNdo/usXyYMS2cN/E9KcQIrtmImUYDI+jEs6yzmSgI8By01n+enkKgVxu+2t+g+ctjQwrCpiyWIHTAQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-decoupled-document/-/ckeditor5-build-decoupled-document-41.4.2.tgz",
+      "integrity": "sha512-YIjcJc9flghFsA5gZaL5oIf6TxLJxUZpXgWYa9l5C68enm36bsDycgJWGGbexHK2HOR9AnBr6ThUBQJkn3StTg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-inline/-/ckeditor5-build-inline-41.4.2.tgz",
+      "integrity": "sha512-h57jjFm0cSOFGSTA2MbvhSXMFxUbPZqwIeA9S0bfUNcGrnm84YaerX8ev8ZP2iMLOckPOcjBiC/70Sp0SvGwxg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-inline/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-multi-root/-/ckeditor5-build-multi-root-41.4.2.tgz",
+      "integrity": "sha512-Hou3cHuzx2YR6cfbTYYgk2cSBkudCfPru471KxsXUtzw+B7KuHLm3LtnLJNpScF2WoGaOoaFzB9D2PkzlhF5hA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-build-multi-root/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-41.4.2.tgz",
+      "integrity": "sha512-u6HVTW7O+YSeeCZ+plg78aW74B2G+E7uKy5YQxvB99uCXGWmYy57D2maaEkPI87ZwZD3VlRnvAalaAdngc4M1g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "blurhash": "2.0.5",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-41.4.2.tgz",
+      "integrity": "sha512-QB3igdZOBI+I8q6eTA5+q27VQrj3Nu7PctNKRehwMC/Z6URboTnntqtkZ3inAZEbWcoLTN2tpDthlufUbQ+cfA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-46.0.3.tgz",
+      "integrity": "sha512-ECz2goSbYZSlhRT2HszIPCMWFfThA0uIuXpI5PjYj7rDJUoip/Y3/UZjyMo47IUFf66Y4VdvJoq0fv/Z86HYIg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-clipboard/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-41.4.2.tgz",
+      "integrity": "sha512-rgDrpEonA2AchfvgYaeb/olMk/HYxUK4B8XPqs+nJxLmBraTv2lANsgsMbwsqAIiRjT9MknmJdX+CEbqljgL/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-46.0.3.tgz",
+      "integrity": "sha512-5Bny1t2jb+Fruy4Tf0Es6YGPe24eWUiCskTv7QZkebEUtectUhZXjrbAPXkn9GQH9E+jU/ywhYkkCKwDgg+Vnw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-core": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-41.4.2.tgz",
+      "integrity": "sha512-kCIJjviiMNIMBMx7XFXFp1IeTELQKv7xyPJiVFDyUftIfthf9uWty72ipZ3BBNBGBkaoTiSzDZ507EsX6czuIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-41.4.2.tgz",
+      "integrity": "sha512-HJJ3Z4R4mCazV2cz+s8bI00ci3/KyIa+fXodBN1+kg3PldX471zSj+DtyFsZyKnUcpUTVygjPEaHKBDpxtUhjQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-easy-image/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-46.0.3.tgz",
+      "integrity": "sha512-NXqmQK45DybJmgWFUln2uTvWqg77BuTp/R/4F33K6fgA4QGmnlWZ+l96Z5Rpmq6Rxc7suBNIKKWRFihquHw1hw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-41.4.2.tgz",
+      "integrity": "sha512-BVf4ipZz36eCTDFiQ8hqN+oBmuvZPzCmNDDjCYuHNGCKGLaIo1Yzi09fHPUWDw1U+en6Cgnwc2HSWgwf7zC7aA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-classic/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-46.0.3.tgz",
+      "integrity": "sha512-svrTpgGCi9YLhzit97i+A+lVStnQ4fNbGj6O1HlRG676BA20zqUkUWbNDPlBQT5sbq4N2oLKPwBmAqtUsF9ivQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-46.0.3.tgz",
+      "integrity": "sha512-VfsD95gALQrUMHRJ5f2KKIPgtRb5flAqug85GSWy+wJZXOv7dC953tc1v8PYtUOHV6R3k2SWOUAGUClRu2ijOQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-46.0.3.tgz",
+      "integrity": "sha512-mS9gd8zTCclstU5DROT5L3sVq6HSDk0jw/7d7bgKEvWbGvQ6iPiqcgZ+bzpyrtvXMQKnmgfytZpU9qfODLpwFA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-46.0.3.tgz",
+      "integrity": "sha512-XiQsDeIZdSRDuFz/eoH16L21+Ucxykt+qHvqHSXB6bnVE8A3+65fxXYXicXnlb8st6UYhVBGwd53cpRz1ljMww==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-mention": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5",
+        "fuzzysort": "3.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-41.4.2.tgz",
+      "integrity": "sha512-25JqIzNYvCqQ6f02YY+a8A8xtjClzI0YCio0JGoRG3JHJXzYsQbTPsiokuE1BCwMCu3gYoFz8eKJYt2selLsCw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-46.0.3.tgz",
+      "integrity": "sha512-Z/IVe2Bn/PXamXxTlG9Pf/4K1OoGsNpwBfdywiqSYxdlF5E/4e5xArCKuFVkLGPO2YPSXShPhucBorqHlGQI2Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-enter/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-41.4.2.tgz",
+      "integrity": "sha512-1UCvk76v2+NDfHfTo3Qg0EJYpddgSC/i66jY3NnQUFt1zt68rAzm/kFOVYjTD/QDn6pyiMAIUeMlKFkswF+upg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-essentials/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-46.0.3.tgz",
+      "integrity": "sha512-WKJ32slfJKPE2xnOWtk8/kqaDlUE3AKXChmRw6fPXM9pRpBRItLrbMO4Lhic9F1V8UzzY88/6VMuTMUlVg7/pQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-46.0.3.tgz",
+      "integrity": "sha512-4A0F3ShSn5QE0aQVus45EiIpFntJdXQnlf/kCLbQstYBUof915vReCa/c0cRu8q+1GOB9DmTarSPfb2jxDKhaA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-46.0.3.tgz",
+      "integrity": "sha512-+AjKdmknSeihgVytx2CZPvqJ8Iv0sQd8kP1AvTMsp7JWr9kP3eMZEWJ3IwUP7GaH9O+cSDqeW2pFY4rW1ajYlQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-classic": "46.0.3",
+        "@ckeditor/ckeditor5-editor-decoupled": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/@ckeditor/ckeditor5-editor-classic": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-46.0.3.tgz",
+      "integrity": "sha512-fw4pdBqT1UpVYkBBpACQn9w5iR2Y62AvGW7ANt6b1nv55+FIN0uEAHsuChvZdFra8iJQR1qyilT24LVOTtk5mg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-41.4.2.tgz",
+      "integrity": "sha512-8AyMumy90nY49reQlHuCgSJFSaym4emCVF6vAAqd71FHtmgtfS9w3xMqXAk6QbgMjfy46cwind0JITZfBfKqLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-heading/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-46.0.3.tgz",
+      "integrity": "sha512-woO40tvOomrE7PHV/LAIOuNDb6sm2xiRQpT3r6TU1bvHZWSdt+hBCVRbnPxMNY2b/+0FGeV6cIOP8jlZ6JXF2g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-46.0.3.tgz",
+      "integrity": "sha512-mct0XA6XxSk9BXorR5HA6jiDmf40Wm2HbwSEL8RcCQ4s/ak+3c85loUQZtV5Enaro8ejUkQ30nbqUnrO21Z8ZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-46.0.3.tgz",
+      "integrity": "sha512-8Cf0L1REllrVffu4BrnNiga0mQgFcQ0V/L4ARMGR3vmafTvS2cOvMyrGJy/69oCGM0NigyU1eSzkGv04o+599w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-46.0.3.tgz",
+      "integrity": "sha512-zBRJ1aBIi/UKKRhCUvK0mTDu9c43GOINKscGJ4ZRAD8WmKdlpxO+xUfCfZouDMGwd67lD9e37LI3xZc+hGCXGA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-heading": "46.0.3",
+        "@ckeditor/ckeditor5-image": "46.0.3",
+        "@ckeditor/ckeditor5-list": "46.0.3",
+        "@ckeditor/ckeditor5-remove-format": "46.0.3",
+        "@ckeditor/ckeditor5-table": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-heading": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-46.0.3.tgz",
+      "integrity": "sha512-FKTgc1I9nDvnoDJ6RzkmPX7knhU3k6iH8IGUngH78TIOmhcWPVzv7Sftszos/LdX+kTc1ZoWWaHo5vrk90waZg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-paragraph": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-image": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.0.3.tgz",
+      "integrity": "sha512-9XcJVJxG+fqzwTupf7EATKeVZ+tXqeWiHLip4w/vMejjX026CPjiB3rKA2K5/H25TKDrvsMBBm22RqpK25dzCw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-undo": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-list": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.0.3.tgz",
+      "integrity": "sha512-KEAnyhUO6hWWa3GO6NGS7Entn2OXutCQ2+od8l5MrqeGxmpnqj0OpPX6qn+RZTVWf1RnqwErCYQhhPoQM/mlZg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-font": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-paragraph": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-46.0.3.tgz",
+      "integrity": "sha512-3OlCeyykkhcueXmo+p/LppeCvC2TtEpljLpC042EbIOCJEbSMlYEGx/AJQGetn2JV8q9L3UKfgnltpOriXAeyg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-table": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.0.3.tgz",
+      "integrity": "sha512-Bt7d02s96cv28Xc+LxNRYBNrqlG7gI5xB8gjQWCuoIYHVikxtDUSBowu7q1UOkBmX/TEHuUpnYjUdBKD5M2n5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-icons": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-46.0.3.tgz",
+      "integrity": "sha512-ztmFx8ujcdIMTWeIQ8Hxixlexfhx8vcclV/+maDzjVHhqRNi9eZ1b/nQ7gnS4/X5Fnh6cPQuCM+3lTUR4jQscA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true
+    },
+    "node_modules/@ckeditor/ckeditor5-image": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.4.2.tgz",
+      "integrity": "sha512-4AgXdvYr6tGzEqwAHVRl+LA8nPRER7vQthVBuT4g1FEkRB6w9kgRsPM2JfsGekoGd8GU0WnMaz8kAcL4C2urYg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-image/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-41.4.2.tgz",
+      "integrity": "sha512-pghHa+DKya6788nTiU1ZItKmAgjf+up4Rqe5GOkxKB7vJc189KSBJYc5foov65nM831rXcWgTk4jybK+JGHmjQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-indent/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-integrations-common": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.3.tgz",
+      "integrity": "sha512-92kQWQj1wiABF7bY1+J79Ze+WHr7pwVBufn1eeJLWcTXbPQq4sAolfKv8Y8Ka9g69mdyE9+GPWmGFYDeQJVPDg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ckeditor5": ">=42.0.0 || ^0.0.0-nightly"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-46.0.3.tgz",
+      "integrity": "sha512-JLkDnhZxP9J/Dw7uxJtBHYrdR1q2xpkIsi+Y0fhG0cejo6Lhfnv2F/1L76EO6JxhfhrkHWrDgLwr860PYvRztA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-41.4.2.tgz",
+      "integrity": "sha512-woMv9/BxkDjG5xsS/OyaxW9tWTuiG6wZWWcYxVJq8FOW2NL68CKQLmyoQ1rdv/2Gw4UPUXTtB+1uGVmQDMXDsQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-link/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-41.4.2.tgz",
+      "integrity": "sha512-nGb36jNJO6YAU35piKabey9B13xw6TnmL5VySS2dEqSt/DTy7RdY5z2K7CU/NGuIGe/bPBZgU1J0dQkRr2F3hA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-list/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-46.0.3.tgz",
+      "integrity": "sha512-ROOQsKcb03UdzyWZOD4p6vPWUpjgBRf4VXgbxKds2z19dm3fOdUwFbolpVrmYuYzdHrI/0xWM/+waD7TEOatuQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@types/hast": "3.0.4",
+        "ckeditor5": "46.0.3",
+        "hast-util-from-dom": "5.0.1",
+        "hast-util-to-html": "9.0.5",
+        "hast-util-to-mdast": "10.1.2",
+        "hastscript": "9.0.1",
+        "rehype-dom-parse": "5.0.2",
+        "rehype-dom-stringify": "4.0.2",
+        "rehype-remark": "10.0.1",
+        "remark-breaks": "4.0.0",
+        "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "remark-stringify": "11.0.0",
+        "unified": "11.0.5",
+        "unist-util-visit": "5.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.4.2.tgz",
+      "integrity": "sha512-+4JqfbnMrB9Si2gAKKCRZTY1hixlk11mY8+PA+32UezyCq/myoAlVGT8ytCr3rywe58nbkGGAv2QbVo6fy8zoQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-46.0.3.tgz",
+      "integrity": "sha512-a7sHtN8M5Glh20SbsB0KWlFxoothUwkq6cqNJKKAI6MrOYsOJX1WaMG2mUfhGr4VTrUieuJYxVtqMFuagbhBgQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-46.0.3.tgz",
+      "integrity": "sha512-gsac1z96MaJMFzapfzqLtEqETpI3JVXMfdQV3N0+kRbFSlUeJmrR/aHLC/+GDQAttkfOuL9i4FlWQKiDeSN15w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-46.0.3.tgz",
+      "integrity": "sha512-6V0O0sqgZMh47knEhhj0htWK3Oxm6jfHLWA4vi9vColwJMv9imuP72vYgrClmKHfN/QtyZ+DGmaufmhaXS2ffw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paragraph": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-41.4.2.tgz",
+      "integrity": "sha512-tOsD40Fcqli5zkH/68WhcqYU8BL4qb8J5xGuk1xmBokz3W0LzebWW0GXmFk5PmWv+fg0dOXfSo8uMzb5ni+CuQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-41.4.2.tgz",
+      "integrity": "sha512-jby5YQ2QowGdDCshPq5Ej11wTFcBZP2dYhQTu6fRZRc+mdihKCILxh0rwBgBOCCf+buflx8RYp/WKd76Kcuq5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-46.0.3.tgz",
+      "integrity": "sha512-rrGeK1NGE5o04/wuyMq10BD7bJ7qkVZq74dDXb7G6l1IkFWU/lY5SLt1K4FgVunY+oBcsena+hktwqgEsmEqdg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-46.0.3.tgz",
+      "integrity": "sha512-b1NUb7nEKdb0R5UOukXRXOeweOIE3Dsa64uwV/H6ZnRfdOmH37TVSKFJ2lWVvPUUljsT3SVdSZbl1aP4aA1SBA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-46.0.3.tgz",
+      "integrity": "sha512-Uxr3/+TRLUIOGubXo/86yzqLGgoEdPV2rGqz40ulrVhG1Q7hOYerJPDs67ULPq6DLukoFFARRTah+UN9EOYRRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-select-all/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-46.0.3.tgz",
+      "integrity": "sha512-YSa+Q49hQe4oRxIFsnUjzIFRG1M5+2vWjzYwS84hQAR0xDMZDD0SqIS6poC3QewuIS/525bcnmASBwXZUrRdIA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-46.0.3.tgz",
+      "integrity": "sha512-zJMa7ekyaeQAqAysFZDRwPRyJ7+ejaP2twYvRJQARf/BgZ6YZdSDvSoW1gGIKN/c/f0XWOSTDBdRCciPZu9vCg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-theme-lark": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-46.0.3.tgz",
+      "integrity": "sha512-PihS9/nmrGXaycsI3TSqVK0qGlc2ZSE3XzL7dEKTCyUta7vvI7hCC/jDaTtfch2d0fZhnIXovlgqlj35u2PjDw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-46.0.3.tgz",
+      "integrity": "sha512-/4kOCM0/s4O65AA6tHdTK9joPFaTs/Uk14RHlyGP6+QJQ5FcNx9g2yJ1HxhRAdkMLy3AsVol9lqqFXC00+W7BA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-html-support": "46.0.3",
+        "@ckeditor/ckeditor5-list": "46.0.3",
+        "@ckeditor/ckeditor5-table": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-list": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.0.3.tgz",
+      "integrity": "sha512-KEAnyhUO6hWWa3GO6NGS7Entn2OXutCQ2+od8l5MrqeGxmpnqj0OpPX6qn+RZTVWf1RnqwErCYQhhPoQM/mlZg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-font": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-table": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.0.3.tgz",
+      "integrity": "sha512-Bt7d02s96cv28Xc+LxNRYBNrqlG7gI5xB8gjQWCuoIYHVikxtDUSBowu7q1UOkBmX/TEHuUpnYjUdBKD5M2n5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.4.2.tgz",
+      "integrity": "sha512-wDn1UUaKHcrscmTYj2PwCFbj9FOXFfhk4JbCepyGFQt31YyaOKBzAyZaJQ7E38wJq7a4afac3MwUDk+j1X5FDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-41.4.2.tgz",
+      "integrity": "sha512-kFiEIZfUNt2TCrwJgM4mot6LLqzbH4vbfYcjbrsUz28kLv8guzcwKXPRe0ZrHo+WS7Cny8j5aCEuUAs3sxEmAg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-41.4.2.tgz",
+      "integrity": "sha512-TgaUhpFfG9csm4seL7LQSS6Rn+Gcm/wteGyD+Yl50BG1mfMIL259KEFkVTXDRwJadQm2KiiHZDLqpcd/lAqc0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-clipboard": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.4.2.tgz",
+      "integrity": "sha512-cMoGXClFxp5uR5Wr1cZnop5IdmqTZXTcrUuEoyhF+1hk+QDhp2ibQ2dTKu6hw+TTzw3Xd6g8Kj0Oj+mXoIur+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-41.4.2.tgz",
+      "integrity": "sha512-NyPvffk+yA2rWsiF3Q/dDyO1ZtUvlX5hEVEWCG9C4wz9NVtBmoK0v1HmcsBDYQ//TwLY3N8HA0LX00UGTHVGFw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-41.4.2.tgz",
+      "integrity": "sha512-5KI9spGZY1W2GpRLc0aJiqm1/33sGX9vxXAvIRabSF1uhK4b2WP6zdjGy0IcwBpIRnAkEGoPoetFmx1esJOVDw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-41.4.2.tgz",
+      "integrity": "sha512-kzy+Az4Dn+5dCR0FMk1qzlGaqbgNSi0a7qLr17ghfVnqbLYmhhELjgLOKU9cjjIm5L2KMEH2qRq5QHlacO90kA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-41.4.2.tgz",
+      "integrity": "sha512-NlDYZzVVpZblkeVLNrguC437PMqYEXNRGB+KF2uzV5/vPAjz3SjleVcGlbTAWVbMQAUMoOtrmrJjeTR4S93UMA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-41.4.2.tgz",
+      "integrity": "sha512-sqmSEHzX0C3L5H+Svj1dSOyetxOnVb5vL2eS/EdzRpnhThwaPsTVWI83bGHPRTh4h89yEli3nMbNsdTTnsR7Rw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-enter": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.4.2.tgz",
+      "integrity": "sha512-pvNNcFGn7TFFuJ1QbT0Jggd5xflORxa5i32nZuSzDLVflXGDKq53xSXxapCzd7XsiVXQlufbXt2SlGj7lhyP1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-41.4.2.tgz",
+      "integrity": "sha512-y3JZF9UMgf6Zwt3HzaPI9B8Gbwc1s+IoK78LFuhkP9B/rgQDBFWi3fXo6ywHsHKZ/EK5JZQuHMdI9czyBuG29Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-font": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-41.4.2.tgz",
+      "integrity": "sha512-++7oIK+MXtHGUQkqmXgZqGDBCEsHCuGkss43goGZ97PcRwLegnDRInowj3K/r3nwQcts1VAWnnLCnCSSYbcGIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-41.4.2.tgz",
+      "integrity": "sha512-xAb3Kox0KfoenZaRWgWaZPQwYLauK46WdQ4zYJ16ozQN5mssnS8sU27EFx0OG5EOv9EBurmOcHnP3Rih1szROQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-41.4.2.tgz",
+      "integrity": "sha512-le+6melLc8lQTPBWppnWXWaX16KXcvXz8ZOO4uuD7+w5JrtRheEG1N35nTblpeT+QcyBjL9mSu519xReL2qjBA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-41.4.2.tgz",
+      "integrity": "sha512-rpQMp6ckpYPWnBg8vL23SdKfJ0F80C1iIIO7EA9ZyimPc+hWH7kVF7f8D2Q2ckG1LrlXAXn9cg4tahMFGeiSzw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-41.4.2.tgz",
+      "integrity": "sha512-QHqFgzQucCRvEOPdxcXOMervxhlK6DiR6JqUvgeJyyiWWQT0HGiG7Vy7QKhL6S0w5BUYFoS5B8rj5LjOEm+xsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-language": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-41.4.2.tgz",
+      "integrity": "sha512-YrjwPRxtHDf99fnsbYxos/OuJcdEYYk4sx8oyVgwG/se0yk4IObx7MZGVebGiqd5cZQRxAxP8VGNgRqjHzpcsg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-41.4.2.tgz",
+      "integrity": "sha512-4izHzZ2AO9QMo+WirGVPYu3qqf+YuYe0CtF37rhdRNFLwDMYV7lGBpEj24US/3lV7CuEKM1V5N2Ojl6b4ew10w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "marked": "4.0.12",
+        "turndown": "6.0.0",
+        "turndown-plugin-gfm": "1.0.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-41.4.2.tgz",
+      "integrity": "sha512-jO8eZE/4NIRJ5Tm/mIdgnLqkBnYj7l3jU4HZLkYvU5tEV5Xk6Rf8bsqMkkBvquf3LVhQbwAiLNjtlrHf68vU7Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-41.4.2.tgz",
+      "integrity": "sha512-SJUHeD6l6UVFlY/Uh2vZIr7qHbz5A4Ud285zxAZpiiiv0NP4wQDw6bo28tD/QkCMm1hRcLCkKWd1aNDkFe+42w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-41.4.2.tgz",
+      "integrity": "sha512-J9sIBgBKhAeZn+KpZADUj6z7VjrbUtHHFL88Ivx2h9jePZPT/LIfDwnnrJEnMjf2KF1bkHvIdP23cZz2BzXwKg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-41.4.2.tgz",
+      "integrity": "sha512-XlCIvIETcWn6/6jfPhVzSqkXZ6fnU0iqqNlyKF67dStfc6vVc6Ut31P+f84SwAJA8ay553OUNyY14YZcoP2tLg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-41.4.2.tgz",
+      "integrity": "sha512-t34VNBZbxO07nEazAKECXcRgH5VrPbrTJW0iZO0/w/yPHUAPZ8ejcdEuohr7cLS3TCHE09biFc1lNPLas/xK5w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-select-all": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.4.2.tgz",
+      "integrity": "sha512-zC0wS0IggFDvk1wDB/SregfejLJk62In+i7P0otOaySg5tFfkJqT3OycplbPqIn3D1UCpIIz4KJzRl66PEVI7g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-41.4.2.tgz",
+      "integrity": "sha512-0mKErojbxNr8Xbx5OjDLdciU3Onwn33h5IMU2j6imcwqORLzyXgU9ENhwwfw6Roeu8Guvi6hEVKBW6GE1UIYIQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-41.4.2.tgz",
+      "integrity": "sha512-TnBJLLEU5dckalm8KZP/xC0kLMeNDVTrWUp8iCLcmLoe9xlt/wIO8VzLVPW+WjgzSZ7Yq+vrzHaCyJRVxuDsBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-41.4.2.tgz",
+      "integrity": "sha512-OicpKzkYqyTjPRGZf6xMYQnuUCAZ4QS2H1MAEH5xTiwYv+eqR/enC/m9FxCEs2Z3DlO9DIjVnoBxe2qUCSxRBQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-style": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-41.4.2.tgz",
+      "integrity": "sha512-q39mtg1kBrmJ8XA7XbOy4HhVzrICvt0KS484d5c3NaX7JetwapAM/QfWDGfMToMukzFcntaGt0be5Bwja0LJSw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-41.4.2.tgz",
+      "integrity": "sha512-rzFSAhdPMD2QylJDwgGniiBoCuHWQAQIEKDtMbQ4FH+/7JiCfKgUsnZxqhDPJwQyV1MWVz4wmXK/1RKqHohOvg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.4.2.tgz",
+      "integrity": "sha512-mJMoALRWAaFg9Jgu+ufSGR/cUGCawMcz7Iwr5TBdrICmIckxx0DxPwWCPoTgI1laBZtRy/QctO2gQ4H+FYbfUw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.4.2.tgz",
+      "integrity": "sha512-dCNQhZw9QcgGUKlYD8STpgNanNp7ILPMRNoDFW9NWHRKsUpjGMYIU3dsE4f08hkA/bckJ9yBaZc7a0LavOrncw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.4.2.tgz",
+      "integrity": "sha512-u17Y8XHhyDHaShQei7WuZ0th8DgKo56YfJqRdZautHKnPJ32r+O97uTcGfBpsobhZbJ6Ss3tUwebve3Obv2K/w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.4.2.tgz",
+      "integrity": "sha512-hpM9Ti2iFvBBIPAESJp3bOY4SR6fzF3V5t46CpVDStLJdqwnQOuZ8Nv1dqzZZWCuK+EByAbY14pgfYM92nNHrQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-41.4.2.tgz",
+      "integrity": "sha512-XuCLL97FotJ9QfuCZOhW7V2XHfVXkplIDpwgnH4HnLjtMLGFVZbyb0k9pEJk3Kp+F8qQbfWDIPFzaNKRDKqtRA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "ckeditor5": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/ckeditor5": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-41.4.2.tgz",
+      "integrity": "sha512-90k7d3R1B7x3muHOKKOGIomFsSQRG1sPuRHdN6J7WmKZH+BrMQgRkUs66xVRhNjrLPmewwJYdQI42Sb1cA1ILQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-alignment": "41.4.2",
+        "@ckeditor/ckeditor5-autoformat": "41.4.2",
+        "@ckeditor/ckeditor5-autosave": "41.4.2",
+        "@ckeditor/ckeditor5-basic-styles": "41.4.2",
+        "@ckeditor/ckeditor5-block-quote": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-build-balloon-block": "41.4.2",
+        "@ckeditor/ckeditor5-build-classic": "41.4.2",
+        "@ckeditor/ckeditor5-build-decoupled-document": "41.4.2",
+        "@ckeditor/ckeditor5-build-inline": "41.4.2",
+        "@ckeditor/ckeditor5-build-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-ckbox": "41.4.2",
+        "@ckeditor/ckeditor5-ckfinder": "41.4.2",
+        "@ckeditor/ckeditor5-clipboard": "41.4.2",
+        "@ckeditor/ckeditor5-cloud-services": "41.4.2",
+        "@ckeditor/ckeditor5-code-block": "41.4.2",
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-easy-image": "41.4.2",
+        "@ckeditor/ckeditor5-editor-balloon": "41.4.2",
+        "@ckeditor/ckeditor5-editor-classic": "41.4.2",
+        "@ckeditor/ckeditor5-editor-decoupled": "41.4.2",
+        "@ckeditor/ckeditor5-editor-inline": "41.4.2",
+        "@ckeditor/ckeditor5-editor-multi-root": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-enter": "41.4.2",
+        "@ckeditor/ckeditor5-essentials": "41.4.2",
+        "@ckeditor/ckeditor5-find-and-replace": "41.4.2",
+        "@ckeditor/ckeditor5-font": "41.4.2",
+        "@ckeditor/ckeditor5-heading": "41.4.2",
+        "@ckeditor/ckeditor5-highlight": "41.4.2",
+        "@ckeditor/ckeditor5-horizontal-line": "41.4.2",
+        "@ckeditor/ckeditor5-html-embed": "41.4.2",
+        "@ckeditor/ckeditor5-html-support": "41.4.2",
+        "@ckeditor/ckeditor5-image": "41.4.2",
+        "@ckeditor/ckeditor5-indent": "41.4.2",
+        "@ckeditor/ckeditor5-language": "41.4.2",
+        "@ckeditor/ckeditor5-link": "41.4.2",
+        "@ckeditor/ckeditor5-list": "41.4.2",
+        "@ckeditor/ckeditor5-markdown-gfm": "41.4.2",
+        "@ckeditor/ckeditor5-media-embed": "41.4.2",
+        "@ckeditor/ckeditor5-mention": "41.4.2",
+        "@ckeditor/ckeditor5-minimap": "41.4.2",
+        "@ckeditor/ckeditor5-page-break": "41.4.2",
+        "@ckeditor/ckeditor5-paragraph": "41.4.2",
+        "@ckeditor/ckeditor5-paste-from-office": "41.4.2",
+        "@ckeditor/ckeditor5-remove-format": "41.4.2",
+        "@ckeditor/ckeditor5-restricted-editing": "41.4.2",
+        "@ckeditor/ckeditor5-select-all": "41.4.2",
+        "@ckeditor/ckeditor5-show-blocks": "41.4.2",
+        "@ckeditor/ckeditor5-source-editing": "41.4.2",
+        "@ckeditor/ckeditor5-special-characters": "41.4.2",
+        "@ckeditor/ckeditor5-style": "41.4.2",
+        "@ckeditor/ckeditor5-table": "41.4.2",
+        "@ckeditor/ckeditor5-theme-lark": "41.4.2",
+        "@ckeditor/ckeditor5-typing": "41.4.2",
+        "@ckeditor/ckeditor5-ui": "41.4.2",
+        "@ckeditor/ckeditor5-undo": "41.4.2",
+        "@ckeditor/ckeditor5-upload": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "@ckeditor/ckeditor5-watchdog": "41.4.2",
+        "@ckeditor/ckeditor5-widget": "41.4.2",
+        "@ckeditor/ckeditor5-word-count": "41.4.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table/node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-46.0.3.tgz",
+      "integrity": "sha512-0w4fwXFExlcsDsPXgNrQz86WJWCUwIYJkcRbjL+K3fMRYBPGVoBO25OHL7tPy2rYvrnZindCJXW9w8FzKSsKhA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-41.4.2.tgz",
+      "integrity": "sha512-dXP+uNl+jkfrSIqMNai2yakR/3JqJ9g0M9WwwnV5vzbEOKD4YKP5+ixvqKb39dwLCLZ4mGpJaX+rjNXBExjSIw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-engine": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-41.4.2.tgz",
+      "integrity": "sha512-wvRbDXJN8PmaWyB0H487DjvdH2ayMyN52+WLkZlVbhX9ICb1sf5XnLz4v/wXeQ4W8JbWdsg2FZIDDQDeXjvyJw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "41.4.2",
+        "@ckeditor/ckeditor5-utils": "41.4.2",
+        "color-convert": "2.0.1",
+        "color-parse": "1.4.2",
+        "lodash-es": "4.17.21",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-46.0.3.tgz",
+      "integrity": "sha512-DnSBUIVOpARMDOtMrwvAOYAMZK263ubGLp48N4Yb4bpbE9VwH9KUaTNP1aRRE36wQ46KaPYiROqhnnq+RaemLQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-46.0.3.tgz",
+      "integrity": "sha512-VfC3KG1fIaXQkzQRjIlt3b+G44DPj39jD9I5cepLN/xXsHU/EAUcJWXScsd/GlViSDR0DUDCygWyhIIbF/Vobw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-upload/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "41.4.2",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-41.4.2.tgz",
+      "integrity": "sha512-VgLr2eLVggyhDqa7H8JUxpnOLTZ0R/YuDZ6ENVUumd9q4VrpNs94ZK0Y/Shp7UmuHQ/sTth+PWTsi+t5KwYqeQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-46.0.3.tgz",
+      "integrity": "sha512-TcSM3n9bsJ+Rpzc7NFN2BdobxXAnRJ52n0XY8CeVYZ0VA61GtG/zINH+OdEUORcpqKylH4F1ftyNEwf6cdUbPA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-46.0.3.tgz",
+      "integrity": "sha512-h5+KbQslzDVWntJQYCkSIj0huJSvE/lkjWTVCsbo2wmbKg6jusP+1oQ5ENtd7Nz4bpJlT83UkKDslSrF23xKlA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-widget/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-46.0.3.tgz",
+      "integrity": "sha512-Qobva/b/79t4hD6ZgWsBT3PgGIFXU2dZW62kFDJNVkGpq1pkKboIdq7Iu57OffLDJaV+xkAmEvV6cIDWc4KADA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -5182,25 +19159,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tinymce/tinymce-angular": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-angular/-/tinymce-angular-9.1.0.tgz",
-      "integrity": "sha512-hskVrvFpY0rb32zg+htrmDt3HuzFJADUA6i7Jtxy255xtGE+CD+vt9QkTTYsh1fVputUBRbo7PGY28iVGCCw7A==",
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=16.0.0",
-        "@angular/core": ">=16.0.0",
-        "@angular/forms": ">=16.0.0",
-        "rxjs": "^7.4.0",
-        "tinymce": "^8.0.0 || ^7.0.0 || ^6.0.0 || ^5.5.0"
-      },
-      "peerDependenciesMeta": {
-        "tinymce": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -5335,6 +19300,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/color-name": "^1.1.0"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5364,6 +19346,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -5421,6 +19413,16 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -5452,12 +19454,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "24.0.3",
@@ -5557,6 +19576,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -5577,6 +19603,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.0.0",
@@ -5773,6 +19806,13 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abbrev": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -5811,11 +19851,41 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals/node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6046,6 +20116,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -6158,6 +20234,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -6314,6 +20401,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/blurhash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -6397,6 +20490,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/browserslist": {
       "version": "4.25.0",
@@ -6585,7 +20684,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6643,6 +20741,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
@@ -6654,6 +20763,39 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chardet": {
@@ -6711,6 +20853,485 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/ckeditor5": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-46.0.3.tgz",
+      "integrity": "sha512-BGadZ1td6emWnNVbX40nygpxZMAYQvtC/wRhdhedJpjqmwXQmwLte9Y9RZg+lnomrEiLiaxzFsz1j4I6u2fBnA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "46.0.3",
+        "@ckeditor/ckeditor5-alignment": "46.0.3",
+        "@ckeditor/ckeditor5-autoformat": "46.0.3",
+        "@ckeditor/ckeditor5-autosave": "46.0.3",
+        "@ckeditor/ckeditor5-basic-styles": "46.0.3",
+        "@ckeditor/ckeditor5-block-quote": "46.0.3",
+        "@ckeditor/ckeditor5-bookmark": "46.0.3",
+        "@ckeditor/ckeditor5-ckbox": "46.0.3",
+        "@ckeditor/ckeditor5-ckfinder": "46.0.3",
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-cloud-services": "46.0.3",
+        "@ckeditor/ckeditor5-code-block": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-easy-image": "46.0.3",
+        "@ckeditor/ckeditor5-editor-balloon": "46.0.3",
+        "@ckeditor/ckeditor5-editor-classic": "46.0.3",
+        "@ckeditor/ckeditor5-editor-decoupled": "46.0.3",
+        "@ckeditor/ckeditor5-editor-inline": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-emoji": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-essentials": "46.0.3",
+        "@ckeditor/ckeditor5-find-and-replace": "46.0.3",
+        "@ckeditor/ckeditor5-font": "46.0.3",
+        "@ckeditor/ckeditor5-fullscreen": "46.0.3",
+        "@ckeditor/ckeditor5-heading": "46.0.3",
+        "@ckeditor/ckeditor5-highlight": "46.0.3",
+        "@ckeditor/ckeditor5-horizontal-line": "46.0.3",
+        "@ckeditor/ckeditor5-html-embed": "46.0.3",
+        "@ckeditor/ckeditor5-html-support": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-image": "46.0.3",
+        "@ckeditor/ckeditor5-indent": "46.0.3",
+        "@ckeditor/ckeditor5-language": "46.0.3",
+        "@ckeditor/ckeditor5-link": "46.0.3",
+        "@ckeditor/ckeditor5-list": "46.0.3",
+        "@ckeditor/ckeditor5-markdown-gfm": "46.0.3",
+        "@ckeditor/ckeditor5-media-embed": "46.0.3",
+        "@ckeditor/ckeditor5-mention": "46.0.3",
+        "@ckeditor/ckeditor5-minimap": "46.0.3",
+        "@ckeditor/ckeditor5-page-break": "46.0.3",
+        "@ckeditor/ckeditor5-paragraph": "46.0.3",
+        "@ckeditor/ckeditor5-paste-from-office": "46.0.3",
+        "@ckeditor/ckeditor5-remove-format": "46.0.3",
+        "@ckeditor/ckeditor5-restricted-editing": "46.0.3",
+        "@ckeditor/ckeditor5-select-all": "46.0.3",
+        "@ckeditor/ckeditor5-show-blocks": "46.0.3",
+        "@ckeditor/ckeditor5-source-editing": "46.0.3",
+        "@ckeditor/ckeditor5-special-characters": "46.0.3",
+        "@ckeditor/ckeditor5-style": "46.0.3",
+        "@ckeditor/ckeditor5-table": "46.0.3",
+        "@ckeditor/ckeditor5-theme-lark": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-undo": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "@ckeditor/ckeditor5-word-count": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-46.0.3.tgz",
+      "integrity": "sha512-xebONgXYuF8Fuhr6C+lpwRSfpChSrJKTy5S0i7vuBY+EeuXLRED7AuCOvPwV9oed1/CqbzDWWH1IefgkLwZwvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-autoformat": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-46.0.3.tgz",
+      "integrity": "sha512-E3bjlf8HbTD9FiGHPQyrbRXniA7W06CecmlKXwHDisGC8lLLF8ZpuRX4oGAH5QLpSVFyGuj0C1GJtVY0+PEjOw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-heading": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-basic-styles": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-46.0.3.tgz",
+      "integrity": "sha512-THmEPEbYopSfq8NTAugPLk+QW8/vuRkJfg/NpESzeugqCkBG2to3thOHdetbpye4IJBokLFhLsGFfKVYfVF81A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-block-quote": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-46.0.3.tgz",
+      "integrity": "sha512-8bI7GoxOPrIExt/32gxLDQJB5VdSp3Oi6fqA+GH0Lqj+ri8HKfl3S147GymTUfBh01IOymQNL7xX04Dq1Nbl6A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-46.0.3.tgz",
+      "integrity": "sha512-UnmCqOU/iyYDef/OVsWbixeXwo+0pb3YGNWgmd2YsCFUUerbpOkDwwGuvCZPE7Hs34lNz8ybbhjR9KmGu8WcAw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-cloud-services": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-image": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "blurhash": "2.0.5",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-46.0.3.tgz",
+      "integrity": "sha512-VXggqo2w0TgFPyu6z+uH3aTWQMhbq2F2iPUi8SreYCL0JclczbU4HDKqzQU+RKhrzp+yhK1n7ztX5aN1H9EVAw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-image": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-46.0.3.tgz",
+      "integrity": "sha512-eKmtcygKoAoba6LGKdsFQyU50yZeeFgD9k05HYnN4BZCqZjrmlTbo3mQrTREgM/w2yxQ4AkDVj162S9NOyibWA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-core": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.3.tgz",
+      "integrity": "sha512-J03+XnTDL+Ex43ttT4fBxfJGRQxDor0zJc3TxlX44g0q7xD1l7T2CIkorry+817e3By3Qe3DfiMSleHKuDnmvQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-watchdog": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-46.0.3.tgz",
+      "integrity": "sha512-UZs1G2wZaUr4lJSUsECBpM5ntr0UIXhGYG6lhE4Lf1TBaOypzxusR0H3txNtWIX1rq6hCeFH1P7meijfvJRgbw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-cloud-services": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-editor-classic": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-46.0.3.tgz",
+      "integrity": "sha512-fw4pdBqT1UpVYkBBpACQn9w5iR2Y62AvGW7ANt6b1nv55+FIN0uEAHsuChvZdFra8iJQR1qyilT24LVOTtk5mg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-engine": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.3.tgz",
+      "integrity": "sha512-U5BMV3pZTViU2ArsmmvfzqG1dt03laxgWtX8y2TtoEhaL+cNnT4N2cxj0StioeTbGAP3imkNKvVfRpRBhJIp/Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-essentials": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-46.0.3.tgz",
+      "integrity": "sha512-lUk+AkDVXb0YXEbyw+14sA5vFtXoWA4i6026tyN8I9uShMIyyjzkVUtTX9a0AWp5j//sJ5Ke+wMS0QUFRDtj+Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-select-all": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-undo": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-heading": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-46.0.3.tgz",
+      "integrity": "sha512-FKTgc1I9nDvnoDJ6RzkmPX7knhU3k6iH8IGUngH78TIOmhcWPVzv7Sftszos/LdX+kTc1ZoWWaHo5vrk90waZg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-paragraph": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-image": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.0.3.tgz",
+      "integrity": "sha512-9XcJVJxG+fqzwTupf7EATKeVZ+tXqeWiHLip4w/vMejjX026CPjiB3rKA2K5/H25TKDrvsMBBm22RqpK25dzCw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-undo": "46.0.3",
+        "@ckeditor/ckeditor5-upload": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-indent": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-46.0.3.tgz",
+      "integrity": "sha512-XLdlp94Bitkki027adnOqL642kCSJphMoZZDYYpTNHQkKhJq6TDp8u66EFlo2/q1quVDgb1qlezDuShouYd1tQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-heading": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-list": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-link": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-46.0.3.tgz",
+      "integrity": "sha512-s2wBD0QQ2Pz8wzTbh3YN83QbYRVbGp3qLwgN+8x7Y/bOuFE4AxR+JhDo14ekdXelXYxIeGJAqG2Z4SQj8v2rXQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-image": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-list": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.0.3.tgz",
+      "integrity": "sha512-KEAnyhUO6hWWa3GO6NGS7Entn2OXutCQ2+od8l5MrqeGxmpnqj0OpPX6qn+RZTVWf1RnqwErCYQhhPoQM/mlZg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-enter": "46.0.3",
+        "@ckeditor/ckeditor5-font": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-media-embed": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-46.0.3.tgz",
+      "integrity": "sha512-aozP4L8WQuPOHBA5qXTQnH3kQrhFJd6/J5KjKl5EicR6MUqeDkvzSLxYnltUBPByoDvkNxHD/GIL8nevgeWCrQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-typing": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-undo": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-paragraph": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-46.0.3.tgz",
+      "integrity": "sha512-3OlCeyykkhcueXmo+p/LppeCvC2TtEpljLpC042EbIOCJEbSMlYEGx/AJQGetn2JV8q9L3UKfgnltpOriXAeyg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-paste-from-office": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-46.0.3.tgz",
+      "integrity": "sha512-pgqBTqP3oIFbmHvk1ddICDmyvBvFE9d+jO0busPXl5oWIqTLaaumwWaredEEUJpYmu02POSrK+WPGS0Qis6mdg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "ckeditor5": "46.0.3"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-table": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.0.3.tgz",
+      "integrity": "sha512-Bt7d02s96cv28Xc+LxNRYBNrqlG7gI5xB8gjQWCuoIYHVikxtDUSBowu7q1UOkBmX/TEHuUpnYjUdBKD5M2n5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "46.0.3",
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@ckeditor/ckeditor5-widget": "46.0.3",
+        "ckeditor5": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-typing": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.3.tgz",
+      "integrity": "sha512-iyxTTWIJ1/DpjCk+Uca9bE8P+Q7nvMssustEoMd6b3n39McCxnnonW7hrLUjFsRf/lPuvcAhpvFApoy2cbBRZA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-ui": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.3.tgz",
+      "integrity": "sha512-5sRd7/IxWI+jL8N8CO5n35AwM5ofMieFLjvhtdzmkZsHl2hNHMHyfjERlOynp6tkX3TlelJBokqpAO7Yu+DrHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "46.0.3",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.3",
+        "@ckeditor/ckeditor5-engine": "46.0.3",
+        "@ckeditor/ckeditor5-icons": "46.0.3",
+        "@ckeditor/ckeditor5-utils": "46.0.3",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
+        "vanilla-colorful": "0.7.2"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/@ckeditor/ckeditor5-utils": {
+      "version": "46.0.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.3.tgz",
+      "integrity": "sha512-z+4EI8IOSJpDzKdRSw0KHmLK3LMwYeZ9R207oQzswqlbvhYcUib3HhfMlwhE6pyAGYTofpZQ2btHEOaLPRCTDQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "46.0.3",
+        "es-toolkit": "1.39.5"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/ckeditor5/node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "^2.0.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -6899,7 +21520,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6912,8 +21532,16 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -6921,6 +21549,29 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -7304,6 +21955,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "license": "MIT"
+    },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -7321,6 +21996,20 @@
         "node": ">= 14"
       }
     },
+    "node_modules/data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -7335,7 +22024,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7347,6 +22035,26 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/default-browser": {
@@ -7407,6 +22115,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7415,6 +22132,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -7445,6 +22172,20 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1464554",
@@ -7524,6 +22265,28 @@
       ],
       "license": "BSD-2-Clause"
     },
+    "node_modules/domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -7568,7 +22331,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7805,7 +22567,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7815,7 +22576,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7832,7 +22592,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7840,6 +22599,32 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -7912,11 +22697,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escodegen": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
@@ -7938,7 +22735,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -7948,7 +22744,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -7973,7 +22768,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -8020,7 +22814,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8177,7 +22970,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/external-editor": {
@@ -8429,6 +23221,22 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -8517,11 +23325,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -8560,7 +23374,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8585,7 +23398,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8660,7 +23472,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8697,7 +23508,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8710,7 +23520,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8726,13 +23535,251 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz",
+      "integrity": "sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "property-information": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hosted-git-info": {
@@ -8801,12 +23848,35 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -8974,7 +24044,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -9305,6 +24374,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9552,6 +24627,118 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.6",
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -10264,7 +25451,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -10408,6 +25600,17 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10474,6 +25677,17 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marked": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
@@ -10490,10 +25704,246 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -10563,6 +26013,597 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -10607,7 +26648,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10617,7 +26657,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -10877,7 +26916,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -11311,6 +27349,12 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -12010,6 +28054,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12078,6 +28133,27 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/psl/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -12184,6 +28260,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -12356,6 +28438,149 @@
         "node": ">=6"
       }
     },
+    "node_modules/rehype-dom-parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz",
+      "integrity": "sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-dom-stringify": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz",
+      "integrity": "sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-dom": "^4.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -12380,7 +28605,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -12630,7 +28854,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -12702,6 +28925,18 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.2",
@@ -13335,6 +29570,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -13503,6 +29749,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -13554,6 +29815,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -13794,12 +30061,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinymce": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.0.2.tgz",
-      "integrity": "sha512-Gkvn5mRcZCAK1EKP7hnk3VBzwqPbqpZU2AN0T08BMtvmY9Sg0C0ZqmMghJCQ3vgo+LWA38pDOPiaM8EW7BZEow==",
-      "license": "GPL-2.0-or-later"
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13836,6 +30097,60 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tr46/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tree-dump": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
@@ -13861,6 +30176,39 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/true-myth": {
@@ -14019,6 +30367,21 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/turndown": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-6.0.0.tgz",
+      "integrity": "sha512-UVJBhSyRHCpNKtQ00mNWlYUM/i+tcipkb++F0PrOpt0L7EhNd0AX9mWEpL2dRFBu7LWXMp4HgAMA4OeKKnN7og==",
+      "license": "MIT",
+      "dependencies": {
+        "jsdom": "^16.2.0"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -14152,6 +30515,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
@@ -14176,6 +30572,94 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -14227,6 +30711,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -14284,6 +30778,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/vanilla-colorful": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -14292,6 +30792,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -14379,6 +30909,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
+      "license": "MIT",
+      "dependencies": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
@@ -14410,6 +30962,26 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10.4"
+      }
     },
     "node_modules/webpack": {
       "version": "5.99.9",
@@ -14726,6 +31298,35 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -14860,6 +31461,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -15039,6 +31652,17 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
       "license": "MIT"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/choir-app-frontend/package.json
+++ b/choir-app-frontend/package.json
@@ -27,11 +27,11 @@
     "@angular/material": "^20.0.3",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
-    "@tinymce/tinymce-angular": "^9.1.0",
+    "@ckeditor/ckeditor5-angular": "^10.0.0",
+    "@ckeditor/ckeditor5-build-classic": "^41.4.2",
     "dompurify": "^3.1.6",
     "marked": "^12.0.2",
     "rxjs": "~7.8.0",
-    "tinymce": "^8.0.2",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },

--- a/choir-app-frontend/src/app/app.component.html
+++ b/choir-app-frontend/src/app/app.component.html
@@ -1,22 +1,2 @@
 <app-service-unavailable *ngIf="!backendAvailable"></app-service-unavailable>
 <router-outlet *ngIf="backendAvailable"></router-outlet>
-<editor apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-  [init]="{
-    plugins: [
-      // Core editing features
-      'anchor', 'autolink', 'charmap', 'codesample', 'emoticons', 'link', 'lists', 'media', 'searchreplace', 'table', 'visualblocks', 'wordcount',
-      // Your account includes a free trial of TinyMCE premium features
-      // Try the most popular premium features until Sep 22, 2025:
-      'checklist', 'mediaembed', 'casechange', 'formatpainter', 'pageembed', 'a11ychecker', 'tinymcespellchecker', 'permanentpen', 'powerpaste', 'advtable', 'advcode', 'advtemplate', 'ai', 'uploadcare', 'mentions', 'tinycomments', 'tableofcontents', 'footnotes', 'mergetags', 'autocorrect', 'typography', 'inlinecss', 'markdown','importword', 'exportword', 'exportpdf'
-    ],
-    toolbar: 'undo redo | blocks fontfamily fontsize | bold italic underline strikethrough | link media table mergetags | addcomment showcomments | spellcheckdialog a11ycheck typography uploadcare | align lineheight | checklist numlist bullist indent outdent | emoticons charmap | removeformat',
-    tinycomments_mode: 'embedded',
-    tinycomments_author: 'Author name',
-    mergetags_list: [
-      { value: 'First.Name', title: 'First Name' },
-      { value: 'Email', title: 'Email' },
-    ],
-    ai_request: (request, respondWith) => respondWith.string(() => Promise.reject('See docs to implement AI Assistant')),
-    uploadcare_public_key: '1853565034b54a658ceb',
-  }"
-></editor>

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.html
@@ -14,12 +14,12 @@
             (change)="toggleInviteHtml()"
             >HTML bearbeiten</mat-slide-toggle>
         </div>
-        <editor
-          apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-          [init]="editorConfig"
+        <ckeditor
+          [editor]="Editor"
+          [config]="editorConfig"
           [hidden]="inviteHtmlMode"
           formControlName="inviteBody"
-        ></editor>
+        ></ckeditor>
         <textarea
           *ngIf="inviteHtmlMode"
           class="html-editor"
@@ -49,12 +49,12 @@
             (change)="toggleResetHtml()"
             >HTML bearbeiten</mat-slide-toggle>
         </div>
-        <editor
-          apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-          [init]="editorConfig"
+        <ckeditor
+          [editor]="Editor"
+          [config]="editorConfig"
           [hidden]="resetHtmlMode"
           formControlName="resetBody"
-        ></editor>
+        ></ckeditor>
         <textarea
           *ngIf="resetHtmlMode"
           class="html-editor"
@@ -83,12 +83,12 @@
             (change)="toggleEmailChangeHtml()"
             >HTML bearbeiten</mat-slide-toggle>
         </div>
-        <editor
-          apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-          [init]="editorConfig"
+        <ckeditor
+          [editor]="Editor"
+          [config]="editorConfig"
           [hidden]="emailChangeHtmlMode"
           formControlName="emailChangeBody"
-        ></editor>
+        ></ckeditor>
         <textarea *ngIf="emailChangeHtmlMode" class="html-editor" formControlName="emailChangeBody"></textarea>
         <p class="hint">Folgende Platzhalter werden ersetzt: {{'{{link}}'}}, {{'{{expiry}}'}}, {{'{{first_name}}'}}, {{'{{surname}}'}}, {{'{{date}}'}}</p>
       </div>
@@ -111,12 +111,12 @@
             (change)="toggleAvailabilityHtml()"
             >HTML bearbeiten</mat-slide-toggle>
         </div>
-        <editor
-          apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-          [init]="editorConfig"
+        <ckeditor
+          [editor]="Editor"
+          [config]="editorConfig"
           [hidden]="availabilityHtmlMode"
           formControlName="availabilityBody"
-        ></editor>
+        ></ckeditor>
         <textarea
           *ngIf="availabilityHtmlMode"
           class="html-editor"
@@ -145,12 +145,12 @@
             (change)="toggleChangeHtml()"
             >HTML bearbeiten</mat-slide-toggle>
         </div>
-        <editor
-          apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-          [init]="editorConfig"
+        <ckeditor
+          [editor]="Editor"
+          [config]="editorConfig"
           [hidden]="changeHtmlMode"
           formControlName="changeBody"
-        ></editor>
+        ></ckeditor>
         <textarea
           *ngIf="changeHtmlMode"
           class="html-editor"
@@ -179,12 +179,12 @@
             (change)="toggleMonthlyHtml()"
             >HTML bearbeiten</mat-slide-toggle>
         </div>
-        <editor
-          apiKey="yg7ki8fidlweat8ztpe4exkehwid3ewwzof9uj595sbb0h1g"
-          [init]="editorConfig"
+        <ckeditor
+          [editor]="Editor"
+          [config]="editorConfig"
           [hidden]="monthlyHtmlMode"
           formControlName="monthlyBody"
-        ></editor>
+        ></ckeditor>
         <textarea
           *ngIf="monthlyHtmlMode"
           class="html-editor"

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
@@ -6,12 +6,13 @@ import { ApiService } from '@core/services/api.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MailTemplate } from '@core/models/mail-template';
 import { PendingChanges } from '@core/guards/pending-changes.guard';
-import { EditorModule } from '@tinymce/tinymce-angular';
+import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
+import * as ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 
 @Component({
   selector: 'app-mail-templates',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MaterialModule, EditorModule],
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule, CKEditorModule],
   templateUrl: './mail-templates.component.html',
   styleUrls: ['./mail-templates.component.scss']
 })
@@ -23,13 +24,10 @@ export class MailTemplatesComponent implements OnInit, PendingChanges {
   changeHtmlMode = false;
   monthlyHtmlMode = false;
   emailChangeHtmlMode = false;
+  public Editor = ClassicEditor;
   editorConfig = {
-    base_url: '/tinymce',
-    suffix: '.min',
-    height: 200,
-    menubar: false,
-    toolbar: 'bold italic underline | forecolor backcolor | link | removeformat'
-  };
+    toolbar: ['bold', 'italic', 'underline', 'link', 'undo', 'redo']
+  } as const;
 
   constructor(private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar) {
     this.form = this.fb.group({


### PR DESCRIPTION
## Summary
- replace TinyMCE with CKEditor 5 in mail template administration
- remove TinyMCE assets and demo usage

## Testing
- `npm run lint --prefix choir-app-frontend` (fails: many lint errors in repository)
- `npm test` (fails: ChromeHeadless missing libatk-1.0.so.0)


------
https://chatgpt.com/codex/tasks/task_e_68befc4dccfc8320b785f0c1e7f28359