### PR TITLE
fix: resolve CKEditor type mismatch

### DIFF
--- a/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
+++ b/choir-app-frontend/src/app/features/admin/mail-templates/mail-templates.component.ts
@@ -8,7 +8,6 @@ import { MailTemplate } from '@core/models/mail-template';
 import { PendingChanges } from '@core/guards/pending-changes.guard';
 import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
-import { EditorConfig } from '@ckeditor/ckeditor5-core';
 
 @Component({
   selector: 'app-mail-templates',
@@ -25,8 +24,8 @@ export class MailTemplatesComponent implements OnInit, PendingChanges {
   changeHtmlMode = false;
   monthlyHtmlMode = false;
   emailChangeHtmlMode = false;
-  public Editor = ClassicEditor;
-  public editorConfig: EditorConfig = {
+  public Editor = ClassicEditor as any;
+  public editorConfig: any = {
     toolbar: ['bold', 'italic', 'underline', 'link', 'undo', 'redo']
   };
 


### PR DESCRIPTION
## Summary
- remove EditorConfig usage and cast ClassicEditor to any to avoid type mismatches

## Testing
- `npm run build`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb75d6288320a949c6c133d831f0