### PR TITLE
feat: copy choir emails to clipboard

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -106,6 +106,10 @@
     <mat-card-header class="collapsible-header" (click)="toggleMembers()">
       <mat-card-title>Chorleiter</mat-card-title>
       <span class="header-controls">
+        <button mat-flat-button color="primary" (click)="copyEmailsToClipboard(); $event.stopPropagation()">
+          <mat-icon>content_copy</mat-icon>
+          <span>E-Mailadressen kopieren</span>
+        </button>
         <button mat-flat-button color="accent" (click)="openInviteDialog(); $event.stopPropagation()">
           <mat-icon>add</mat-icon>
           <span>Neues Mitglied einladen</span>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -194,6 +194,22 @@ export class ManageChoirComponent implements OnInit {
     this.membersExpanded = !this.membersExpanded;
   }
 
+  copyEmailsToClipboard(): void {
+    const emails = this.dataSource.data
+      .map(u => u.email)
+      .filter(email => !!email)
+      .join(';');
+
+    if (!emails) {
+      this.snackBar.open('Keine E-Mailadressen vorhanden.', 'OK', { duration: 3000 });
+      return;
+    }
+
+    navigator.clipboard.writeText(emails)
+      .then(() => this.snackBar.open('E-Mailadressen kopiert.', 'OK', { duration: 3000 }))
+      .catch(() => this.snackBar.open('Fehler beim Kopieren der E-Mailadressen.', 'Schließen'));
+  }
+
   onSaveChoirDetails(): void {
     if (this.choirForm.invalid) {
       return;


### PR DESCRIPTION
## Summary
- add "E-Mailadressen kopieren" button on Mein Chor page
- implement clipboard logic to aggregate and copy all choir member emails

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d918080883209c30b6511d2c34a2