### PR TITLE
Allow configurable default availability

### DIFF
--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -51,7 +51,12 @@ exports.findByMonth = async (req, res) => {
         }
     });
     const map = Object.fromEntries(avail.map(a => [a.date, a]));
-    const result = dates.map(d => map[d] ? map[d] : { date: d, status: 'AVAILABLE' });
+    const user = await db.user.findByPk(req.userId);
+    const defaultStatus = user?.preferences?.defaultAvailability;
+    const result = dates.map(d => {
+        if (map[d]) return map[d];
+        return defaultStatus ? { date: d, status: defaultStatus } : { date: d };
+    });
     res.status(200).send(result);
 };
 

--- a/choir-app-backend/src/models/user_availability.model.js
+++ b/choir-app-backend/src/models/user_availability.model.js
@@ -6,8 +6,7 @@ module.exports = (sequelize, DataTypes) => {
         },
         status: {
             type: DataTypes.ENUM('AVAILABLE', 'MAYBE', 'UNAVAILABLE'),
-            allowNull: false,
-            defaultValue: 'AVAILABLE'
+            allowNull: false
         }
     });
     return UserAvailability;

--- a/choir-app-backend/tests/availability.controller.test.js
+++ b/choir-app-backend/tests/availability.controller.test.js
@@ -20,6 +20,7 @@ const controller = require('../src/controllers/availability.controller');
     assert.strictEqual(res.statusCode, 200);
     const aprilDates = res.data.map(a => a.date);
     assert.ok(!aprilDates.includes('2025-04-18'));
+    assert.ok(res.data.every(a => a.status === undefined));
 
     await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 5 } }, res);
     const mayDates = res.data.map(a => a.date);
@@ -29,6 +30,10 @@ const controller = require('../src/controllers/availability.controller');
     await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 5 } }, res);
     const mayWithEvent = res.data.map(a => a.date);
     assert.ok(mayWithEvent.includes('2025-05-17'));
+
+    await user.update({ preferences: { defaultAvailability: 'MAYBE' } });
+    await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 6 } }, res);
+    assert.ok(res.data.every(a => a.status === 'MAYBE'));
 
   await controller.findByMonth({ ...baseReq, params: { year: 2025, month: 12 } }, res);
   const decDates = res.data.map(a => a.date);

--- a/choir-app-frontend/src/app/core/models/user-availability.ts
+++ b/choir-app-frontend/src/app/core/models/user-availability.ts
@@ -1,6 +1,6 @@
 export interface UserAvailability {
   date: string;
-  status: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE';
+  status?: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE';
   /** Automatically generated note for church holidays */
   holidayHint?: string;
 }

--- a/choir-app-frontend/src/app/core/models/user-preferences.ts
+++ b/choir-app-frontend/src/app/core/models/user-preferences.ts
@@ -7,4 +7,6 @@ export interface UserPreferences {
     timesSung?: boolean;
     timesRehearsed?: boolean;
   };
+  /** Default availability status for new events */
+  defaultAvailability?: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE';
 }

--- a/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/availability-table/availability-table.component.ts
@@ -34,7 +34,7 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
       })));
   }
 
-  setStatus(date: string, status: UserAvailability['status']): void {
+  setStatus(date: string, status: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE'): void {
     const i = this.availabilities.findIndex(v => v.date === date);
     if (i >= 0) this.availabilities[i].status = status;
 
@@ -46,7 +46,7 @@ export class AvailabilityTableComponent implements OnInit, OnChanges {
       });
   }
 
-  cellClass(status: string): string {
+  cellClass(status?: string): string {
     switch (status) {
       case 'AVAILABLE': return 'available';
       case 'MAYBE': return 'maybe';


### PR DESCRIPTION
## Summary
- Remove server-side default of 'AVAILABLE' for unset availabilities
- Honor user's profile preference when pre-filling availability status
- Support optional availability status in frontend models and update table component

## Testing
- `npm run test:backend`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcfb00e7483208d9b7823c542df75