### PR TITLE
refactor: centralize menu visibility

### DIFF
--- a/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
+++ b/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { AuthService } from './auth.service';
+
+export interface MenuVisibility {
+  [key: string]: boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MenuVisibilityService {
+  private visibilitySubject = new BehaviorSubject<MenuVisibility>({});
+  visibility$ = this.visibilitySubject.asObservable();
+
+  constructor(private auth: AuthService) {
+    combineLatest([this.auth.currentUser$, this.auth.activeChoir$]).subscribe(([user, choir]) => {
+      const visibility: MenuVisibility = {};
+      const keys = [
+        'dashboard',
+        'events',
+        'dienstplan',
+        'availability',
+        'participation',
+        'posts',
+        'programs',
+        'stats',
+        'manageChoir',
+        'repertoire',
+        'collections',
+        'library'
+      ];
+      keys.forEach(k => visibility[k] = false);
+      if (choir) {
+        const modules = choir.modules || {};
+        const base: MenuVisibility = {
+          dashboard: true,
+          events: true,
+          dienstplan: modules.dienstplan !== false,
+          availability: true,
+          participation: true,
+          posts: true,
+          programs: modules.programs !== false,
+          stats: true,
+          manageChoir: true,
+          repertoire: true,
+          collections: true,
+          library: true
+        };
+        Object.assign(visibility, base);
+        const roles = Array.isArray(user?.roles) ? user.roles : [];
+        const isSingerOnly = roles.includes('singer') &&
+          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian', 'organist'].includes(r));
+        if (isSingerOnly) {
+          const singerMenu = modules.singerMenu || {};
+          for (const key of Object.keys(base)) {
+            if (singerMenu[key] === false) {
+              visibility[key] = false;
+            }
+          }
+        }
+      }
+      this.visibilitySubject.next(visibility);
+    });
+  }
+
+  isVisible(key: string): Observable<boolean> {
+    return this.visibility$.pipe(map(v => v[key] !== false));
+  }
+}
+

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dial
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { HelpService } from '@core/services/help.service';
 import { AuthService } from '@core/services/auth.service';
+import { MenuVisibilityService } from '@core/services/menu-visibility.service';
 import { ApiService } from '@core/services/api.service';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { ThemeService } from '@core/services/theme.service';
@@ -46,7 +47,8 @@ describe('MainLayoutComponent', () => {
         { provide: ApiService, useValue: apiServiceMock },
         { provide: BreakpointObserver, useValue: breakpointMock },
         { provide: ThemeService, useValue: themeMock },
-        { provide: LoanCartService, useValue: cartMock }
+        { provide: LoanCartService, useValue: cartMock },
+        MenuVisibilityService
       ]
     })
     .compileComponents();

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewChild, HostListener, AfterViewInit, OnDestroy } 
 import { Router, RouterModule, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { ApiService } from 'src/app/core/services/api.service';
+import { MenuVisibilityService } from '@core/services/menu-visibility.service';
 
 // Angular Material Imports
 import { MaterialModule } from '@modules/material.module';
@@ -101,7 +102,8 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
     private api: ApiService,
     private router: Router,
     private route: ActivatedRoute,
-    private cart: LoanCartService
+    private cart: LoanCartService,
+    private menu: MenuVisibilityService
   ) {
     this.isLoggedIn$ = this.authService.isLoggedIn$;
     this.isAdmin$ = this.authService.isAdmin$;
@@ -229,23 +231,8 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
     this.authService.switchChoir(id).subscribe();
   }
 
