### PR TITLE
Add member count endpoint accessible to singers

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -86,6 +86,17 @@ exports.updateMyChoir = async (req, res, next) => {
     }
 };
 
+// Anzahl der Mitglieder des aktiven Chors abrufen
+exports.getChoirMemberCount = async (req, res, next) => {
+    try {
+        const count = await db.user_choir.count({ where: { choirId: req.activeChoirId } });
+        res.status(200).send({ count });
+    } catch (err) {
+        err.message = `Error fetching member count for choirId ${req.activeChoirId}: ${err.message}`;
+        next(err);
+    }
+};
+
 // Alle Mitglieder (Direktoren) des aktiven Chors abrufen
 exports.getChoirMembers = async (req, res, next) => {
     try {

--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -13,6 +13,7 @@ router.get("/", wrap(controller.getMyChoirDetails));
 
 // Ab hier: Member-Management und Einstellungen nur für Choir-Admins
 router.put("/", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.updateMyChoir));
+router.get("/members/count", wrap(controller.getChoirMemberCount));
 router.get("/members", role.requireDirectorOrHigher, wrap(controller.getChoirMembers));
 router.post("/members", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.inviteUserToChoir));
 router.put("/members/:userId", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.updateMember));

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -610,6 +610,10 @@ export class ApiService {
     return this.choirService.getChoirMembers(options?.choirId);
   }
 
+  getChoirMemberCount(options?: { choirId?: number }): Observable<number> {
+    return this.choirService.getChoirMemberCount(options?.choirId);
+  }
+
   inviteUserToChoir(
     email: string,
     rolesInChoir: string[],

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { Choir } from '../models/choir';
 import { UserInChoir } from '../models/user';
@@ -26,6 +27,13 @@ export class ChoirService {
   getChoirMembers(choirId?: number): Observable<UserInChoir[]> {
     const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
     return this.http.get<UserInChoir[]>(`${this.apiUrl}/choir-management/members`, { params });
+  }
+
+  getChoirMemberCount(choirId?: number): Observable<number> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http
+      .get<{ count: number }>(`${this.apiUrl}/choir-management/members/count`, { params })
+      .pipe(map(res => res.count));
   }
 
   inviteUserToChoir(email: string, rolesInChoir: string[], choirId?: number): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -122,8 +122,7 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.memberCount$ = this.refresh$.pipe(
-      switchMap(() => this.apiService.getChoirMembers()),
-      map(members => members.length)
+      switchMap(() => this.apiService.getChoirMemberCount())
     );
 
     this.borrowedItems$ = this.refresh$.pipe(


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch choir member count
- expose member count in services and dashboard without requiring elevated roles

## Testing
- `npm test` *(fails: libXcomposite.so.1: cannot open shared object file)*
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_68c5786dc21c8320bb5bc51745fa488f