### PR TITLE
feat: limit latest post height

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -53,11 +53,11 @@
         <article>
           <mat-card class="latest-post-card" *ngIf="latestPost$ | async as post">
             <mat-card-title>Neuester Beitrag</mat-card-title>
-            <mat-card-content>
-              <h3>{{ post.title }}</h3>
-              <div [innerHTML]="post.text | markdown | async"></div>
-              <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
-            </mat-card-content>
+              <mat-card-content>
+                <h3>{{ post.title }}</h3>
+                <div class="post-excerpt" [innerHTML]="post.text | markdown | async"></div>
+                <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
+              </mat-card-content>
             <mat-card-actions>
               <button mat-button color="primary" (click)="openLatestPost(post)">Zum Beitrag</button>
               <button mat-button color="accent" routerLink="/pieces">Chor-Stücke öffnen</button>

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.scss
@@ -188,11 +188,11 @@
   background-color: var(--dot-color, #1976d2);
 }
 
-.item-container {
-  width: 95%;
-  text-align: center;
-  padding: 0.5rem;
-  border-bottom: 1px solid #eee;
+  .item-container {
+    width: 95%;
+    text-align: center;
+    padding: 0.5rem;
+    border-bottom: 1px solid #eee;
 
   &:last-child {
     border-bottom: none;
@@ -204,20 +204,33 @@
     &:hover {
       background-color: color.adjust(#eee, $lightness: -5%);
     }
-  }
+    }
 
-  .title {
-    font-weight: bold;
-    font-size: 1.1rem;
-  }
+    .title {
+      font-weight: bold;
+      font-size: 1.1rem;
+    }
 
   .composer {
     font-size: 0.9rem;
     color: #999;
   }
 
-  .subtitle {
-    font-size: 0.9rem;
-    color: #666;
+    .subtitle {
+      font-size: 0.9rem;
+      color: #666;
+    }
   }
+
+.latest-post-card {
+  max-height: 350px;
 }
+
+.latest-post-card .post-excerpt {
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+


### PR DESCRIPTION
## Summary
- Limit latest post tile height on dashboard and show ellipsis for overflow

## Testing
- `npm test` (fails: /root/.cache/puppeteer/chrome/... error while loading shared libraries: libatk-1.0.so.0)


------
https://chatgpt.com/codex/tasks/task_e_68c037e5c2e88320a74b8a76d4510f2f