### PR TITLE
Fix incorrect first_name placeholder in emails

### DIFF
--- a/choir-app-backend/src/services/email.service.js
+++ b/choir-app-backend/src/services/email.service.js
@@ -18,12 +18,12 @@ async function sendTemplateMail(type, to, replacements = {}, overrideSettings) {
   // merge defaults first to avoid undefined values overriding fallbacks
   const final = { date: formatDate(), ...replacements };
 
-  // prefer a provided first name over a surname and fall back to email prefix
+  // prefer provided names and fall back to the email prefix
   if (!final.surname) {
     final.surname = final.name || to.split('@')[0];
   }
   if (!final.first_name) {
-    final.first_name = final.firstName || final.name || to.split('@')[0];
+    final.first_name = final.firstName || to.split('@')[0];
   }
 
   const { subject, html, text } = buildTemplate(template, type, final);

--- a/choir-app-backend/tests/email.service.test.js
+++ b/choir-app-backend/tests/email.service.test.js
@@ -33,6 +33,12 @@ const db = require('../src/models');
       await emailService2.sendInvitationMail('tester@example.com', 'tok', 'Choir', new Date(), undefined, 'Invitor', undefined);
       assert.ok(capturedOptions.html.includes('tester tester'), 'Fallback to email prefix failed');
 
+      // Test that first_name does not fall back to surname when only surname is provided
+      capturedOptions = undefined;
+      await db.mail_template.create({ type: 'reset', subject: '', body: 'Hallo {{first_name}} {{surname}}' });
+      await emailService2.sendPasswordResetMail('tester@example.com', 'tok', 'Nachname', undefined);
+      assert.ok(capturedOptions.html.includes('tester Nachname'), 'First name should fall back to email prefix, not surname');
+
       emailTransporter.sendMail = originalSendMail;
 
       console.log('email.service tests passed');


### PR DESCRIPTION
## Summary
- stop using surname as fallback for `first_name` when building email templates
- add regression test ensuring first name defaults to email prefix rather than surname

## Testing
- `npm test --prefix choir-app-backend`
- `npm run lint --prefix choir-app-backend` *(fails: no-unused-vars and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc4ce21e883208be6e35dcfe6c748