### PR TITLE
Guard manage copies until library data loads

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -247,6 +247,7 @@
                 *ngIf="(isChoirAdmin || isAdmin)"
                 mat-icon-button
                 (click)="manageCopies(col, $event)"
+                [disabled]="!libraryItemsLoaded"
                 matTooltip="Exemplare verwalten">
                 <mat-icon>list</mat-icon>
               </button>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -86,6 +86,7 @@ export class ManageChoirComponent implements OnInit {
   collectionDataSource = new MatTableDataSource<Collection>();
   libraryItemIds = new Set<number>();
   private libraryItemsByCollection = new Map<number, LibraryItem>();
+  libraryItemsLoaded = false;
 
   displayedLogColumns: string[] = ['timestamp', 'user', 'action'];
   logDataSource = new MatTableDataSource<ChoirLog>();
@@ -182,6 +183,7 @@ export class ManageChoirComponent implements OnInit {
           this.libraryItemsByCollection.set(id, i);
         }
       });
+      this.libraryItemsLoaded = true;
     });
   }
 
@@ -412,6 +414,9 @@ export class ManageChoirComponent implements OnInit {
 
   manageCopies(collection: Collection, event: Event): void {
     event.stopPropagation();
+    if (!this.libraryItemsLoaded) {
+      return;
+    }
     const existing = this.libraryItemsByCollection.get(collection.id);
     if (existing) {
       this.dialog.open(CollectionCopiesDialogComponent, { data: { item: existing } });


### PR DESCRIPTION
## Summary
- disable manage-copies button until library items are fetched
- track library item load state and guard manageCopies when data is missing

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*
- `npm run lint --prefix choir-app-backend` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f3303d788320a74c265f73ec7493