### PR TITLE
Handle missing member names in participation sorting

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
@@ -1,0 +1,15 @@
+import { ParticipationComponent } from './participation.component';
+import { UserInChoir } from '@core/models/user';
+
+describe('ParticipationComponent', () => {
+  it('sortByVoice should handle null names', () => {
+    const component = new ParticipationComponent({} as any);
+    const members: UserInChoir[] = [
+      { id: 1, name: null as any, email: '', voice: 'SOPRAN' },
+      { id: 2, name: 'Alpha', email: '', voice: 'SOPRAN' }
+    ];
+    expect(() => component['sortByVoice'](members)).not.toThrow();
+    const sorted = component['sortByVoice'](members);
+    expect(sorted.length).toBe(2);
+  });
+});

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -175,15 +175,19 @@ export class ParticipationComponent implements OnInit {
     return members.sort((a, b) => {
       const va = this.voiceOrder.indexOf(this.baseVoice(this.voiceOf(a).toUpperCase()));
       const vb = this.voiceOrder.indexOf(this.baseVoice(this.voiceOf(b).toUpperCase()));
+      const aName = a.name ?? '';
+      const bName = b.name ?? '';
+      const aFirst = a.firstName ?? '';
+      const bFirst = b.firstName ?? '';
       if (va === -1 && vb === -1) {
-        const ln = a.name.localeCompare(b.name);
-        return ln !== 0 ? ln : (a.firstName || '').localeCompare(b.firstName || '');
+        const ln = aName.localeCompare(bName);
+        return ln !== 0 ? ln : aFirst.localeCompare(bFirst);
       }
       if (va === -1) return 1;
       if (vb === -1) return -1;
       if (va !== vb) return va - vb;
-      const ln = a.name.localeCompare(b.name);
-      return ln !== 0 ? ln : (a.firstName || '').localeCompare(b.firstName || '');
+      const ln = aName.localeCompare(bName);
+      return ln !== 0 ? ln : aFirst.localeCompare(bFirst);
     });
   }
 


### PR DESCRIPTION
## Summary
- guard against null `name` values when sorting choir members
- add regression test for participation sorting

## Testing
- `npm test`
- `npm run lint` *(fails: 667 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfccd53b748320909367c9269fec09