### PR TITLE
Display availability and allow sorting in participation view

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -1,3 +1,13 @@
+<div class="controls" *ngIf="members.length > 0">
+  <mat-form-field appearance="fill">
+    <mat-label>Sortierung</mat-label>
+    <mat-select [value]="sortMode" (selectionChange)="onSortModeChange($any($event.value))">
+      <mat-option value="voice">nach Stimme</mat-option>
+      <mat-option value="name">alphabetisch</mat-option>
+    </mat-select>
+  </mat-form-field>
+</div>
+
 <div class="table-container mat-elevation-z4" *ngIf="members.length > 0">
   <mat-table [dataSource]="members">
     <ng-container matColumnDef="name">
@@ -13,7 +23,7 @@
     <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
       <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
       <mat-cell *matCellDef="let m">
-        <mat-icon *ngIf="iconFor(status(m.id, col.key)) as icon">{{ icon }}</mat-icon>
+        <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, col.key)) as icon" [ngClass]="classFor(status(m.id, col.key))">{{ icon }}</mat-icon>
       </mat-cell>
     </ng-container>
 
@@ -21,7 +31,7 @@
       <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
       <mat-cell *matCellDef="let m">
         <ng-container *ngFor="let ev of col.events">
-          <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon">{{ icon }}</mat-icon>
+          <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon" [ngClass]="classFor(status(m.id, ev.date))">{{ icon }}</mat-icon>
         </ng-container>
       </mat-cell>
     </ng-container>

--- a/choir-app-frontend/src/app/features/participation/participation.component.scss
+++ b/choir-app-frontend/src/app/features/participation/participation.component.scss
@@ -2,8 +2,24 @@
   overflow-x: auto;
 }
 
+.controls {
+  margin-bottom: 1em;
+}
+
 .status-icon {
   font-size: 16px;
   vertical-align: middle;
   margin-right: 2px;
+}
+
+.available {
+  color: #388e3c;
+}
+
+.maybe {
+  color: #fbc02d;
+}
+
+.unavailable {
+  color: #d32f2f;
 }

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -24,6 +24,7 @@ interface MonthColumn extends EventColumn {
 })
 export class ParticipationComponent implements OnInit {
   members: UserInChoir[] = [];
+  sortMode: 'voice' | 'name' = 'voice';
   displayMode: 'events' | 'months' = 'events';
   eventColumns: EventColumn[] = [];
   monthColumns: MonthColumn[] = [];
@@ -40,7 +41,7 @@ export class ParticipationComponent implements OnInit {
 
   private loadMembers(): void {
     this.api.getChoirMembers().subscribe(m => {
-      this.members = this.sortByVoice(m);
+      this.members = this.sortMembers(m);
     });
   }
 
@@ -104,7 +105,17 @@ export class ParticipationComponent implements OnInit {
   iconFor(status?: string): string {
     switch (status) {
       case 'AVAILABLE': return 'check';
+      case 'MAYBE': return 'help';
       case 'UNAVAILABLE': return 'close';
+      default: return '';
+    }
+  }
+
+  classFor(status?: string): string {
+    switch (status) {
+      case 'AVAILABLE': return 'available';
+      case 'MAYBE': return 'maybe';
+      case 'UNAVAILABLE': return 'unavailable';
       default: return '';
     }
   }
@@ -171,6 +182,15 @@ export class ParticipationComponent implements OnInit {
     return this.baseVoiceMap[voice] || voice;
   }
 
+  private sortMembers(members: UserInChoir[]): UserInChoir[] {
+    return this.sortMode === 'name' ? this.sortByName(members) : this.sortByVoice(members);
+  }
+
+  onSortModeChange(mode: 'voice' | 'name'): void {
+    this.sortMode = mode;
+    this.members = this.sortMembers([...this.members]);
+  }
+
   private sortByVoice(members: UserInChoir[]): UserInChoir[] {
     return members.sort((a, b) => {
       const va = this.voiceOrder.indexOf(this.baseVoice(this.voiceOf(a).toUpperCase()));
@@ -182,6 +202,13 @@ export class ParticipationComponent implements OnInit {
       if (va === -1) return 1;
       if (vb === -1) return -1;
       if (va !== vb) return va - vb;
+      const ln = a.name.localeCompare(b.name);
+      return ln !== 0 ? ln : (a.firstName || '').localeCompare(b.firstName || '');
+    });
+  }
+
+  private sortByName(members: UserInChoir[]): UserInChoir[] {
+    return members.sort((a, b) => {
       const ln = a.name.localeCompare(b.name);
       return ln !== 0 ? ln : (a.firstName || '').localeCompare(b.firstName || '');
     });


### PR DESCRIPTION
## Summary
- show availability icons for all statuses in participation table
- let users choose sorting by voice or name

## Testing
- `npm test --prefix choir-app-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68bfcfc9bbc48320af78951270a0c31d