### PR TITLE
Require names for singer registration

### DIFF
--- a/choir-app-backend/src/controllers/invitation.controller.js
+++ b/choir-app-backend/src/controllers/invitation.controller.js
@@ -31,16 +31,16 @@ exports.getInvitation = async (req, res) => {
 
 exports.completeRegistration = async (req, res) => {
   const token = req.params.token;
-  const { name, password } = req.body;
-  if (!name || !password) {
-    return res.status(400).send({ message: 'Name and password are required.' });
+  const { firstName, name, password } = req.body;
+  if (!firstName || !name || !password) {
+    return res.status(400).send({ message: 'First name, last name and password are required.' });
   }
   try {
     const entry = await validateToken(token);
     if (!entry) {
       return res.status(404).send({ message: 'Invitation not found or expired.' });
     }
-    await db.user.update({ name, password: bcrypt.hashSync(password, 8) }, { where: { id: entry.user.id } });
+    await db.user.update({ firstName, name, password: bcrypt.hashSync(password, 8) }, { where: { id: entry.user.id } });
     await entry.update({ registrationStatus: 'REGISTERED', inviteToken: null, inviteExpiry: null });
     res.status(200).send({ message: 'Registration completed.' });
   } catch (err) {

--- a/choir-app-backend/src/controllers/join.controller.js
+++ b/choir-app-backend/src/controllers/join.controller.js
@@ -14,9 +14,9 @@ exports.getJoinInfo = async (req, res) => {
 };
 
 exports.joinChoir = async (req, res) => {
-  const { name, email, password } = req.body;
-  if (!name || !email || !password) {
-    return res.status(400).send({ message: 'Name, email and password are required.' });
+  const { firstName, name, email, password } = req.body;
+  if (!firstName || !name || !email || !password) {
+    return res.status(400).send({ message: 'First name, last name, email and password are required.' });
   }
   try {
     const choir = await db.choir.findOne({ where: { joinHash: req.params.token } });
@@ -25,7 +25,7 @@ exports.joinChoir = async (req, res) => {
     }
     const existing = await db.user.findOne({ where: { email } });
     if (existing) return res.status(409).send({ message: 'User already exists.' });
-    const user = await db.user.create({ name, email, password: bcrypt.hashSync(password, 8), roles: ['singer'] });
+    const user = await db.user.create({ firstName, name, email, password: bcrypt.hashSync(password, 8), roles: ['singer'] });
     await choir.addUser(user, { through: { rolesInChoir: ['singer'], registrationStatus: 'REGISTERED' } });
     res.status(201).send({ message: 'Registration completed.' });
   } catch (err) {

--- a/choir-app-backend/tests/join.controller.test.js
+++ b/choir-app-backend/tests/join.controller.test.js
@@ -24,7 +24,7 @@ const controller = require('../src/controllers/join.controller');
     assert.strictEqual(res.statusCode, 200, 'join info should succeed when enabled');
     assert.strictEqual(res.data.choirName, 'Join Test Choir');
 
-    await controller.joinChoir({ params: { token: 'token123' }, body: { name: 'User', email: 'u@example.com', password: 'pw' } }, res);
+    await controller.joinChoir({ params: { token: 'token123' }, body: { firstName: 'Test', name: 'User', email: 'u@example.com', password: 'pw' } }, res);
     assert.strictEqual(res.statusCode, 201, 'join should succeed when enabled');
     await db.sequelize.close();
   } catch (err) {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -616,7 +616,7 @@ export class ApiService {
     return this.userService.confirmEmailChange(token);
   }
 
-  completeRegistration(token: string, data: { name: string; password: string }): Observable<any> {
+  completeRegistration(token: string, data: { firstName: string; name: string; password: string }): Observable<any> {
     return this.userService.completeRegistration(token, data);
   }
 
@@ -624,7 +624,7 @@ export class ApiService {
     return this.userService.getJoinInfo(token);
   }
 
-  joinChoir(token: string, data: { name: string; email: string; password: string }): Observable<any> {
+  joinChoir(token: string, data: { firstName: string; name: string; email: string; password: string }): Observable<any> {
     return this.userService.joinChoir(token, data);
   }
 

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -38,7 +38,7 @@ export class UserService {
     return this.http.get(`${this.apiUrl}/email-change/confirm/${token}`);
   }
 
-  completeRegistration(token: string, data: { name: string; password: string }): Observable<any> {
+  completeRegistration(token: string, data: { firstName: string; name: string; password: string }): Observable<any> {
     return this.http.post(`${this.apiUrl}/invitations/${token}`, data);
   }
 
@@ -46,7 +46,7 @@ export class UserService {
     return this.http.get(`${this.apiUrl}/join/${token}`);
   }
 
-  joinChoir(token: string, data: { name: string; email: string; password: string }): Observable<any> {
+  joinChoir(token: string, data: { firstName: string; name: string; email: string; password: string }): Observable<any> {
     return this.http.post(`${this.apiUrl}/join/${token}`, data);
   }
 

--- a/choir-app-frontend/src/app/features/user/join/join-choir.component.html
+++ b/choir-app-frontend/src/app/features/user/join/join-choir.component.html
@@ -1,7 +1,11 @@
 <h2>Dem Chor "{{choirName}}" beitreten</h2>
 <form [formGroup]="form" (ngSubmit)="submit()">
   <mat-form-field appearance="outline">
-    <mat-label>Name</mat-label>
+    <mat-label>Vorname</mat-label>
+    <input matInput formControlName="firstName">
+  </mat-form-field>
+  <mat-form-field appearance="outline">
+    <mat-label>Nachname</mat-label>
     <input matInput formControlName="name">
   </mat-form-field>
   <mat-form-field appearance="outline">

--- a/choir-app-frontend/src/app/features/user/join/join-choir.component.ts
+++ b/choir-app-frontend/src/app/features/user/join/join-choir.component.ts
@@ -21,6 +21,7 @@ export class JoinChoirComponent implements OnInit {
               private api: ApiService, private snack: MatSnackBar,
               private router: Router) {
     this.form = this.fb.group({
+      firstName: ['', Validators.required],
       name: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required]

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.html
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.html
@@ -2,7 +2,11 @@
 <p *ngIf="email">Registriere den Account für {{email}}</p>
 <form [formGroup]="form" (ngSubmit)="submit()">
   <mat-form-field appearance="outline">
-    <mat-label>Name</mat-label>
+    <mat-label>Vorname</mat-label>
+    <input matInput formControlName="firstName">
+  </mat-form-field>
+  <mat-form-field appearance="outline">
+    <mat-label>Nachname</mat-label>
     <input matInput formControlName="name">
   </mat-form-field>
   <mat-form-field appearance="outline">

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.spec.ts
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.spec.ts
@@ -52,11 +52,11 @@ describe('InviteRegistrationComponent', () => {
     spyOn(router, 'navigate');
 
     component.token = 'abc';
-    component.form.setValue({ name: 'Test', password: 'secret' });
+    component.form.setValue({ firstName: 'First', name: 'Test', password: 'secret' });
 
     component.submit();
 
-    expect(api.completeRegistration).toHaveBeenCalledWith('abc', { name: 'Test', password: 'secret' });
+    expect(api.completeRegistration).toHaveBeenCalledWith('abc', { firstName: 'First', name: 'Test', password: 'secret' });
     expect(router.navigate).toHaveBeenCalledWith(['/login']);
   });
 });

--- a/choir-app-frontend/src/app/features/user/registration/invite-registration.component.ts
+++ b/choir-app-frontend/src/app/features/user/registration/invite-registration.component.ts
@@ -20,6 +20,7 @@ export class InviteRegistrationComponent implements OnInit {
 
   constructor(private route: ActivatedRoute, private fb: FormBuilder, private api: ApiService, private snack: MatSnackBar, private router: Router) {
     this.form = this.fb.group({
+      firstName: ['', Validators.required],
       name: ['', Validators.required],
       password: ['', Validators.required]
     });


### PR DESCRIPTION
## Summary
- Enforce first and last name fields when singers register via join links or invitations
- Update frontend registration forms and API/services to submit first and last names
- Adjust tests for new registration fields

## Testing
- `node tests/join.controller.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bffa9a2d488320acebef523128d726