### PR TITLE
fix: load choir logs only for admins

### DIFF
--- a/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir-resolver.ts
@@ -31,8 +31,8 @@ export class ManageChoirResolver implements Resolve<any> {
         const choirDetails$ = this.apiService.getMyChoirDetails(opts);
         const collections$ = this.apiService.getChoirCollections(opts);
         const planRules$ = this.apiService.getPlanRules(opts);
-        const logs$ = this.apiService.getChoirLogs(opts);
         if (isAdmin) {
+          const logs$ = this.apiService.getChoirLogs(opts);
           return forkJoin({
             choirDetails: choirDetails$,
             members: this.apiService.getChoirMembers(opts),
@@ -45,6 +45,7 @@ export class ManageChoirResolver implements Resolve<any> {
         return this.apiService.checkChoirAdminStatus().pipe(
           switchMap(status => {
             if (status.isChoirAdmin) {
+              const logs$ = this.apiService.getChoirLogs();
               return forkJoin({
                 choirDetails: choirDetails$,
                 members: this.apiService.getChoirMembers(),
@@ -59,7 +60,7 @@ export class ManageChoirResolver implements Resolve<any> {
                 members: of([]),
                 collections: collections$,
                 planRules: planRules$,
-                logs: logs$,
+                logs: of([]),
                 isChoirAdmin: of(false)
               });
             }


### PR DESCRIPTION
## Summary
- avoid fetching choir logs unless user is admin or choir admin to prevent 403 errors

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run lint` *(fails: 691 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c57b897654832098bb759976d3d298