### PR TITLE
feat: enhance lending management

### DIFF
--- a/choir-app-backend/src/controllers/choir-lending.controller.js
+++ b/choir-app-backend/src/controllers/choir-lending.controller.js
@@ -33,16 +33,27 @@ exports.init = async (req, res) => {
   res.status(201).send(result);
 };
 
-// Update borrower or status of a copy
+// Update borrower of a copy
 exports.update = async (req, res) => {
   const { id } = req.params;
   const copy = await Lending.findByPk(id);
   if (!copy) return res.status(404).send({ message: 'Copy not found.' });
-  const { borrowerName, borrowerId, status } = req.body;
+  const { borrowerName, borrowerId } = req.body;
   const data = {};
-  if (borrowerName !== undefined) data.borrowerName = borrowerName;
-  if (borrowerId !== undefined) data.borrowerId = borrowerId;
-  if (status) data.status = status;
+  if (borrowerName !== undefined) {
+    data.borrowerName = borrowerName;
+    data.status = borrowerName ? 'borrowed' : 'available';
+    if (borrowerName) {
+      data.borrowedAt = new Date();
+      data.returnedAt = null;
+      if (borrowerId !== undefined) data.borrowerId = borrowerId;
+    } else {
+      data.returnedAt = new Date();
+      data.borrowerId = null;
+    }
+  } else if (borrowerId !== undefined) {
+    data.borrowerId = borrowerId;
+  }
   await copy.update(data);
   res.status(200).send(copy);
 };

--- a/choir-app-backend/src/controllers/lending.controller.js
+++ b/choir-app-backend/src/controllers/lending.controller.js
@@ -16,16 +16,27 @@ exports.list = async (req, res) => {
   res.status(200).send(copies);
 };
 
-// Update borrower or status of a copy
+// Update borrower of a copy
 exports.update = async (req, res) => {
   const { id } = req.params;
   const copy = await Lending.findByPk(id);
   if (!copy) return res.status(404).send({ message: 'Copy not found.' });
-  const { borrowerName, borrowerId, status } = req.body;
+  const { borrowerName, borrowerId } = req.body;
   const data = {};
-  if (borrowerName !== undefined) data.borrowerName = borrowerName;
-  if (borrowerId !== undefined) data.borrowerId = borrowerId;
-  if (status) data.status = status;
+  if (borrowerName !== undefined) {
+    data.borrowerName = borrowerName;
+    data.status = borrowerName ? 'borrowed' : 'available';
+    if (borrowerName) {
+      data.borrowedAt = new Date();
+      data.returnedAt = null;
+      if (borrowerId !== undefined) data.borrowerId = borrowerId;
+    } else {
+      data.returnedAt = new Date();
+      data.borrowerId = null;
+    }
+  } else if (borrowerId !== undefined) {
+    data.borrowerId = borrowerId;
+  }
   await copy.update(data);
   res.status(200).send(copy);
 };

--- a/choir-app-backend/src/models/lending.model.js
+++ b/choir-app-backend/src/models/lending.model.js
@@ -8,6 +8,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true
     },
