### PR TITLE
Enable lending list setup for all choir collections

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -244,7 +244,7 @@
                 library_music
               </mat-icon>
               <button
-                *ngIf="(isChoirAdmin || isAdmin) && libraryItemIds.has(col.id)"
+                *ngIf="(isChoirAdmin || isAdmin)"
                 mat-icon-button
                 (click)="manageCopies(col, $event)"
                 matTooltip="Exemplare verwalten">

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -412,9 +412,19 @@ export class ManageChoirComponent implements OnInit {
 
   manageCopies(collection: Collection, event: Event): void {
     event.stopPropagation();
-    const item = this.libraryItemsByCollection.get(collection.id);
-    if (item) {
-      this.dialog.open(CollectionCopiesDialogComponent, { data: { item } });
+    const existing = this.libraryItemsByCollection.get(collection.id);
+    if (existing) {
+      this.dialog.open(CollectionCopiesDialogComponent, { data: { item: existing } });
+    } else {
+      const copiesStr = prompt('Anzahl der Exemplare eingeben:');
+      const copies = copiesStr ? parseInt(copiesStr, 10) : NaN;
+      if (!isNaN(copies) && copies > 0) {
+        this.apiService.addLibraryItem({ collectionId: collection.id, copies }).subscribe(newItem => {
+          this.libraryItemsByCollection.set(collection.id, newItem);
+          this.libraryItemIds.add(collection.id);
+          this.dialog.open(CollectionCopiesDialogComponent, { data: { item: newItem } });
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Show copy-management button for every collection in the choir management view
- Create a library item on demand when a collection lacks one and open the lending dialog

## Testing
- `npm test` *(fails: libXdamage.so.1: cannot open shared object file)*
- `npm --prefix choir-app-frontend run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ea3dfdbc8320bcd848d1435544c2