### PR TITLE
Remove Organist checkbox from admin user dialogs

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.html
@@ -19,7 +19,6 @@
         <mat-option value="singer">Sänger</mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-checkbox formControlName="isOrganist">Organist</mat-checkbox>
   </form>
 </div>
 <div mat-dialog-actions align="end">

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
@@ -26,8 +26,7 @@ export class AddMemberDialogComponent implements OnInit {
   ) {
     this.form = this.fb.group({
       user: ['', Validators.required],
-      roles: [['director'], Validators.required],
-      isOrganist: [false]
+      roles: [['director'], Validators.required]
     });
   }
 
@@ -63,10 +62,7 @@ export class AddMemberDialogComponent implements OnInit {
     if (this.form.valid) {
       const user: User = this.form.value.user;
       const roles = this.form.value.roles as string[];
-      const isOrg = this.form.value.isOrganist;
-      const finalRoles = isOrg && !roles.includes('organist') ? [...roles, 'organist'] :
-        (!isOrg ? roles.filter(r => r !== 'organist') : roles);
-      this.dialogRef.close({ email: user.email, roles: finalRoles });
+      this.dialogRef.close({ email: user.email, roles });
     }
   }
 }

--- a/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.html
@@ -13,11 +13,10 @@
       <mat-select formControlName="roles" multiple>
         <mat-option value="director">Dirigent</mat-option>
         <mat-option value="choir_admin">Chor-Admin</mat-option>
+        <mat-option value="organist">Organist</mat-option>
         <mat-option value="singer">Sänger</mat-option>
       </mat-select>
     </mat-form-field>
-
-    <mat-checkbox formControlName="isOrganist">Organist</mat-checkbox>
   </form>
 </div>
 <div mat-dialog-actions>

--- a/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/add-to-choir-dialog/add-to-choir-dialog.component.ts
@@ -25,7 +25,6 @@ export class AddToChoirDialogComponent implements OnInit {
     this.form = this.fb.group({
       choir: [null, Validators.required],
       roles: [['singer'], Validators.required],
-      isOrganist: [false],
     });
   }
 
@@ -43,11 +42,7 @@ export class AddToChoirDialogComponent implements OnInit {
     if (this.form.valid) {
       const choirId = this.form.value.choir;
       const roles = this.form.value.roles as string[];
-      const isOrg = this.form.value.isOrganist;
-      const finalRoles = isOrg && !roles.includes('organist')
-        ? [...roles, 'organist']
-        : (!isOrg ? roles.filter(r => r !== 'organist') : roles);
-      this.dialogRef.close({ choirId, roles: finalRoles });
+      this.dialogRef.close({ choirId, roles });
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove separate Organist checkbox from dialogs adding users to choirs
- allow selecting Organist directly in role selection

## Testing
- `npm test --prefix choir-app-frontend` *(fails: libatk-1.0.so.0 missing)*
- `npm run lint` *(fails: Lint errors found in the listed files)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ae2b18c8320a82f26b37f270964