+    borrowedAt: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    returnedAt: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
     status: {
       type: DataTypes.ENUM('available', 'borrowed'),
       defaultValue: 'available'

--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -218,8 +218,10 @@ function programPdf(program) {
 
 function lendingListPdf(title, copies) {
   const left = 50;
+  const col2 = left + 50;
+  const col3 = col2 + 250;
+  const col4 = col3 + 100;
   const right = 545;
-  const col2 = left + 80;
   const lines = [];
   let y = 800;
 
@@ -229,19 +231,31 @@ function lendingListPdf(title, copies) {
     return `BT /F1 ${size} Tf ${x} ${yPos - 2} Td (${escape(text)}) Tj ET`;
   }
 
+  function formatDate(d) {
+    if (!d) return '';
+    const date = new Date(d);
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    return `${day}.${month}.${date.getFullYear()}`;
+  }
+
   lines.push(`BT /F1 18 Tf ${left} ${y} Td (${escape('Ausleihliste ' + title)}) Tj ET`);
   y -= 30;
   const topLine = y + 8;
   lines.push('0.5 w 0 0 0 RG');
   lines.push(`${left} ${topLine} m ${right} ${topLine} l S`);
   lines.push(cellCenter(left, col2, 'Nr.', y));
-  lines.push(cellCenter(col2, right, 'Name', y));
+  lines.push(cellCenter(col2, col3, 'Name', y));
+  lines.push(cellCenter(col3, col4, 'Ausleihe', y));
+  lines.push(cellCenter(col4, right, 'Rückgabe', y));
   y -= 20;
   lines.push(`${left} ${y + 8} m ${right} ${y + 8} l S`);
 
   for (const copy of copies) {
     lines.push(cellCenter(left, col2, String(copy.copyNumber), y));
-    lines.push(cellCenter(col2, right, copy.borrowerName || '', y));
+    lines.push(cellCenter(col2, col3, copy.borrowerName || '', y));
+    lines.push(cellCenter(col3, col4, formatDate(copy.borrowedAt), y));
+    lines.push(cellCenter(col4, right, formatDate(copy.returnedAt), y));
     y -= 20;
     lines.push(`${left} ${y + 8} m ${right} ${y + 8} l S`);
   }
@@ -249,6 +263,8 @@ function lendingListPdf(title, copies) {
   const bottomLine = y + 8;
   lines.push(`${left} ${topLine} m ${left} ${bottomLine} l S`);
   lines.push(`${col2} ${topLine} m ${col2} ${bottomLine} l S`);
+  lines.push(`${col3} ${topLine} m ${col3} ${bottomLine} l S`);
+  lines.push(`${col4} ${topLine} m ${col4} ${bottomLine} l S`);
   lines.push(`${right} ${topLine} m ${right} ${bottomLine} l S`);
 
   const content = lines.join('\n');

--- a/choir-app-frontend/src/app/core/models/lending.ts
+++ b/choir-app-frontend/src/app/core/models/lending.ts
@@ -1,7 +1,9 @@
 export interface Lending {
   id: number;
   copyNumber: number;
-  borrowerName?: string;
-  borrowerId?: number;
+  borrowerName?: string | null;
+  borrowerId?: number | null;
   status: 'available' | 'borrowed';
+  borrowedAt?: string;
+  returnedAt?: string;
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -13,6 +13,7 @@ import { Choir } from 'src/app/core/models/choir';
 import { UserInChoir } from 'src/app/core/models/user';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { Collection } from 'src/app/core/models/collection';
+import { LibraryItem } from 'src/app/core/models/library-item';
 import { InviteUserDialogComponent } from '../invite-user-dialog/invite-user-dialog.component';
 import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 import { ActivatedRoute, RouterModule } from '@angular/router';
@@ -172,17 +173,17 @@ export class ManageChoirComponent implements OnInit {
         this.dataSource.data = pageData.members;
         this.collectionDataSource.data = pageData.collections;
         this.logDataSource.data = pageData.logs;
-      }
-    });
 
-    this.collectionCopyIds.clear();
-    pageData.collections.forEach(col => {
-      this.apiService.getCollectionCopies(col.id).subscribe(copies => {
-        if (copies.length > 0) {
-          this.collectionCopyIds.add(col.id);
-        }
-      });
-      this.libraryItemsLoaded = true;
+        this.collectionCopyIds.clear();
+        pageData.collections.forEach((col: Collection) => {
+          this.apiService.getCollectionCopies(col.id).subscribe(copies => {
+            if (copies.length > 0) {
+              this.collectionCopyIds.add(col.id);
+            }
+          });
+          this.libraryItemsLoaded = true;
+        });
+      }
     });
   }
 

--- a/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.html
@@ -5,30 +5,47 @@
       <th mat-header-cell *matHeaderCellDef>Nr.</th>
       <td mat-cell *matCellDef="let c">{{ c.copyNumber }}</td>
     </ng-container>
+
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef>Name</th>
       <td mat-cell *matCellDef="let c">
-        <input matInput [(ngModel)]="c.borrowerName" />
+        <input
+          matInput
+          [(ngModel)]="c.borrowerName"
+          [matAutocomplete]="auto"
+          (optionSelected)="onNameSelected(c, $event.option.value)"
+          (blur)="onNameBlur(c)"
+          [readonly]="!!c.borrowerName"
+        />
       </td>
     </ng-container>
-    <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef>Status</th>
-      <td mat-cell *matCellDef="let c">
-        <mat-select [(ngModel)]="c.status">
-          <mat-option value="available">verfügbar</mat-option>
-          <mat-option value="borrowed">ausgeliehen</mat-option>
-        </mat-select>
-      </td>
+
+    <ng-container matColumnDef="borrowed">
+      <th mat-header-cell *matHeaderCellDef>Ausleihe</th>
+      <td mat-cell *matCellDef="let c">{{ c.borrowedAt | date: 'dd.MM.yyyy' }}</td>
     </ng-container>
+
+    <ng-container matColumnDef="returned">
+      <th mat-header-cell *matHeaderCellDef>Rückgabe</th>
+      <td mat-cell *matCellDef="let c">{{ c.returnedAt | date: 'dd.MM.yyyy' }}</td>
+    </ng-container>
+
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let c">
-        <button mat-icon-button (click)="save(c)"><mat-icon>save</mat-icon></button>
+        <button mat-button color="primary" (click)="returnCopy(c)" *ngIf="c.borrowerName">Rückgabe</button>
       </td>
     </ng-container>
-    <tr mat-header-row *matHeaderRowDef="['number','name','status','actions']"></tr>
-    <tr mat-row *matRowDef="let row; columns: ['number','name','status','actions']"></tr>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>
+
+  <mat-autocomplete #auto="matAutocomplete">
+    <mat-option *ngFor="let m of members" [value]="fullName(m)">
+      {{ fullName(m) }}
+    </mat-option>
+  </mat-autocomplete>
 </div>
 <div mat-dialog-actions>
   <span class="spacer"></span>


### PR DESCRIPTION
## Summary
- add borrower and return date tracking to lending model and PDF output
- allow selecting singers or free text for copy loans and auto-save with return option
- fix manage choir data loading and missing type imports

## Testing
- `npm test` *(fails: ChromeHeadless missing libcups.so.2)*
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_68c4fe604cac8320b34cb40b344316e9