### PR TITLE
Add admin donations listing

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -274,6 +274,18 @@ exports.clearMailLogs = async (req, res) => {
     }
 };
 
+exports.getDonations = async (req, res) => {
+    try {
+        const donations = await db.donation.findAll({
+            include: [{ model: db.user, as: 'user', attributes: ['id', 'firstName', 'name', 'email'] }],
+            order: [['donatedAt', 'DESC']]
+        });
+        res.status(200).send(donations);
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
 // Recalculate repertoire statuses for all choirs based on past events
 exports.recalculatePieceStatuses = async (req, res) => {
     try {

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -134,11 +134,14 @@ exports.getMe = async (req, res) => {
 
 exports.registerDonation = async (req, res) => {
     try {
+        const { amount } = req.body;
         const user = await User.findByPk(req.userId);
         if (!user) {
             return res.status(404).send({ message: "User not found." });
         }
-        user.lastDonation = new Date();
+        const donatedAt = new Date();
+        await db.donation.create({ userId: req.userId, amount: parseFloat(amount) || 0, donatedAt });
+        user.lastDonation = donatedAt;
         await user.save();
         res.status(200).send({ message: "Donation recorded." });
     } catch (err) {

--- a/choir-app-backend/src/models/donation.model.js
+++ b/choir-app-backend/src/models/donation.model.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const Donation = sequelize.define('donation', {
+    amount: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    donatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  });
+  return Donation;
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -49,6 +49,7 @@ db.program = require("./program.model.js")(sequelize, Sequelize);
 db.program_element = require("./program_element.model.js")(sequelize, Sequelize);
 db.program_item = require("./program_item.model.js")(sequelize, Sequelize);
 db.district = require("./district.model.js")(sequelize, Sequelize);
+db.donation = require("./donation.model.js")(sequelize, Sequelize);
 
 
 // --- Define Associations ---
@@ -152,6 +153,10 @@ db.choir.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
 db.user.hasMany(db.post, { as: 'posts' });
 db.post.belongsTo(db.user, { foreignKey: 'userId', as: 'author' });
+
+// Donations
+db.user.hasMany(db.donation, { as: 'donations' });
+db.donation.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
 
 // Library items referencing collections
 db.collection.hasMany(db.library_item, { as: 'libraryItems', foreignKey: 'collectionId' });

--- a/choir-app-backend/src/routes/admin.routes.js
+++ b/choir-app-backend/src/routes/admin.routes.js
@@ -37,6 +37,7 @@ router.delete("/users/:id/reset-token", wrap(controller.clearResetToken));
 router.get("/login-attempts", wrap(controller.getLoginAttempts));
 router.get('/mail-logs', wrap(controller.getMailLogs));
 router.delete('/mail-logs', wrap(controller.clearMailLogs));
+router.get('/donations', wrap(controller.getDonations));
 
 router.get('/logs', wrap(controller.listLogs));
 router.get('/logs/:filename', wrap(controller.getLog));

--- a/choir-app-frontend/src/app/core/models/donation.ts
+++ b/choir-app-frontend/src/app/core/models/donation.ts
@@ -1,0 +1,12 @@
+export interface Donation {
+  id: number;
+  userId: number;
+  amount: number;
+  donatedAt: string;
+  user?: {
+    id: number;
+    firstName?: string;
+    name: string;
+    email: string;
+  };
+}

--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -12,6 +12,7 @@ import { FrontendUrl } from '../models/frontend-url';
 import { SystemAdminEmail } from '../models/system-admin-email';
 import { UploadOverview } from '../models/backend-file';
 import { MailLog } from '../models/mail-log';
+import { Donation } from '../models/donation';
 
 @Injectable({ providedIn: 'root' })
 export class AdminService {
@@ -186,5 +187,9 @@ export class AdminService {
 
   updateSystemAdminEmail(data: SystemAdminEmail): Observable<SystemAdminEmail> {
     return this.http.put<SystemAdminEmail>(`${this.apiUrl}/admin/system-admin-email`, data);
+  }
+
+  getDonations(): Observable<Donation[]> {
+    return this.http.get<Donation[]>(`${this.apiUrl}/admin/donations`);
   }
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -38,6 +38,7 @@ import { SystemService } from './system.service';
 import { PlanRuleService } from './plan-rule.service';
 import { StatsSummary } from '../models/stats-summary';
 import { RepertoireFilter } from '../models/repertoire-filter';
+import { Donation } from '../models/donation';
 import { MailSettings } from '../models/mail-settings';
 import { MailTemplate } from '../models/mail-template';
 import { FrontendUrl } from '../models/frontend-url';
@@ -794,9 +795,13 @@ export class ApiService {
         return this.systemService.pingBackend();
     }
 
-  registerDonation(): Observable<any> {
-        return this.userService.registerDonation();
-    }
+  registerDonation(amount: number): Observable<any> {
+        return this.userService.registerDonation(amount);
+  }
+
+  getDonations(): Observable<Donation[]> {
+        return this.adminService.getDonations();
+  }
 
   // --- Post Methods ---
   getPosts(): Observable<Post[]> {

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -50,7 +50,7 @@ export class UserService {
     return this.http.post(`${this.apiUrl}/join/${token}`, data);
   }
 
-  registerDonation(): Observable<any> {
-    return this.http.post(`${this.apiUrl}/users/me/donate`, {});
+  registerDonation(amount: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/users/me/donate`, { amount });
   }
 }

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -21,6 +21,7 @@ export const adminRoutes: Routes = [
       { path: 'districts', loadComponent: () => import('./manage-districts/manage-districts.component').then(m => m.ManageDistrictsComponent), data: { title: 'Admin – Bezirke' } },
       { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent), data: { title: 'Admin – Änderungen' } },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent), data: { title: 'Admin – Protokolle' } },
+      { path: 'donations', loadComponent: () => import('./donations/donations.component').then(m => m.DonationsComponent), data: { title: 'Admin – Spenden' } },
       { path: 'develop', loadComponent: () => import('./develop/develop.component').then(m => m.DevelopComponent), data: { title: 'Admin – Develop' } },
       { path: 'files', loadComponent: () => import('./manage-files/manage-files.component').then(m => m.ManageFilesComponent), data: { title: 'Admin – Dateien' } },
     ],

--- a/choir-app-frontend/src/app/features/admin/donations/donations.component.html
+++ b/choir-app-frontend/src/app/features/admin/donations/donations.component.html
@@ -1,0 +1,21 @@
+<mat-card>
+  <mat-card-content>
+    <h2>Spenden</h2>
+    <table mat-table [dataSource]="donations" class="mat-elevation-z8">
+      <ng-container matColumnDef="user">
+        <th mat-header-cell *matHeaderCellDef>Benutzer</th>
+        <td mat-cell *matCellDef="let d">{{ d.user?.firstName }} {{ d.user?.name }}</td>
+      </ng-container>
+      <ng-container matColumnDef="date">
+        <th mat-header-cell *matHeaderCellDef>Datum</th>
+        <td mat-cell *matCellDef="let d">{{ d.donatedAt | date:'short' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="amount">
+        <th mat-header-cell *matHeaderCellDef>Betrag</th>
+        <td mat-cell *matCellDef="let d">{{ d.amount | number:'1.2-2' }} €</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </mat-card-content>
+</mat-card>

--- a/choir-app-frontend/src/app/features/admin/donations/donations.component.ts
+++ b/choir-app-frontend/src/app/features/admin/donations/donations.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Donation } from '@core/models/donation';
+
+@Component({
+  selector: 'app-donations',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './donations.component.html',
+})
+export class DonationsComponent implements OnInit {
+  donations: Donation[] = [];
+  displayedColumns = ['user', 'date', 'amount'];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.getDonations().subscribe(d => (this.donations = d));
+  }
+}

--- a/choir-app-frontend/src/app/features/donations/donation-success.component.html
+++ b/choir-app-frontend/src/app/features/donations/donation-success.component.html
@@ -3,7 +3,16 @@
     <mat-card-content>
       <h2>Vielen Dank für deine Spende!</h2>
       <p>Dein Beitrag hilft, die laufenden Kosten zu decken.</p>
-      <button mat-raised-button color="primary" (click)="back()">Zurück</button>
+      <div *ngIf="!saved">
+        <mat-form-field>
+          <mat-label>Betrag (EUR)</mat-label>
+          <input matInput type="number" [(ngModel)]="amount" />
+        </mat-form-field>
+        <button mat-raised-button color="primary" (click)="save()">Speichern</button>
+      </div>
+      <div *ngIf="saved">
+        <button mat-raised-button color="primary" (click)="back()">Zurück</button>
+      </div>
     </mat-card-content>
   </mat-card>
 </div>

--- a/choir-app-frontend/src/app/features/donations/donation-success.component.ts
+++ b/choir-app-frontend/src/app/features/donations/donation-success.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
 import { Router } from '@angular/router';
@@ -8,14 +9,30 @@ import { AuthService } from '@core/services/auth.service';
 @Component({
   selector: 'app-donation-success',
   standalone: true,
-  imports: [CommonModule, MaterialModule],
+  imports: [CommonModule, MaterialModule, FormsModule],
   templateUrl: './donation-success.component.html',
 })
 export class DonationSuccessComponent implements OnInit {
+  amount = 0;
+  saved = false;
+
   constructor(private api: ApiService, private auth: AuthService, private router: Router) {}
 
   ngOnInit(): void {
-    this.api.registerDonation().subscribe(() => {
+    const params = new URLSearchParams(window.location.search);
+    const amt = params.get('amount') || params.get('amt');
+    if (amt) {
+      const parsed = parseFloat(amt);
+      if (!isNaN(parsed)) {
+        this.amount = parsed;
+        this.save();
+      }
+    }
+  }
+
+  save(): void {
+    this.api.registerDonation(this.amount).subscribe(() => {
+      this.saved = true;
       this.api.getCurrentUser().subscribe(user => this.auth.setCurrentUser(user));
     });
   }

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -380,6 +380,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
           { displayName: 'Verlage', route: '/admin/publishers' },
           { displayName: 'Änderungsvorschläge', route: '/admin/piece-changes' },
           { displayName: 'Protokolle', route: '/admin/protocols' },
+          { displayName: 'Spenden', route: '/admin/donations' },
           { displayName: 'Dateien', route: '/admin/files' },
           { displayName: 'Develop', route: '/admin/develop' }
         ]


### PR DESCRIPTION
## Summary
- record donation amounts and timestamps via new Donation model
- expose admin endpoint and UI to view all donations
- capture optional amount after donation success

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c0185beadc8320b36647ccbb1da0c3