### PR TITLE
feat: add district and congregation fields

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -90,7 +90,7 @@ exports.getAllUsers = async (req, res) => {
     try {
         const users = await db.user.findAll({
             order: [['name', 'ASC']],
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin', 'resetToken', 'resetTokenExpiry'],
+            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin', 'resetToken', 'resetTokenExpiry'],
             include: [{
                 model: db.choir,
                 as: 'choirs',
@@ -107,7 +107,7 @@ exports.getAllUsers = async (req, res) => {
 const bcrypt = require('bcryptjs');
 
 exports.createUser = async (req, res) => {
-    const { firstName, name, email, password, roles, street, postalCode, city, voice, shareWithChoir } = req.body;
+    const { firstName, name, email, password, roles, street, postalCode, city, congregation, district, voice, shareWithChoir } = req.body;
     try {
         const VOICE_OPTIONS = db.user.rawAttributes.voice.values;
         const normalizedVoice = voice === '' ? null : voice;
@@ -124,6 +124,8 @@ exports.createUser = async (req, res) => {
             street,
             postalCode,
             city,
+            congregation,
+            district,
             voice: normalizedVoice,
             shareWithChoir: !!shareWithChoir
         });
@@ -139,7 +141,7 @@ exports.createUser = async (req, res) => {
 
 exports.updateUser = async (req, res) => {
     const { id } = req.params;
-    const { firstName, name, email, password, roles, street, postalCode, city, voice, shareWithChoir } = req.body;
+    const { firstName, name, email, password, roles, street, postalCode, city, congregation, district, voice, shareWithChoir } = req.body;
     try {
         const VOICE_OPTIONS = db.user.rawAttributes.voice.values;
         const user = await db.user.findByPk(id);
@@ -153,6 +155,8 @@ exports.updateUser = async (req, res) => {
             street: street ?? user.street,
             postalCode: postalCode ?? user.postalCode,
             city: city ?? user.city,
+            congregation: congregation ?? user.congregation,
+            district: district ?? user.district,
             shareWithChoir: shareWithChoir !== undefined ? !!shareWithChoir : user.shareWithChoir,
             ...(password ? { password: bcrypt.hashSync(password, 8) } : {})
         };
@@ -191,7 +195,7 @@ exports.getUserByEmail = async (req, res) => {
     try {
         const user = await db.user.findOne({
             where: { email },
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
+            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
             include: [{
                 model: db.choir,
                 as: 'choirs',

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -9,7 +9,7 @@ const emailService = require('../services/email.service');
 exports.getMe = async (req, res) => {
     try {
         const user = await User.findByPk(req.userId, {
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'parish', 'district', 'voice', 'shareWithChoir', 'helpShown'],
+            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'helpShown'],
             include: [{
                 model: Choir,
                 as: 'choirs', // Use the plural alias 'choirs' defined in the association
@@ -37,7 +37,7 @@ exports.getMe = async (req, res) => {
  * @description Update the profile of the currently logged-in user.
  */
  exports.updateMe = async (req, res) => {
-    const { firstName, name, email, street, postalCode, city, parish, district, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
+    const { firstName, name, email, street, postalCode, city, congregation, district, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
 
     try {
         const VOICE_OPTIONS = User.rawAttributes.voice.values;
@@ -76,8 +76,8 @@ exports.getMe = async (req, res) => {
         if (city !== undefined) {
             updateData.city = city;
         }
-        if (parish !== undefined) {
-            updateData.parish = parish;
+        if (congregation !== undefined) {
+            updateData.congregation = congregation;
         }
         if (district !== undefined) {
             updateData.district = district;

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -61,7 +61,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true
     },
-    parish: {
+    congregation: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -28,7 +28,7 @@ export interface User {
   street?: string;
   postalCode?: string;
   city?: string;
-  parish?: string;
+  congregation?: string;
   district?: string;
   voice?: string;
   shareWithChoir?: boolean;

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; parish?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -28,6 +28,14 @@
       <input matInput formControlName="city">
     </mat-form-field>
     <mat-form-field appearance="outline">
+      <mat-label>Bezirk</mat-label>
+      <input matInput formControlName="district">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Gemeinde</mat-label>
+      <input matInput formControlName="congregation">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
       <mat-label>Stimmlage</mat-label>
       <mat-select formControlName="voice">
         <mat-option value="">-</mat-option>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -29,6 +29,8 @@ export class UserDialogComponent {
       street: [data?.street || ''],
       postalCode: [data?.postalCode || ''],
       city: [data?.city || ''],
+      district: [data?.district || ''],
+      congregation: [data?.congregation || ''],
       voice: [data?.voice || ''],
       shareWithChoir: [data?.shareWithChoir || false],
       roles: [data?.roles || ['director'], Validators.required],

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -59,7 +59,7 @@
 
           <mat-form-field appearance="outline">
             <mat-label>Gemeinde</mat-label>
-            <input matInput formControlName="parish">
+            <input matInput formControlName="congregation">
           </mat-form-field>
 
           <mat-form-field appearance="outline">

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -51,7 +51,7 @@ export class ProfileComponent implements OnInit {
       street: [''],
       postalCode: [''],
       city: [''],
-      parish: [''],
+      congregation: [''],
       district: [''],
       voice: [''],
       shareWithChoir: [false],
@@ -77,7 +77,7 @@ export class ProfileComponent implements OnInit {
           street: user.street || '',
           postalCode: user.postalCode || '',
           city: user.city || '',
-          parish: user.parish || '',
+          congregation: user.congregation || '',
           district: user.district || '',
           voice: user.voice || '',
           shareWithChoir: !!user.shareWithChoir,
@@ -86,7 +86,7 @@ export class ProfileComponent implements OnInit {
         if (user.roles?.includes('admin')) {
           this.profileForm.get('roles')?.enable();
         }
-        if (!user.parish || !user.district) {
+        if (!user.congregation || !user.district) {
           this.snackBar.open('Bitte ergänze dein Profil um Gemeinde und Bezirk.', 'OK', { duration: 10000, verticalPosition: 'top' });
         }
         this.isLoading = false;
@@ -105,14 +105,14 @@ export class ProfileComponent implements OnInit {
 
     const formValue = this.profileForm.value;
     const oldEmail = this.currentUser?.email;
-    const updatePayload: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; parish?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] } = {
+    const updatePayload: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] } = {
       firstName: formValue.firstName,
       name: formValue.name,
       email: formValue.email,
       street: formValue.street,
       postalCode: formValue.postalCode,
       city: formValue.city,
-      parish: formValue.parish,
+      congregation: formValue.congregation,
       district: formValue.district,
       voice: formValue.voice,
       shareWithChoir: formValue.shareWithChoir


### PR DESCRIPTION
## Summary
- show Bezirk and Gemeinde in admin user dialog
- rename parish field to congregation throughout app
- support storing congregation and district for users in backend

## Testing
- `npm test` (fails: ChromeHeadless missing libatk-1.0.so.0)
- `npm run test:backend`
- `npm run lint` (fails: 666 lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68bfcd31acd883208226ec5546cf35f5