### PR TITLE
feat: add mobile bottom navigation

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar color="primary" class="main-toolbar">
   <ng-container *ngIf="(isLoggedIn$ | async)">
-  <button type="button" aria-label="Menü umschalten" mat-icon-button (click)="toggleDrawer()">
+  <button type="button" aria-label="Menü umschalten" class="sidenav-toggle" mat-icon-button (click)="toggleDrawer()">
     <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
   </button>
   </ng-container>
@@ -96,4 +96,28 @@
 
   </mat-sidenav-content>
 </mat-sidenav-container>
+
+<nav class="bottom-nav" *ngIf="(isLoggedIn$ | async)">
+  <a mat-button routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+    <mat-icon>home</mat-icon>
+    <span>Home</span>
+  </a>
+  <a mat-button routerLink="/events" routerLinkActive="active">
+    <mat-icon>event</mat-icon>
+    <span>Termine</span>
+  </a>
+  <a mat-button routerLink="/dienstplan" routerLinkActive="active">
+    <mat-icon>assignment</mat-icon>
+    <span>Dienstplan</span>
+  </a>
+  <a mat-button routerLink="/repertoire" routerLinkActive="active">
+    <mat-icon>library_music</mat-icon>
+    <span>Chor</span>
+  </a>
+  <a mat-button routerLink="/admin" routerLinkActive="active" *ngIf="isAdmin$ | async">
+    <mat-icon>settings</mat-icon>
+    <span>Admin</span>
+  </a>
+</nav>
+
 <app-footer></app-footer>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.scss
@@ -105,3 +105,48 @@
 .logo-svg_icon_white svg {
   color: green !important;
 }
+
+.bottom-nav {
+  display: none;
+}
+
+@media (max-width: 480px) {
+  .bottom-nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: var(--footer-height);
+    background: var(--page-header-bg-color, #fff);
+    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.2);
+    justify-content: space-around;
+    align-items: center;
+    z-index: 1000;
+  }
+
+  .bottom-nav a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    color: inherit;
+    font-size: 0.75rem;
+  }
+
+  .bottom-nav a.active {
+    color: var(--brand);
+  }
+
+  .bottom-nav mat-icon {
+    font-size: 22px;
+    line-height: 22px;
+  }
+
+  .appDrawer,
+  app-footer,
+  .sidenav-toggle {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- replace sidebar with bottom navigation on small screens
- style bottom navigation links and hide drawer toggle

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe53ed8708320b2e62182108fc705