### PR TITLE
Fix participation PDF query

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -342,7 +342,12 @@ exports.downloadParticipationPdf = async (req, res, next) => {
         let members;
         try {
             members = await db.user.findAll({
-                include: [{ model: db.user_choir, where: { choirId: req.activeChoirId }, attributes: [] }],
+                include: [{
+                    model: db.choir,
+                    where: { id: req.activeChoirId },
+                    attributes: [],
+                    through: { attributes: [] }
+                }],
                 attributes: ['firstName', 'name', 'email', 'voice', 'district', 'congregation'],
                 order: [['name', 'ASC']]
             });
@@ -351,7 +356,12 @@ exports.downloadParticipationPdf = async (req, res, next) => {
             if (e.name === 'SequelizeDatabaseError') {
                 // Fallback for databases that do not yet contain district/congregation columns
                 members = await db.user.findAll({
-                    include: [{ model: db.user_choir, where: { choirId: req.activeChoirId }, attributes: [] }],
+                    include: [{
+                        model: db.choir,
+                        where: { id: req.activeChoirId },
+                        attributes: [],
+                        through: { attributes: [] }
+                    }],
                     order: [['name', 'ASC']]
                 });
                 logger.debug(`Fetched ${members.length} members for choirId ${req.activeChoirId} using fallback`);


### PR DESCRIPTION
## Summary
- fix participation PDF generation by querying users through choir association

## Testing
- `npm test --prefix choir-app-backend`
- `npm run lint --prefix choir-app-backend` *(fails: adoptedCollectionIds assigned but unused, link assigned value but never used, next defined but never used, branch can never execute, Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_e_68c505752b0083209e41eb8a61e2bec0