### PR TITLE
Add municipality and district fields with admin-managed districts

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -81,6 +81,7 @@ const clientErrorRoutes = require("./routes/client-error.routes");
 const postRoutes = require("./routes/post.routes");
 const libraryRoutes = require("./routes/library.routes");
 const programRoutes = require("./routes/program.routes");
+const districtRoutes = require("./routes/district.routes");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
@@ -112,6 +113,7 @@ app.use("/api/client-errors", clientErrorRoutes);
 app.use("/api/posts", postRoutes);
 app.use("/api/library", libraryRoutes);
 app.use("/api/programs", programRoutes);
+app.use("/api/districts", districtRoutes);
 
 // Handle 404 for unknown routes
 app.use((req, res, _next) => {

--- a/choir-app-backend/src/controllers/district.controller.js
+++ b/choir-app-backend/src/controllers/district.controller.js
@@ -1,0 +1,41 @@
+const db = require('../models');
+const District = db.district;
+
+exports.getAll = async (_req, res) => {
+  try {
+    const districts = await District.findAll({ order: [['name', 'ASC']] });
+    res.status(200).send(districts);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.create = async (req, res) => {
+  const { name } = req.body;
+  if (!name) {
+    return res.status(400).send({ message: 'Name is required.' });
+  }
+  try {
+    const district = await District.create({ name });
+    res.status(201).send(district);
+  } catch (err) {
+    if (err.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).send({ message: 'District already exists.' });
+    }
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.remove = async (req, res) => {
+  try {
+    const id = req.params.id;
+    const district = await District.findByPk(id);
+    if (!district) {
+      return res.status(404).send({ message: 'District not found.' });
+    }
+    await district.destroy();
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+};

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -9,7 +9,7 @@ const emailService = require('../services/email.service');
 exports.getMe = async (req, res) => {
     try {
         const user = await User.findByPk(req.userId, {
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'helpShown'],
+            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'parish', 'district', 'voice', 'shareWithChoir', 'helpShown'],
             include: [{
                 model: Choir,
                 as: 'choirs', // Use the plural alias 'choirs' defined in the association
@@ -37,7 +37,7 @@ exports.getMe = async (req, res) => {
  * @description Update the profile of the currently logged-in user.
  */
  exports.updateMe = async (req, res) => {
-    const { firstName, name, email, street, postalCode, city, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
+    const { firstName, name, email, street, postalCode, city, parish, district, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
 
     try {
         const VOICE_OPTIONS = User.rawAttributes.voice.values;
@@ -75,6 +75,12 @@ exports.getMe = async (req, res) => {
         }
         if (city !== undefined) {
             updateData.city = city;
+        }
+        if (parish !== undefined) {
+            updateData.parish = parish;
+        }
+        if (district !== undefined) {
+            updateData.district = district;
         }
         if (voice !== undefined) {
             const normalizedVoice = voice === '' ? null : voice;

--- a/choir-app-backend/src/models/district.model.js
+++ b/choir-app-backend/src/models/district.model.js
@@ -1,0 +1,10 @@
+module.exports = (sequelize, DataTypes) => {
+  const District = sequelize.define('district', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+  });
+  return District;
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -48,6 +48,7 @@ db.loan_request_item = require("./loan_request_item.model.js")(sequelize, Sequel
 db.program = require("./program.model.js")(sequelize, Sequelize);
 db.program_element = require("./program_element.model.js")(sequelize, Sequelize);
 db.program_item = require("./program_item.model.js")(sequelize, Sequelize);
+db.district = require("./district.model.js")(sequelize, Sequelize);
 
 
 // --- Define Associations ---

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -61,6 +61,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true
     },
+    parish: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    district: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
     voice: {
       type: DataTypes.ENUM('Sopran I', 'Sopran II', 'Alt I', 'Alt II', 'Tenor I', 'Tenor II', 'Bass I', 'Bass II'),
       allowNull: true

--- a/choir-app-backend/src/routes/district.routes.js
+++ b/choir-app-backend/src/routes/district.routes.js
@@ -1,0 +1,13 @@
+const authJwt = require("../middleware/auth.middleware");
+const role = require("../middleware/role.middleware");
+const controller = require("../controllers/district.controller");
+const router = require("express").Router();
+const { handler: wrap } = require("../utils/async");
+
+router.use(authJwt.verifyToken);
+
+router.get("/", wrap(controller.getAll));
+router.post("/", role.requireAdmin, wrap(controller.create));
+router.delete("/:id", role.requireAdmin, wrap(controller.remove));
+
+module.exports = router;

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -100,6 +100,10 @@ async function seedDatabase(options = {}) {
                 where: { key: 'SYSTEM_ADMIN_EMAIL' },
                 defaults: { value: process.env.SYSTEM_ADMIN_EMAIL || '' }
             });
+            const districts = ['Braunschweig', 'Göttingen', 'Hannover-Nordost', 'Hannover-Südwest', 'Hildesheim', 'Lübeck-Schwerin', 'Lüneburg', 'Wolfenbüttel'];
+            for (const name of districts) {
+                await db.district.findOrCreate({ where: { name }, defaults: { name } });
+            }
             logger.info("Initial seeding completed successfully.");
         } else {
             logger.info("Database already seeded. Skipping initial setup.");

--- a/choir-app-frontend/src/app/core/models/district.ts
+++ b/choir-app-frontend/src/app/core/models/district.ts
@@ -1,0 +1,4 @@
+export interface District {
+  id: number;
+  name: string;
+}

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -28,6 +28,8 @@ export interface User {
   street?: string;
   postalCode?: string;
   city?: string;
+  parish?: string;
+  district?: string;
   voice?: string;
   shareWithChoir?: boolean;
 

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -53,6 +53,8 @@ import { MonthlyPlanService } from './monthly-plan.service';
 import { PostService } from './post.service';
 import { LibraryService } from './library.service';
 import { ProgramService } from './program.service';
+import { District } from '../models/district';
+import { DistrictService } from './district.service';
 
 @Injectable({
   providedIn: 'root'
@@ -80,7 +82,8 @@ export class ApiService {
               private monthlyPlanService: MonthlyPlanService,
               private postService: PostService,
               private libraryService: LibraryService,
-              private programService: ProgramService) {
+              private programService: ProgramService,
+              private districtService: DistrictService) {
 
   }
 
@@ -166,6 +169,20 @@ export class ApiService {
   }
   reportPiece(pieceId: number, category: string, reason: string) {
     return this.pieceService.reportPiece(pieceId, category, reason);
+  }
+
+  // --- Districts ---
+
+  getDistricts(): Observable<District[]> {
+    return this.districtService.getDistricts();
+  }
+
+  createDistrict(name: string): Observable<District> {
+    return this.districtService.createDistrict({ name });
+  }
+
+  deleteDistrict(id: number): Observable<any> {
+    return this.districtService.deleteDistrict(id);
   }
 
   // --- Global Piece Methods ---

--- a/choir-app-frontend/src/app/core/services/district.service.ts
+++ b/choir-app-frontend/src/app/core/services/district.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CreatorService } from './creator.service';
+import { District } from '../models/district';
+
+@Injectable({ providedIn: 'root' })
+export class DistrictService extends CreatorService<District> {
+  constructor(http: HttpClient) { super(http, 'districts'); }
+
+  getDistricts(): Observable<District[]> { return this.getAll(); }
+  createDistrict(data: { name: string }): Observable<District> { return this.create(data); }
+  deleteDistrict(id: number): Observable<any> { return this.delete(id); }
+}

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; parish?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -18,6 +18,7 @@ export const adminRoutes: Routes = [
       { path: 'publishers', loadComponent: () => import('./manage-publishers/manage-publishers.component').then(m => m.ManagePublishersComponent), data: { title: 'Admin – Verlage' } },
       { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent), data: { title: 'Admin – Chöre' } },
       { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent), data: { title: 'Admin – Benutzer' } },
+      { path: 'districts', loadComponent: () => import('./manage-districts/manage-districts.component').then(m => m.ManageDistrictsComponent), data: { title: 'Admin – Bezirke' } },
       { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent), data: { title: 'Admin – Änderungen' } },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent), data: { title: 'Admin – Protokolle' } },
       { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent), data: { title: 'Admin – Develop' } },

--- a/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.html
@@ -1,0 +1,24 @@
+<h2>Bezirke verwalten</h2>
+
+<form [formGroup]="form" (ngSubmit)="add()" class="add-form">
+  <mat-form-field appearance="outline">
+    <mat-label>Bezirk</mat-label>
+    <input matInput formControlName="name">
+  </mat-form-field>
+  <button mat-flat-button color="primary" type="submit">Hinzufügen</button>
+</form>
+
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Bezirk</th>
+    <td mat-cell *matCellDef="let d">{{ d.name }}</td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+    <td mat-cell *matCellDef="let d">
+      <button mat-icon-button color="warn" (click)="delete(d)"><mat-icon>delete</mat-icon></button>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.scss
@@ -1,0 +1,6 @@
+.add-form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 16px;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ManageDistrictsComponent } from './manage-districts.component';
+import { of } from 'rxjs';
+import { ApiService } from '@core/services/api.service';
+
+class MockApiService {
+  getDistricts() { return of([]); }
+  createDistrict() { return of({}); }
+  deleteDistrict() { return of({}); }
+}
+
+describe('ManageDistrictsComponent', () => {
+  let component: ManageDistrictsComponent;
+  let fixture: ComponentFixture<ManageDistrictsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ManageDistrictsComponent],
+      providers: [{ provide: ApiService, useClass: MockApiService }]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ManageDistrictsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { District } from '@core/models/district';
+import { MatTableDataSource } from '@angular/material/table';
+import { Subject, takeUntil } from 'rxjs';
+
+@Component({
+  selector: 'app-manage-districts',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './manage-districts.component.html',
+  styleUrls: ['./manage-districts.component.scss']
+})
+export class ManageDistrictsComponent implements OnInit, OnDestroy {
+  displayedColumns = ['name', 'actions'];
+  dataSource = new MatTableDataSource<District>([]);
+  form: FormGroup;
+  private destroy$ = new Subject<void>();
+
+  constructor(private api: ApiService, private fb: FormBuilder) {
+    this.form = this.fb.group({ name: [''] });
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  load(): void {
+    this.api.getDistricts().pipe(takeUntil(this.destroy$)).subscribe(ds => {
+      this.dataSource.data = ds;
+    });
+  }
+
+  add(): void {
+    const name = this.form.value.name?.trim();
+    if (!name) { return; }
+    this.api.createDistrict(name).pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.form.reset();
+      this.load();
+    });
+  }
+
+  delete(d: District): void {
+    if (confirm(`Bezirk "${d.name}" löschen?`)) {
+      this.api.deleteDistrict(d.id).pipe(takeUntil(this.destroy$)).subscribe(() => this.load());
+    }
+  }
+}

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -50,6 +50,19 @@
           </mat-form-field>
 
           <mat-form-field appearance="outline">
+            <mat-label>Bezirk</mat-label>
+            <input type="text" matInput formControlName="district" [matAutocomplete]="districtAuto">
+            <mat-autocomplete #districtAuto="matAutocomplete">
+              <mat-option *ngFor="let d of districts" [value]="d.name">{{ d.name }}</mat-option>
+            </mat-autocomplete>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Gemeinde</mat-label>
+            <input matInput formControlName="parish">
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
             <mat-label>Stimmlage</mat-label>
             <mat-select formControlName="voice">
               <mat-option value="">-</mat-option>

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.spec.ts
@@ -13,6 +13,7 @@ class MockApiService {
     return of({ id: 1, firstName: 'Admin', name: 'User', email: 'admin@example.com', roles: ['admin'] });
   }
   updateCurrentUser() { return of({}); }
+  getDistricts() { return of([]); }
 }
 
 describe('ProfileComponent', () => {


### PR DESCRIPTION
## Summary
- extend user profile with parish and district fields
- add backend endpoints and seeding for configurable districts
- allow admins to manage district list and prompt users to complete missing profile info

## Testing
- `cd choir-app-backend && npm test`
- `cd choir-app-frontend && npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc29192888320b063717ff2bace77