### PR TITLE
Display fallback last service tile and restore last rehearsal

### DIFF
--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -50,20 +50,27 @@
 
 
       <section class="grid">
-        <article>
-          <mat-card class="latest-post-card" *ngIf="latestPost$ | async as post">
-            <mat-card-title>Neuester Beitrag</mat-card-title>
+        <ng-container *ngIf="latestPost$ | async as post; else lastServiceTile">
+          <article>
+            <mat-card class="latest-post-card">
+              <mat-card-title>Neuester Beitrag</mat-card-title>
               <mat-card-content>
                 <h3>{{ post.title }}</h3>
                 <div class="post-excerpt" [innerHTML]="post.text | markdown | async"></div>
                 <small>{{ post.updatedAt | date:'short' }} – {{ post.author?.name }}</small>
               </mat-card-content>
-            <mat-card-actions>
-              <button mat-button color="primary" (click)="openLatestPost(post)">Zum Beitrag</button>
-              <button mat-button color="accent" routerLink="/pieces">Chor-Stücke öffnen</button>
-            </mat-card-actions>
-          </mat-card>
-        </article>
+              <mat-card-actions>
+                <button mat-button color="primary" (click)="openLatestPost(post)">Zum Beitrag</button>
+                <button mat-button color="accent" routerLink="/pieces">Chor-Stücke öffnen</button>
+              </mat-card-actions>
+            </mat-card>
+          </article>
+        </ng-container>
+        <ng-template #lastServiceTile>
+          <article>
+            <app-event-card cardTitle="Letzter Gottesdienst" [event]="lastService$ | async"></app-event-card>
+          </article>
+        </ng-template>
 
         <article>
           <mat-card class="next-events-card">
@@ -121,6 +128,8 @@
             <app-my-calendar></app-my-calendar>
           </mat-card-content>
         </mat-card>
+
+        <app-event-card cardTitle="Letzte Probe" [event]="lastRehearsal$ | async"></app-event-card>
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Show last service card when no latest post exists
- Reintroduce last rehearsal card in dashboard

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadlessCI` *(failed: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c03f7325a88320ae79e205bccd58c2