### PR TITLE
Add participation PDF export

### DIFF
--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -17,6 +17,7 @@ router.post("/members", role.requireChoirAdmin, role.requireNonDemo, wrap(contro
 router.put("/members/:userId", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.updateMember));
 router.delete("/members", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.removeUserFromChoir));
 router.get("/logs", role.requireChoirAdmin, wrap(controller.getChoirLogs));
+router.get("/participation/pdf", role.requireChoirAdmin, wrap(controller.downloadParticipationPdf));
 // Sammlungen können von allen Mitgliedern eingesehen werden
 router.get("/collections", wrap(controller.getChoirCollections));
 router.delete("/collections/:id", role.requireChoirAdmin, wrap(controller.removeCollectionFromChoir));

--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -273,4 +273,88 @@ function lendingListPdf(title, copies) {
   return Buffer.from(pdf, 'binary');
 }
 
-module.exports = { monthlyPlanPdf, programPdf, lendingListPdf };
+function participationPdf(members, events) {
+  const left = 50;
+  const right = 545;
+  const top = 800;
+  const rowHeight = 20;
+  const dateLabels = events.map(e => {
+    const d = new Date(e.date);
+    return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit' });
+  });
+  const columns = ['Sängername', 'E-Mail', 'Stimme', 'Bezirk', 'Gemeinde', ...dateLabels];
+  const colWidth = (right - left) / columns.length;
+  const lines = [];
+  let y = top;
+  const topLine = y + 8;
+  lines.push('0.5 w 0 0 0 RG');
+  lines.push(`${left} ${topLine} m ${right} ${topLine} l S`);
+  columns.forEach((col, i) => {
+    const x = left + i * colWidth + 2;
+    lines.push(`BT /F1 12 Tf ${x} ${y} Td (${escape(col)}) Tj ET`);
+  });
+  y -= rowHeight;
+  lines.push(`${left} ${y + 8} m ${right} ${y + 8} l S`);
+
+  function voiceCode(v) {
+    const map = {
+      'Sopran I': 'S1',
+      'Sopran II': 'S2',
+      'Alt I': 'A1',
+      'Alt II': 'A2',
+      'Tenor I': 'T1',
+      'Tenor II': 'T2',
+      'Bass I': 'B1',
+      'Bass II': 'B2'
+    };
+    return v ? (map[v] || v) : '';
+  }
+
+  for (const m of members) {
+    const row = [
+      `${m.name || ''}${m.firstName ? ', ' + m.firstName : ''}`,
+      m.email || '',
+      voiceCode(m.voice),
+      m.district || '',
+      m.congregation || ''
+    ];
+    for (let i = 0; i < events.length; i++) row.push('');
+    row.forEach((cell, i) => {
+      const x = left + i * colWidth + 2;
+      lines.push(`BT /F1 12 Tf ${x} ${y} Td (${escape(cell)}) Tj ET`);
+    });
+    y -= rowHeight;
+    lines.push(`${left} ${y + 8} m ${right} ${y + 8} l S`);
+  }
+
+  const bottomLine = y + 8;
+  for (let i = 0; i <= columns.length; i++) {
+    const x = left + i * colWidth;
+    lines.push(`${x} ${topLine} m ${x} ${bottomLine} l S`);
+  }
+  lines.push(`BT /F1 10 Tf ${left} ${y - 12} Td (${escape('Stimmen: S1,S2,A1,A2,T1,T2,B1,B2')}) Tj ET`);
+  lines.push(`BT /F1 10 Tf ${left} ${y - 24} Td (${escape('Bezirke: BS,GÖ,H-NO,H-SW,HI,WF')}) Tj ET`);
+
+  const content = lines.join('\n');
+  const objects = [];
+  objects.push('<< /Type /Catalog /Pages 2 0 R >>');
+  objects.push('<< /Type /Pages /Kids [3 0 R] /Count 1 >>');
+  objects.push('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 5 0 R /Resources << /Font << /F1 4 0 R >> >> >>');
+  objects.push('<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>');
+  objects.push(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`);
+  const offsets = [];
+  let pdf = '%PDF-1.4\n';
+  for (let i = 0; i < objects.length; i++) {
+    offsets[i] = pdf.length;
+    pdf += `${i + 1} 0 obj\n${objects[i]}\nendobj\n`;
+  }
+  const xrefStart = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (let i = 0; i < offsets.length; i++) {
+    pdf += `${String(offsets[i]).padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF`;
+  return Buffer.from(pdf, 'binary');
+}
+
+module.exports = { monthlyPlanPdf, programPdf, lendingListPdf, participationPdf };

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -655,6 +655,10 @@ export class ApiService {
     return this.choirService.getChoirLogs(options?.choirId);
   }
 
+  downloadParticipationPdf(options?: { choirId?: number }): Observable<Blob> {
+    return this.choirService.downloadParticipationPdf(options?.choirId);
+  }
+
   removeCollectionFromChoir(collectionId: number, options?: { choirId?: number }): Observable<any> {
     return this.choirService.removeCollectionFromChoir(collectionId, options?.choirId);
   }

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -58,4 +58,9 @@ export class ChoirService {
     const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
     return this.http.get<ChoirLog[]>(`${this.apiUrl}/choir-management/logs`, { params });
   }
+
+  downloadParticipationPdf(choirId?: number): Observable<Blob> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get(`${this.apiUrl}/choir-management/participation/pdf`, { params, responseType: 'blob' });
+  }
 }

--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -6,6 +6,7 @@
       <mat-option value="name">alphabetisch</mat-option>
     </mat-select>
   </mat-form-field>
+  <button mat-raised-button (click)="downloadPdf()">PDF</button>
 </div>
 
 <div class="table-container mat-elevation-z4" *ngIf="members.length > 0">

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -244,5 +244,16 @@ export class ParticipationComponent implements OnInit {
     const { year, month } = this.parseMonthKey(key);
     return new Date(year, month - 1, 1).toLocaleDateString('de-DE', { month: 'long', year: 'numeric' });
   }
+
+  downloadPdf(): void {
+    this.api.downloadParticipationPdf().subscribe(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'beteiligung.pdf';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  }
 }
 


### PR DESCRIPTION
## Summary
- add a download button on the participation page to generate a PDF list
- expose frontend service methods for participation PDF export
- implement backend route and PDF generation for member participation sheet

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68c4e8e7099c8320aac27a5a7ab055e4