### PR TITLE
Allow choir admins to manage participation

### DIFF
--- a/choir-app-backend/src/controllers/availability.controller.js
+++ b/choir-app-backend/src/controllers/availability.controller.js
@@ -71,6 +71,18 @@ exports.setAvailability = async (req, res) => {
     res.status(200).send(avail);
 };
 
+exports.setUserAvailability = async (req, res) => {
+    const { date, status } = req.body;
+    const { userId } = req.params;
+    if (!date || !status) return res.status(400).send({ message: 'date and status required' });
+    const [avail] = await db.user_availability.findOrCreate({
+        where: { userId, choirId: req.activeChoirId, date },
+        defaults: { status }
+    });
+    if (avail.status !== status) await avail.update({ status });
+    res.status(200).send(avail);
+};
+
 exports.findAllByMonth = async (req, res) => {
     const { year, month } = req.params;
     const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();

--- a/choir-app-backend/src/routes/availability.routes.js
+++ b/choir-app-backend/src/routes/availability.routes.js
@@ -8,6 +8,7 @@ router.use(auth.verifyToken);
 
 router.get("/:year/:month/all", role.requireChoirAdmin, wrap(controller.findAllByMonth));
 router.get("/:year/:month", wrap(controller.findByMonth));
+router.put("/:userId", role.requireChoirAdmin, wrap(controller.setUserAvailability));
 router.put("/", wrap(controller.setAvailability));
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -480,6 +480,10 @@ export class ApiService {
     return this.availabilityService.getMemberAvailabilities(year, month);
   }
 
+  setMemberAvailability(userId: number, date: string, status: string): Observable<UserAvailability> {
+    return this.availabilityService.setMemberAvailability(userId, date, status);
+  }
+
 
   // --- User Methods ---
 

--- a/choir-app-frontend/src/app/core/services/availability.service.ts
+++ b/choir-app-frontend/src/app/core/services/availability.service.ts
@@ -21,4 +21,8 @@ export class AvailabilityService {
   getMemberAvailabilities(year: number, month: number): Observable<MemberAvailability[]> {
     return this.http.get<MemberAvailability[]>(`${this.apiUrl}/availabilities/${year}/${month}/all`);
   }
+
+  setMemberAvailability(userId: number, date: string, status: string): Observable<UserAvailability> {
+    return this.http.put<UserAvailability>(`${this.apiUrl}/availabilities/${userId}`, { date, status });
+  }
 }

--- a/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
+++ b/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
@@ -53,6 +53,7 @@ export class MenuVisibilityService {
         const isSingerOnly = roles.includes('singer') &&
           !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian', 'organist'].includes(r));
         if (isSingerOnly) {
+          visibility['participation'] = false;
           const singerMenu = modules.singerMenu || {};
           for (const key of Object.keys(base)) {
             if (singerMenu[key] === false) {

--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -23,7 +23,7 @@
 
     <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
       <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
-      <mat-cell *matCellDef="let m">
+      <mat-cell *matCellDef="let m" (click)="changeStatus(m.id, col.key)">
         <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, col.key)) as icon" [ngClass]="classFor(status(m.id, col.key))">{{ icon }}</mat-icon>
       </mat-cell>
     </ng-container>
@@ -32,7 +32,7 @@
       <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
       <mat-cell *matCellDef="let m">
         <ng-container *ngFor="let ev of col.events">
-          <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon" [ngClass]="classFor(status(m.id, ev.date))">{{ icon }}</mat-icon>
+          <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon" [ngClass]="classFor(status(m.id, ev.date))" (click)="changeStatus(m.id, ev.date)">{{ icon }}</mat-icon>
         </ng-container>
       </mat-cell>
     </ng-container>

--- a/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
@@ -1,9 +1,10 @@
 import { ParticipationComponent } from './participation.component';
 import { UserInChoir } from '@core/models/user';
+import { BehaviorSubject } from 'rxjs';
 
 describe('ParticipationComponent', () => {
   it('sortByVoice should handle null names', () => {
-    const component = new ParticipationComponent({} as any);
+    const component = new ParticipationComponent({} as any, { currentUser$: new BehaviorSubject<any>(null) } as any);
     const members: UserInChoir[] = [
       { id: 1, name: null as any, email: '', voice: 'SOPRAN' },
       { id: 2, name: 'Alpha', email: '', voice: 'SOPRAN' }

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
+import { AuthService } from '@core/services/auth.service';
 import { UserInChoir } from '@core/models/user';
 import { Event } from '@core/models/event';
 import { MemberAvailability } from '@core/models/member-availability';
@@ -29,12 +30,17 @@ export class ParticipationComponent implements OnInit {
   eventColumns: EventColumn[] = [];
   monthColumns: MonthColumn[] = [];
   displayedColumns: string[] = ['name', 'voice'];
+  isChoirAdmin = false;
 
   private availabilityMap: { [userId: number]: { [date: string]: string } } = {};
 
-  constructor(private api: ApiService) {}
+  constructor(private api: ApiService, private auth: AuthService) {}
 
   ngOnInit(): void {
+    this.auth.currentUser$.subscribe(user => {
+      const roles = Array.isArray(user?.roles) ? user.roles : user?.roles ? [user.roles] : [];
+      this.isChoirAdmin = roles.some(r => ['choir_admin', 'director', 'admin'].includes(r));
+    });
     this.loadMembers();
     this.loadEvents();
   }
@@ -118,6 +124,25 @@ export class ParticipationComponent implements OnInit {
       case 'UNAVAILABLE': return 'unavailable';
       default: return '';
     }
+  }
+
+  private nextStatus(current?: string): string {
+    switch (current) {
+      case 'UNAVAILABLE': return 'AVAILABLE';
+      case 'AVAILABLE': return 'MAYBE';
+      case 'MAYBE': return 'UNAVAILABLE';
+      default: return 'UNAVAILABLE';
+    }
+  }
+
+  changeStatus(userId: number, date: string): void {
+    if (!this.isChoirAdmin) return;
+    const key = this.dateKey(date);
+    const next = this.nextStatus(this.status(userId, key));
+    this.api.setMemberAvailability(userId, key, next).subscribe(avail => {
+      if (!this.availabilityMap[userId]) this.availabilityMap[userId] = {};
+      this.availabilityMap[userId][key] = avail.status!;
+    });
   }
 
   private readonly voiceMap: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Allow choir admins to update availability for any singer
- Hide participation menu for singers by default
- Enable conductors to change participation statuses directly in overview

## Testing
- `node tests/availability.controller.test.js`
- `npm test` *(frontend: missing libcups.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c57fb5b4388320b32b2b8a54f864b3