### PR TITLE
style: adjust column widths for piece list

### DIFF
--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.scss
@@ -20,22 +20,39 @@
   font-style: italic;
 }
 
-.piece-link-table .piece-composer {
-  color: #666;
-  font-size: 0.9em;
-}
 
-.piece-link-table .number-cell mat-form-field {
-  width: 4rem;
+.piece-link-table {
+  width: 100%;
 
-  // Hide outline by default and only show on hover or focus
-  .mat-form-field-outline {
-    display: none;
+  .mat-column-number {
+    width: 20%;
   }
 
-  &:hover .mat-form-field-outline,
-  &.mat-focused .mat-form-field-outline {
-    display: block;
+  .mat-column-title {
+    width: auto;
+  }
+
+  .mat-column-actions {
+    width: 30%;
+  }
+
+  .piece-composer {
+    color: #666;
+    font-size: 0.9em;
+  }
+
+  .number-cell mat-form-field {
+    width: 4rem;
+
+    // Hide outline by default and only show on hover or focus
+    .mat-form-field-outline {
+      display: none;
+    }
+
+    &:hover .mat-form-field-outline,
+    &.mat-focused .mat-form-field-outline {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure collection edit's piece list columns use 20% / auto / 30% widths for number, title, and actions

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c03e6a82d88320ada8dcfddbedfb41