### PR TITLE
feat(admin): manage reset tokens

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -90,7 +90,7 @@ exports.getAllUsers = async (req, res) => {
     try {
         const users = await db.user.findAll({
             order: [['name', 'ASC']],
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
+            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin', 'resetToken', 'resetTokenExpiry'],
             include: [{
                 model: db.choir,
                 as: 'choirs',
@@ -218,6 +218,18 @@ exports.sendPasswordReset = async (req, res) => {
             await emailService.sendPasswordResetMail(user.email, token, user.name, user.firstName);
         }
         res.status(200).send({ message: 'Reset email sent if user exists.' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.clearResetToken = async (req, res) => {
+    const { id } = req.params;
+    try {
+        const user = await db.user.findByPk(id);
+        if (!user) return res.status(404).send({ message: 'Not found' });
+        await user.update({ resetToken: null, resetTokenExpiry: null });
+        res.status(200).send({ message: 'Reset token cleared.' });
     } catch (err) {
         res.status(500).send({ message: err.message });
     }

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -33,6 +33,7 @@ router.post("/users", wrap(controller.createUser));
 router.put("/users/:id", wrap(controller.updateUser));
 router.delete("/users/:id", wrap(controller.deleteUser));
 router.post("/users/:id/send-password-reset", wrap(controller.sendPasswordReset));
+router.delete("/users/:id/reset-token", wrap(controller.clearResetToken));
 router.get("/login-attempts", wrap(controller.getLoginAttempts));
 router.get('/mail-logs', wrap(controller.getMailLogs));
 router.delete('/mail-logs', wrap(controller.clearMailLogs));

--- a/choir-app-backend/tests/admin.controller.test.js
+++ b/choir-app-backend/tests/admin.controller.test.js
@@ -22,7 +22,16 @@ const controller = require('../src/controllers/admin.controller');
     assert.strictEqual(res.statusCode, 400, 'status 400 on invalid voice');
     assert.strictEqual(res.data.message, 'Invalid voice value.');
 
+    const resetUser = await db.user.create({ email: 'reset@example.com', roles: ['director'], resetToken: 'abc', resetTokenExpiry: new Date() });
+    res = { status(code){ this.statusCode = code; return this; }, send(data){ this.data = data; } };
+    await controller.clearResetToken({ params: { id: resetUser.id } }, res);
+    assert.strictEqual(res.statusCode, 200, 'status 200 on clear reset token');
+    const cleared = await db.user.findByPk(resetUser.id);
+    assert.strictEqual(cleared.resetToken, null, 'resetToken cleared');
+    assert.strictEqual(cleared.resetTokenExpiry, null, 'resetTokenExpiry cleared');
+
     console.log('admin.controller.updateUser voice tests passed');
+    console.log('admin.controller.clearResetToken tests passed');
     await db.sequelize.close();
   } catch (err) {
     console.error(err);

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -50,6 +50,8 @@ export interface User {
   availableChoirs?: Choir[];
   lastDonation?: string;
   lastLogin?: string;
+  resetToken?: string | null;
+  resetTokenExpiry?: string | null;
 }
 
 export interface UserInChoir extends User {

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -76,6 +76,10 @@ export class AdminService {
     return this.http.post(`${this.apiUrl}/admin/users/${id}/send-password-reset`, {});
   }
 
+  clearResetToken(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/admin/users/${id}/reset-token`);
+  }
+
   getLoginAttempts(year?: number, month?: number): Observable<LoginAttempt[]> {
     const params: any = {};
     if (year !== undefined && month !== undefined) {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -681,6 +681,10 @@ export class ApiService {
     return this.adminService.sendPasswordReset(id);
   }
 
+  clearResetToken(id: number): Observable<any> {
+    return this.adminService.clearResetToken(id);
+  }
+
   getLoginAttempts(year?: number, month?: number): Observable<LoginAttempt[]> {
     return this.adminService.getLoginAttempts(year, month);
   }

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -51,6 +51,15 @@
     <mat-cell *matCellDef="let element">{{ element.lastLogin | date:'short' }}</mat-cell>
   </ng-container>
 
+  <ng-container matColumnDef="resetToken">
+    <mat-header-cell *matHeaderCellDef>Reset-Token</mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      <ng-container *ngIf="element.resetToken">
+        {{ element.resetTokenExpiry | date:'short' }}
+      </ng-container>
+    </mat-cell>
+  </ng-container>
+
   <ng-container matColumnDef="actions">
     <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let element">
@@ -62,6 +71,9 @@
       </button>
       <button mat-icon-button (click)="sendReset(element)">
         <mat-icon>mail</mat-icon>
+      </button>
+      <button mat-icon-button (click)="clearReset(element)" *ngIf="element.resetToken">
+        <mat-icon>clear</mat-icon>
       </button>
       <button mat-icon-button color="warn" (click)="deleteUser(element)">
         <mat-icon>delete</mat-icon>
@@ -99,6 +111,7 @@
       </div>
       <div><strong>Chöre:</strong> {{ choirList(element) }}</div>
       <div><strong>Letzter Login:</strong> {{ element.lastLogin | date:'short' }}</div>
+      <div *ngIf="element.resetToken"><strong>Reset-Token:</strong> {{ element.resetTokenExpiry | date:'short' }}</div>
     </div>
     <div class="mobile-actions">
       <button mat-icon-button color="primary" (click)="editUser(element)">
@@ -109,6 +122,9 @@
       </button>
       <button mat-icon-button (click)="sendReset(element)">
         <mat-icon>mail</mat-icon>
+      </button>
+      <button mat-icon-button (click)="clearReset(element)" *ngIf="element.resetToken">
+        <mat-icon>clear</mat-icon>
       </button>
       <button mat-icon-button color="warn" (click)="deleteUser(element)">
         <mat-icon>delete</mat-icon>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -22,7 +22,7 @@ import { map } from 'rxjs/operators';
 })
 export class ManageUsersComponent implements OnInit {
   users: User[] = [];
-  displayedColumns = ['name', 'email', 'roles', 'choirs', 'lastLogin', 'actions'];
+  displayedColumns = ['name', 'email', 'roles', 'choirs', 'lastLogin', 'resetToken', 'actions'];
   dataSource = new MatTableDataSource<User>();
   filterValue = '';
   isHandset$: Observable<boolean>;
@@ -94,6 +94,16 @@ export class ManageUsersComponent implements OnInit {
     if (confirm('Passwort-Reset-E-Mail senden?')) {
       this.api.sendPasswordReset(user.id).subscribe(() => {
         this.snack.open('E-Mail gesendet, falls der Benutzer existiert.', 'OK', { duration: 3000 });
+      });
+    }
+  }
+
+  clearReset(user: User): void {
+    if (confirm('Reset-Token löschen?')) {
+      this.api.clearResetToken(user.id).subscribe(() => {
+        user.resetToken = null;
+        user.resetTokenExpiry = null;
+        this.snack.open('Reset-Token gelöscht', 'OK', { duration: 3000 });
       });
     }
   }


### PR DESCRIPTION
## Summary
- show reset token info for users and allow admins to clear reset tokens
- expose backend endpoint to clear a user's reset token
- wire up frontend admin panel to view token expiry and delete tokens

## Testing
- `npm run test:backend`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run lint` *(fails: 659 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbf9cb79c8320932d66814ac8c285