### PR TITLE
Add load-more pagination for posts

### DIFF
--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -4,24 +4,31 @@
 
 <ng-container *ngIf="posts.length; else noPosts">
   <div class="post-list">
-    <mat-card *ngFor="let p of posts" class="post" id="post-{{ p.id }}">
-      <mat-card-header>
-        <mat-card-title>{{ p.title }}</mat-card-title>
-        <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }} <span *ngIf="!p.published">(Entwurf)</span></mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div [innerHTML]="p.text | markdown | async"></div>
-        <div *ngIf="p.expiresAt" class="expires">Sichtbar bis {{ p.expiresAt | date:'shortDate' }}</div>
-      </mat-card-content>
-      <mat-card-actions *ngIf="canEdit(p)" class="actions">
-        <button mat-button color="accent" (click)="publishPost(p)" *ngIf="!p.published">Veröffentlichen</button>
-        <button mat-icon-button (click)="editPost(p)" matTooltip="Bearbeiten"><mat-icon>edit</mat-icon></button>
-        <button mat-icon-button (click)="deletePost(p)" matTooltip="Löschen"><mat-icon>delete</mat-icon></button>
-      </mat-card-actions>
-    </mat-card>
+    <ng-container *ngFor="let p of posts | slice:0:displayCount; let last = last">
+      <mat-card id="post-{{ p.id }}">
+        <mat-card-header>
+          <mat-card-title>{{ p.title }}</mat-card-title>
+          <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }} <span *ngIf="!p.published">(Entwurf)</span></mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <div [innerHTML]="p.text | markdown | async"></div>
+          <div *ngIf="p.expiresAt" class="expires">Sichtbar bis {{ p.expiresAt | date:'shortDate' }}</div>
+        </mat-card-content>
+        <mat-card-actions *ngIf="canEdit(p)" class="actions">
+          <button mat-button color="accent" (click)="publishPost(p)" *ngIf="!p.published">Veröffentlichen</button>
+          <button mat-icon-button (click)="editPost(p)" matTooltip="Bearbeiten"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button (click)="deletePost(p)" matTooltip="Löschen"><mat-icon>delete</mat-icon></button>
+        </mat-card-actions>
+      </mat-card>
+      <mat-divider *ngIf="!last"></mat-divider>
+    </ng-container>
+    <div class="load-more" *ngIf="displayCount < posts.length">
+      <a (click)="showMore()">Ältere anzeigen</a>
+    </div>
   </div>
 </ng-container>
 
 <ng-template #noPosts>
   <div class="no-posts">Noch keine Beiträge angelegt.</div>
 </ng-template>
+

--- a/choir-app-frontend/src/app/features/posts/post-list.component.scss
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.scss
@@ -14,8 +14,18 @@
   overflow: auto;
 }
 
-.post {
-  margin-bottom: 1rem;
+
+mat-divider {
+  margin: 1rem 0;
+}
+
+.load-more {
+  text-align: center;
+  margin: 1rem 0;
+
+  a {
+    cursor: pointer;
+  }
 }
 
 .no-posts {

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -19,6 +19,7 @@ import { MarkdownPipe } from '@shared/pipes/markdown.pipe';
 })
 export class PostListComponent implements OnInit {
   posts: Post[] = [];
+  displayCount = 5;
   currentUserId: number | null = null;
   isChoirAdmin = false;
   isSingerOnly = false;
@@ -45,11 +46,16 @@ export class PostListComponent implements OnInit {
   loadPosts(): void {
     this.api.getPosts().subscribe(p => {
       this.posts = p;
+      this.displayCount = Math.min(5, this.posts.length);
       const fragment = this.route.snapshot.fragment;
       if (fragment) {
         setTimeout(() => document.getElementById(fragment)?.scrollIntoView({ behavior: 'smooth' }), 0);
       }
     });
+  }
+
+  showMore(): void {
+    this.displayCount = Math.min(this.displayCount + 5, this.posts.length);
   }
 
   canEdit(post: Post): boolean {


### PR DESCRIPTION
## Summary
- Show only five posts initially and provide a link to load five more at a time
- Add visual dividers between posts

## Testing
- `npm test` *(fails: libXdamage.so.1: cannot open shared object file)*
- `npm run lint` *(terminated: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c036fa7218832090829a6603cff824