-  private singerMenuVisible(key: string): Observable<boolean> {
-    return combineLatest([this.authService.currentUser$, this.authService.activeChoir$]).pipe(
-      map(([user, choir]) => {
-        const roles = Array.isArray(user?.roles) ? user!.roles : [];
-        const isSingerOnly = roles.includes('singer') &&
-          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian', 'organist'].includes(r));
-        if (!isSingerOnly) {
-          return true;
-        }
-        const menu = choir?.modules?.singerMenu || {};
-        return menu[key] !== false;
-      })
-    );
-  }
-
-  private visibleFor(key: string, base$: Observable<boolean>): Observable<boolean> {
-    return combineLatest([base$, this.singerMenuVisible(key)]).pipe(
+  private visible(key: string, base$: Observable<boolean>): Observable<boolean> {
+    return combineLatest([base$, this.menu.isVisible(key)]).pipe(
       map(([base, allowed]) => base && allowed)
     );
   }
@@ -294,77 +281,77 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
         key: 'events',
         displayName: 'Ereignisse',
         route: '/events',
-        visibleSubject: this.visibleFor('events', this.isLoggedIn$),
+        visibleSubject: this.visible('events', this.isLoggedIn$),
         iconName: 'event',
       },
       {
         key: 'dienstplan',
         displayName: 'Dienstplan',
         route: '/dienstplan',
-        visibleSubject: this.visibleFor('dienstplan', dienstplanVisible$),
+        visibleSubject: this.visible('dienstplan', dienstplanVisible$),
         iconName: 'calendar_today',
       },
       {
         key: 'availability',
         displayName: 'Verfügbarkeiten',
         route: '/availability',
-        visibleSubject: this.visibleFor('availability', this.isLoggedIn$),
+        visibleSubject: this.visible('availability', this.isLoggedIn$),
         iconName: 'event_available',
       },
       {
         key: 'participation',
         displayName: 'Beteiligung',
         route: '/participation',
-        visibleSubject: this.visibleFor('participation', this.isLoggedIn$),
+        visibleSubject: this.visible('participation', this.isLoggedIn$),
         iconName: 'group',
       },
       {
         key: 'posts',
         displayName: 'Beiträge',
         route: '/posts',
-        visibleSubject: this.visibleFor('posts', this.isLoggedIn$),
+        visibleSubject: this.visible('posts', this.isLoggedIn$),
         iconName: 'article',
       },
       {
         key: 'programs',
         displayName: 'Programme',
         route: '/programs',
-        visibleSubject: this.visibleFor('programs', programsVisible$),
+        visibleSubject: this.visible('programs', programsVisible$),
         iconName: 'queue_music',
       },
       {
         key: 'stats',
         displayName: 'Statistik',
         route: '/stats',
-        visibleSubject: this.visibleFor('stats', this.isLoggedIn$),
+        visibleSubject: this.visible('stats', this.isLoggedIn$),
         iconName: 'bar_chart',
       },
       {
         key: 'manageChoir',
         displayName: 'Mein Chor',
         route: '/manage-choir',
-        visibleSubject: this.visibleFor('manageChoir', this.isLoggedIn$),
+        visibleSubject: this.visible('manageChoir', this.isLoggedIn$),
         iconName: 'settings',
       },
       {
         key: 'repertoire',
         displayName: 'Repertoire',
         route: '/repertoire',
-        visibleSubject: this.visibleFor('repertoire', this.isLoggedIn$),
+        visibleSubject: this.visible('repertoire', this.isLoggedIn$),
         iconName: 'library_music',
       },
       {
         key: 'collections',
         displayName: 'Sammlungen',
         route: '/collections',
-        visibleSubject: this.visibleFor('collections', this.isLoggedIn$),
+        visibleSubject: this.visible('collections', this.isLoggedIn$),
         iconName: 'folder',
       },
       {
         key: 'library',
         displayName: 'Bibliothek',
         route: '/library',
-        visibleSubject: this.visibleFor('library', this.isLoggedIn$),
+        visibleSubject: this.visible('library', this.isLoggedIn$),
         iconName: 'menu_book',
       },
       {

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HelpWizardComponent } from './help-wizard.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { AuthService } from '@core/services/auth.service';
+import { MenuVisibilityService } from '@core/services/menu-visibility.service';
 import { BehaviorSubject } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -20,7 +21,8 @@ describe('HelpWizardComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
-        { provide: AuthService, useValue: authServiceMock }
+        { provide: AuthService, useValue: authServiceMock },
+        MenuVisibilityService
       ]
     }).compileComponents();
 

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
@@ -6,6 +6,7 @@ import { MaterialModule } from '@modules/material.module';
 import { Observable, combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AuthService } from '@core/services/auth.service';
+import { MenuVisibilityService } from '@core/services/menu-visibility.service';
 
 @Component({
   selector: 'app-help-wizard',
@@ -26,7 +27,8 @@ export class HelpWizardComponent {
 
   constructor(
     public dialogRef: MatDialogRef<HelpWizardComponent>,
-    private auth: AuthService
+    private auth: AuthService,
+    private menu: MenuVisibilityService
   ) {
     this.isSingerOnly$ = combineLatest([
       this.auth.currentUser$,
@@ -46,15 +48,7 @@ export class HelpWizardComponent {
    * Returns whether a specific menu item is visible for singers based on choir configuration.
    */
   menuVisible(key: string): Observable<boolean> {
-    return combineLatest([this.isSingerOnly$, this.auth.activeChoir$]).pipe(
-      map(([isSingerOnly, choir]) => {
-        if (!isSingerOnly) {
-          return true;
-        }
-        const menu = choir?.modules?.singerMenu || {};
-        return menu[key] !== false;
-      })
-    );
+    return this.menu.isVisible(key);
   }
 
   close(): void {


### PR DESCRIPTION
## Summary
- centralize menu visibility in a dedicated service combining choir module settings and user roles
- update main layout and help wizard to use shared menu visibility

## Testing
- `npm test`
- `npm run lint --prefix choir-app-frontend` *(fails: Lint errors found in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c446a83a58832081903f7e912101b7