### PR TITLE
feat: add timeline component design

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -1,21 +1,25 @@
 <div class="dashboard-layout">
   <aside class="nav">
     <app-my-calendar></app-my-calendar>
-    <div class="upcoming-section">
-      <h2>Nächste Termine</h2>
-      <mat-slide-toggle [(ngModel)]="showOnlyMine" (change)="onToggleMine()">
-        Nur meine Termine
-      </mat-slide-toggle>
-      <mat-list>
-        <mat-list-item *ngFor="let ev of nextEvents$ | async"
-          [ngStyle]="{ 'border-left': '4px solid ' + ((ev.choirId != null ? choirColors[ev.choirId] : undefined) || 'transparent'), 'padding-left': '8px' }">
-          <a href="#" (click)="openEvent(ev); $event.preventDefault()">
-            {{ ev.date | date:'shortDate' }} - {{ ev.choir?.name }} -
-            {{ ev.type === 'SERVICE' ? 'Gottesdienst' : 'Probe' }}
-          </a>
-        </mat-list-item>
-      </mat-list>
-    </div>
+    <article class="card upcoming-timeline">
+      <div class="timeline-header">
+        <h3>Nächste Termine</h3>
+        <mat-slide-toggle [(ngModel)]="showOnlyMine" (change)="onToggleMine()">
+          Nur meine Termine
+        </mat-slide-toggle>
+      </div>
+      <div class="timeline">
+        <ng-container *ngFor="let ev of upcomingEvents$ | async">
+          <div class="item" (click)="openEvent(ev)" tabindex="0" role="button">
+            <div class="dot" aria-hidden="true"></div>
+            <div>
+              <div><strong>{{ ev.date | date:'dd.MM.yy' }}</strong> · {{ ev.title }}</div>
+              <div class="muted">{{ ev.timeRange }}<ng-container *ngIf="ev.location">, {{ ev.location }}</ng-container></div>
+            </div>
+          </div>
+        </ng-container>
+      </div>
+    </article>
   </aside>
 
   <div class="hero">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
@@ -74,9 +74,48 @@ mat-card-content h3 {
   }
 }
 
-.upcoming-section mat-list-item {
-  border-left: 4px solid transparent;
-  margin-bottom: 4px;
+.upcoming-timeline {
+  padding: 1rem;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  background: #fff;
+
+  .timeline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  .timeline {
+    border-left: 2px solid #eee;
+    padding-left: 1rem;
+  }
+
+  .item {
+    position: relative;
+    margin-bottom: 1rem;
+    cursor: pointer;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .dot {
+    position: absolute;
+    left: -1.15rem;
+    top: 0.4rem;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #3f51b5;
+  }
+
+  .muted {
+    color: #666;
+    font-size: 0.875rem;
+  }
 }
 
 .item-container {

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -49,7 +49,7 @@ export class DashboardComponent implements OnInit {
   lastProgram$!: Observable<Program | null>;
   activeChoir$: Observable<Choir | null>;
   pieceChanges$!: Observable<PieceChange[]>;
-  nextEvents$!: Observable<Event[]>;
+  upcomingEvents$!: Observable<Event[]>;
   latestPost$!: Observable<import('@core/models/post').Post | null>;
   borrowedItems$!: Observable<LibraryItem[]>;
   showOnlyMine = false;
@@ -97,7 +97,7 @@ export class DashboardComponent implements OnInit {
       switchMap(() => this.apiService.getLastEvent('REHEARSAL'))
     );
 
-    this.nextEvents$ = this.refresh$.pipe(
+    this.upcomingEvents$ = this.refresh$.pipe(
       switchMap(() => this.apiService.getNextEvents(5, this.showOnlyMine))
     );
 


### PR DESCRIPTION
## Summary
- overhaul dashboard upcoming events with timeline card
- add timeline styling and rename events stream to upcomingEvents$

## Testing
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68bfe750132c8320bbf75043dde27902