### PR TITLE
Remove TinyMCE module and fix CKEditor setup

### DIFF
--- a/choir-app-frontend/src/app/app.component.ts
+++ b/choir-app-frontend/src/app/app.component.ts
@@ -5,31 +5,15 @@ import { ThemeService } from '@core/services/theme.service';
 import { ApiService } from '@core/services/api.service';
 import { ServiceUnavailableComponent } from '@features/service-unavailable/service-unavailable.component';
 import { CommonModule } from '@angular/common';
-import { EditorModule } from '@tinymce/tinymce-angular';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterModule, ServiceUnavailableComponent, CommonModule, EditorModule],
+  imports: [RouterModule, ServiceUnavailableComponent, CommonModule],
   templateUrl: './app.component.html',
 })
 export class AppComponent {
   backendAvailable = true;
-  editorInit = {
-    plugins: [
-      'anchor', 'autolink', 'charmap', 'codesample', 'emoticons', 'link', 'lists', 'media', 'searchreplace', 'table', 'visualblocks', 'wordcount',
-      'checklist', 'mediaembed', 'casechange', 'formatpainter', 'pageembed', 'a11ychecker', 'tinymcespellchecker', 'permanentpen', 'powerpaste', 'advtable', 'advcode', 'advtemplate', 'ai', 'uploadcare', 'mentions', 'tinycomments', 'tableofcontents', 'footnotes', 'mergetags', 'autocorrect', 'typography', 'inlinecss', 'markdown', 'importword', 'exportword', 'exportpdf'
-    ],
-    toolbar: 'undo redo | blocks fontfamily fontsize | bold italic underline strikethrough | link media table mergetags | addcomment showcomments | spellcheckdialog a11ycheck typography uploadcare | align lineheight | checklist numlist bullist indent outdent | emoticons charmap | removeformat',
-    tinycomments_mode: 'embedded',
-    tinycomments_author: 'Author name',
-    mergetags_list: [
-      { value: 'First.Name', title: 'First Name' },
-      { value: 'Email', title: 'Email' }
-    ],
-    ai_request: (request: any, respondWith: any) => respondWith.string(() => Promise.reject('See docs to implement AI Assistant')),
-    uploadcare_public_key: '1853565034b54a658ceb'
-  };
 
   constructor(private themeService: ThemeService,
               private api: ApiService) {

--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
@@ -7,7 +7,8 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MailTemplate } from '@core/models/mail-template';
 import { PendingChanges } from '@core/guards/pending-changes.guard';
 import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
-import * as ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import { EditorConfig } from '@ckeditor/ckeditor5-core';
 
 @Component({
   selector: 'app-mail-templates',
@@ -25,9 +26,9 @@ export class MailTemplatesComponent implements OnInit, PendingChanges {
   monthlyHtmlMode = false;
   emailChangeHtmlMode = false;
   public Editor = ClassicEditor;
-  editorConfig = {
+  public editorConfig: EditorConfig = {
     toolbar: ['bold', 'italic', 'underline', 'link', 'undo', 'redo']
-  } as const;
+  };
 
   constructor(private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar) {
     this.form = this.fb.group({


### PR DESCRIPTION
## Summary
- Remove TinyMCE EditorModule and unused configuration from AppComponent
- Correct CKEditor imports and configuration in mail templates component

## Testing
- `npm test` *(fails: ChromeHeadless failed to start: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3fffd1948320acffa891f013d43e