### PR TITLE
Add mobile responsive styles

### DIFF
--- a/choir-app-frontend/src/styles.scss
+++ b/choir-app-frontend/src/styles.scss
@@ -147,3 +147,33 @@ $choir-app-frontend-theme: mat.m2-define-light-theme((
 @include mat.all-component-themes($choir-app-frontend-theme);
 
  */
+/* Zusätzliche mobile Styles */
+@media (max-width: 480px) {
+  .hero .headline h1 { font-size: 18px }
+  .kpi { grid-template-columns: repeat(2, 1fr) }
+
+  .quick-actions { flex-direction: column; gap: 6px }
+  .button, .button.secondary { width: 100%; justify-content: center }
+
+  .bar { flex-wrap: wrap; gap: 8px }
+  .search { flex: 1 1 100% }
+
+  /* Bottom Navigation */
+  .bottom-nav {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    position: fixed;
+    bottom: 0; left: 0; right: 0;
+    background: #fff;
+    border-top: 1px solid #e5e7eb;
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.05);
+    padding: 6px 0;
+    z-index: 20;
+  }
+  .bottom-nav a {
+    display: flex; flex-direction: column; align-items: center;
+    font-size: 12px; color: #4b5563; text-decoration: none;
+  }
+  .bottom-nav a.active { color: var(--brand) }
+}


### PR DESCRIPTION
## Summary
- add mobile-specific CSS rules for small screens

## Testing
- `npm test` *(fails: cannot start ChromeHeadless: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe734730483209b61f450b19d553d