### PR TITLE
Add choir-specific activity logs

### DIFF
--- a/choir-app-backend/src/controllers/event.controller.js
+++ b/choir-app-backend/src/controllers/event.controller.js
@@ -103,6 +103,7 @@ exports.create = async (req, res) => {
         });
 
     // Senden Sie eine Antwort, die dem Frontend mitteilt, was passiert ist.
+    await db.choir_log.create({ choirId, userId: req.userId, action: 'event_created', details: { eventId: event.id, type, date } });
     res.status(201).send({
         message: "Event successfully created.",
         wasUpdated: false,
@@ -374,6 +375,7 @@ exports.update = async (req, res) => {
                 { model: db.monthly_plan, as: 'monthlyPlan', attributes: ['month', 'year', 'finalized', 'version'], required: false }
             ]
         });
+    await db.choir_log.create({ choirId: req.activeChoirId, userId: req.userId, action: 'event_updated', details: { eventId: id, type, date } });
     res.status(200).send(updated);
 };
 
@@ -382,6 +384,7 @@ exports.delete = async (req, res) => {
 
     const num = await Event.destroy({ where: { id, choirId: req.activeChoirId } });
         if (num === 1) {
+            await db.choir_log.create({ choirId: req.activeChoirId, userId: req.userId, action: 'event_deleted', details: { eventId: id } });
             res.send({ message: 'Event deleted successfully!' });
         } else {
             res.status(404).send({ message: 'Event not found.' });

--- a/choir-app-backend/src/controllers/invitation.controller.js
+++ b/choir-app-backend/src/controllers/invitation.controller.js
@@ -42,6 +42,7 @@ exports.completeRegistration = async (req, res) => {
     }
     await db.user.update({ firstName, name, password: bcrypt.hashSync(password, 8) }, { where: { id: entry.user.id } });
     await entry.update({ registrationStatus: 'REGISTERED', inviteToken: null, inviteExpiry: null });
+    await db.choir_log.create({ choirId: entry.choirId, userId: entry.user.id, action: 'member_join' });
     res.status(200).send({ message: 'Registration completed.' });
   } catch (err) {
     res.status(500).send({ message: err.message });

--- a/choir-app-backend/src/controllers/repertoire.controller.js
+++ b/choir-app-backend/src/controllers/repertoire.controller.js
@@ -397,6 +397,8 @@ exports.updateStatus = async (req, res) => {
             { status: status },
             { where: { choirId: req.activeChoirId, pieceId: pieceId } }
         );
+        const piece = await db.piece.findByPk(pieceId, { attributes: ['title'] });
+        await db.choir_log.create({ choirId: req.activeChoirId, userId: req.userId, action: 'repertoire_update_status', details: { pieceId, pieceTitle: piece?.title, status } });
         res.status(200).send({ message: "Status updated successfully." });
     } catch (err) {
         res.status(500).send({ message: err.message });
@@ -410,6 +412,8 @@ exports.updateNotes = async (req, res) => {
             { notes: notes },
             { where: { choirId: req.activeChoirId, pieceId: pieceId } }
         );
+        const piece = await db.piece.findByPk(pieceId, { attributes: ['title'] });
+        await db.choir_log.create({ choirId: req.activeChoirId, userId: req.userId, action: 'repertoire_update_notes', details: { pieceId, pieceTitle: piece?.title } });
         res.status(200).send({ message: "Notes updated successfully." });
     } catch (err) {
         res.status(500).send({ message: err.message });
@@ -423,6 +427,8 @@ exports.updateRating = async (req, res) => {
             { rating: rating },
             { where: { choirId: req.activeChoirId, pieceId: pieceId } }
         );
+        const piece = await db.piece.findByPk(pieceId, { attributes: ['title'] });
+        await db.choir_log.create({ choirId: req.activeChoirId, userId: req.userId, action: 'repertoire_update_rating', details: { pieceId, pieceTitle: piece?.title, rating } });
         res.status(200).send({ message: "Rating updated successfully." });
     } catch (err) {
         res.status(500).send({ message: err.message });
@@ -490,6 +496,8 @@ exports.addPieceToRepertoire = async (req, res) => {
     try {
         const choir = await db.choir.findByPk(req.activeChoirId);
         await choir.addPiece(pieceId); // This creates the link in choir_repertoire
+        const piece = await db.piece.findByPk(pieceId, { attributes: ['title'] });
+        await db.choir_log.create({ choirId: req.activeChoirId, userId: req.userId, action: 'repertoire_add_piece', details: { pieceId, pieceTitle: piece?.title } });
         res.status(200).send({ message: "Piece added to repertoire." });
     } catch (err) {
         res.status(500).send({ message: err.message });

--- a/choir-app-backend/src/models/choir_log.model.js
+++ b/choir-app-backend/src/models/choir_log.model.js
@@ -1,0 +1,13 @@
+module.exports = (sequelize, DataTypes) => {
+    const ChoirLog = sequelize.define('choir_log', {
+        action: {
+            type: DataTypes.STRING,
+            allowNull: false
+        },
+        details: {
+            type: DataTypes.JSON,
+            allowNull: true
+        }
+    });
+    return ChoirLog;
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -50,6 +50,7 @@ db.program_element = require("./program_element.model.js")(sequelize, Sequelize)
 db.program_item = require("./program_item.model.js")(sequelize, Sequelize);
 db.district = require("./district.model.js")(sequelize, Sequelize);
 db.donation = require("./donation.model.js")(sequelize, Sequelize);
+db.choir_log = require("./choir_log.model.js")(sequelize, Sequelize);
 
 
 // --- Define Associations ---
@@ -189,6 +190,12 @@ db.program_element.belongsTo(db.program, { foreignKey: 'programId', as: 'program
 
 db.piece.hasMany(db.program_element, { as: 'programElements', foreignKey: 'pieceId' });
 db.program_element.belongsTo(db.piece, { foreignKey: 'pieceId', as: 'piece' });
+
+// Choir logs
+db.choir.hasMany(db.choir_log, { as: 'logs' });
+db.choir_log.belongsTo(db.choir, { foreignKey: 'choirId', as: 'choir' });
+db.user.hasMany(db.choir_log, { as: 'choirLogs' });
+db.choir_log.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
 
 
 module.exports = db;

--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -16,6 +16,7 @@ router.get("/members", role.requireChoirAdmin, wrap(controller.getChoirMembers))
 router.post("/members", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.inviteUserToChoir));
 router.put("/members/:userId", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.updateMember));
 router.delete("/members", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.removeUserFromChoir));
+router.get("/logs", role.requireChoirAdmin, wrap(controller.getChoirLogs));
 // Sammlungen können von allen Mitgliedern eingesehen werden
 router.get("/collections", wrap(controller.getChoirCollections));
 router.delete("/collections/:id", role.requireChoirAdmin, wrap(controller.removeCollectionFromChoir));

--- a/choir-app-frontend/src/app/core/models/choir-log.ts
+++ b/choir-app-frontend/src/app/core/models/choir-log.ts
@@ -1,0 +1,11 @@
+export interface ChoirLog {
+  id: number;
+  action: string;
+  details?: any;
+  createdAt: string;
+  user?: {
+    id: number;
+    firstName: string;
+    name: string;
+  };
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -15,6 +15,7 @@ import { LookupPiece } from '@core/models/lookup-piece';
 import { Author } from '@core/models/author';
 import { Publisher } from '@core/models/publisher';
 import { Choir } from '@core/models/choir';
+import { ChoirLog } from '../models/choir-log';
 import { PlanRule } from '@core/models/plan-rule';
 import { PieceChange } from '../models/piece-change';
 import { Post } from '../models/post';
@@ -635,6 +636,10 @@ export class ApiService {
 
   getChoirCollections(options?: { choirId?: number }): Observable<Collection[]> {
     return this.choirService.getChoirCollections(options?.choirId);
+  }
+
+  getChoirLogs(options?: { choirId?: number }): Observable<ChoirLog[]> {
+    return this.choirService.getChoirLogs(options?.choirId);
   }
 
   removeCollectionFromChoir(collectionId: number, options?: { choirId?: number }): Observable<any> {

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -5,6 +5,7 @@ import { environment } from 'src/environments/environment';
 import { Choir } from '../models/choir';
 import { UserInChoir } from '../models/user';
 import { Collection } from '../models/collection';
+import { ChoirLog } from '../models/choir-log';
 
 @Injectable({ providedIn: 'root' })
 export class ChoirService {
@@ -51,5 +52,10 @@ export class ChoirService {
   removeCollectionFromChoir(collectionId: number, choirId?: number): Observable<any> {
     const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
     return this.http.delete(`${this.apiUrl}/choir-management/collections/${collectionId}`, { params });
+  }
+
+  getChoirLogs(choirId?: number): Observable<ChoirLog[]> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get<ChoirLog[]>(`${this.apiUrl}/choir-management/logs`, { params });
   }
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -31,12 +31,14 @@ export class ManageChoirResolver implements Resolve<any> {
         const choirDetails$ = this.apiService.getMyChoirDetails(opts);
         const collections$ = this.apiService.getChoirCollections(opts);
         const planRules$ = this.apiService.getPlanRules(opts);
+        const logs$ = this.apiService.getChoirLogs(opts);
         if (isAdmin) {
           return forkJoin({
             choirDetails: choirDetails$,
             members: this.apiService.getChoirMembers(opts),
             collections: collections$,
             planRules: planRules$,
+            logs: logs$,
             isChoirAdmin: of(true)
           });
         }
@@ -48,6 +50,7 @@ export class ManageChoirResolver implements Resolve<any> {
                 members: this.apiService.getChoirMembers(),
                 collections: collections$,
                 planRules: planRules$,
+                logs: logs$,
                 isChoirAdmin: of(true)
               });
             } else {
@@ -56,6 +59,7 @@ export class ManageChoirResolver implements Resolve<any> {
                 members: of([]),
                 collections: collections$,
                 planRules: planRules$,
+                logs: logs$,
                 isChoirAdmin: of(false)
               });
             }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -192,6 +192,33 @@
     </mat-card-content>
   </mat-card>
 
+  <!-- Log Card -->
+  <mat-card class="table-card" *ngIf="isChoirAdmin">
+    <mat-card-header>
+      <mat-card-title>Log</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="table-wrapper mat-elevation-z4">
+        <mat-table [dataSource]="logDataSource">
+          <ng-container matColumnDef="timestamp">
+            <mat-header-cell *matHeaderCellDef>Wann</mat-header-cell>
+            <mat-cell *matCellDef="let log">{{ log.createdAt | date:'short' }}</mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="user">
+            <mat-header-cell *matHeaderCellDef>Wer</mat-header-cell>
+            <mat-cell *matCellDef="let log">{{ log.user?.name }}, {{ log.user?.firstName }}</mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="action">
+            <mat-header-cell *matHeaderCellDef>Was</mat-header-cell>
+            <mat-cell *matCellDef="let log">{{ formatAction(log) }}</mat-cell>
+          </ng-container>
+          <mat-header-row *matHeaderRowDef="displayedLogColumns"></mat-header-row>
+          <mat-row *matRowDef="let row; columns: displayedLogColumns;"></mat-row>
+        </mat-table>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
   <mat-card class="table-card">
     <mat-card-header>
       <mat-card-title>Sammlungen im Chor</mat-card-title>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -17,6 +17,7 @@ import { InviteUserDialogComponent } from '../invite-user-dialog/invite-user-dia
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { environment } from 'src/environments/environment';
+import { ChoirLog } from 'src/app/core/models/choir-log';
 
 
 @Component({
@@ -81,6 +82,9 @@ export class ManageChoirComponent implements OnInit {
 
   displayedCollectionColumns: string[] = ['title', 'publisher', 'actions'];
   collectionDataSource = new MatTableDataSource<Collection>();
+
+  displayedLogColumns: string[] = ['timestamp', 'user', 'action'];
+  logDataSource = new MatTableDataSource<ChoirLog>();
 
 
   // Für die Mitglieder-Tabelle
@@ -160,6 +164,7 @@ export class ManageChoirComponent implements OnInit {
         }
         this.dataSource.data = pageData.members;
         this.collectionDataSource.data = pageData.collections;
+        this.logDataSource.data = pageData.logs;
       }
     });
   }
@@ -178,6 +183,9 @@ export class ManageChoirComponent implements OnInit {
       });
       this.apiService.getChoirCollections(opts).subscribe(cols => {
         this.collectionDataSource.data = cols;
+      });
+      this.apiService.getChoirLogs(opts).subscribe(logs => {
+        this.logDataSource.data = logs;
       });
     }
   }
@@ -208,6 +216,31 @@ export class ManageChoirComponent implements OnInit {
     navigator.clipboard.writeText(emails)
       .then(() => this.snackBar.open('E-Mailadressen kopiert.', 'OK', { duration: 3000 }))
       .catch(() => this.snackBar.open('Fehler beim Kopieren der E-Mailadressen.', 'Schließen'));
+  }
+
+  formatAction(log: ChoirLog): string {
+    switch (log.action) {
+      case 'member_join':
+        return 'Beitritt';
+      case 'member_leave':
+        return 'Abmeldung';
+      case 'repertoire_add_piece':
+        return `Repertoire: Stück ${log.details?.pieceTitle || log.details?.pieceId} hinzugefügt`;
+      case 'repertoire_update_status':
+        return `Repertoire: Status geändert (${log.details?.pieceTitle || log.details?.pieceId})`;
+      case 'repertoire_update_notes':
+        return `Repertoire: Notizen geändert (${log.details?.pieceTitle || log.details?.pieceId})`;
+      case 'repertoire_update_rating':
+        return `Repertoire: Bewertung geändert (${log.details?.pieceTitle || log.details?.pieceId})`;
+      case 'event_created':
+        return `Termin erstellt (${log.details?.type})`;
+      case 'event_updated':
+        return `Termin geändert (${log.details?.type})`;
+      case 'event_deleted':
+        return 'Termin gelöscht';
+      default:
+        return log.action;
+    }
   }
 
   onSaveChoirDetails(): void {


### PR DESCRIPTION
## Summary
- log choir membership changes, repertoire edits and event updates
- expose choir logs via new endpoint for admins
- display choir log table in manage choir page

## Testing
- `cd choir-app-backend && npm test >/tmp/backend-test.log && tail -n 20 /tmp/backend-test.log`
- `cd choir-app-frontend && npm install >/tmp/frontend-install.log && tail -n 20 /tmp/frontend-install.log`
- `cd choir-app-frontend && npm test >/tmp/frontend-test.log && cat /tmp/frontend-test.log | tail -n 20` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e357eee483208428fd3b77161b2c