### PR TITLE
Restrict library borrowing for singer role

### DIFF
--- a/choir-app-frontend/src/app/features/library/library.component.html
+++ b/choir-app-frontend/src/app/features/library/library.component.html
@@ -56,7 +56,7 @@
       <ng-container matColumnDef="actions">
         <mat-header-cell *matHeaderCellDef></mat-header-cell>
         <mat-cell *matCellDef="let element">
-          <button mat-icon-button color="primary" *ngIf="element.status === 'available'" (click)="addToCart(element, $event)">
+          <button mat-icon-button color="primary" *ngIf="element.status === 'available' && !isSingerOnly" (click)="addToCart(element, $event)">
             <mat-icon>add_shopping_cart</mat-icon>
           </button>
           <button mat-icon-button *ngIf="isAdmin || isLibrarian" [matMenuTriggerFor]="itemMenu" (click)="$event.stopPropagation()">

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -36,6 +36,7 @@ export class LibraryComponent implements OnInit, AfterViewInit {
   collections$!: Observable<Collection[]>;
   isAdmin = false;
   isLibrarian = false;
+  isSingerOnly = false;
   displayedColumns: string[] = ['cover', 'title', 'copies', 'actions'];
 
   dataSource = new MatTableDataSource<LibraryItem>();
@@ -56,6 +57,10 @@ export class LibraryComponent implements OnInit, AfterViewInit {
     this.collections$ = this.apiService.getCollections();
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
     this.auth.isLibrarian$.subscribe(l => this.isLibrarian = l);
+    this.auth.currentUser$.subscribe(user => {
+      const roles = Array.isArray(user?.roles) ? user.roles : [];
+      this.isSingerOnly = roles.includes('singer') && !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
+    });
   }
 
   ngAfterViewInit(): void {

--- a/choir-app-frontend/src/app/features/library/loan-cart.component.ts
+++ b/choir-app-frontend/src/app/features/library/loan-cart.component.ts
@@ -24,11 +24,19 @@ export class LoanCartComponent {
   reason = '';
   choir$!: Observable<any>;
   user$!: Observable<any>;
+  isSingerOnly = false;
 
   constructor(private cart: LoanCartService, private api: ApiService, private auth: AuthService, private snack: MatSnackBar, private router: Router) {
     this.items$ = this.cart.items$;
     this.choir$ = this.api.getMyChoirDetails();
     this.user$ = this.auth.currentUser$;
+    this.auth.currentUser$.subscribe(user => {
+      const roles = Array.isArray(user?.roles) ? user.roles : [];
+      this.isSingerOnly = roles.includes('singer') && !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
+      if (this.isSingerOnly) {
+        this.router.navigate(['/library']);
+      }
+    });
   }
 
   remove(id: number): void {


### PR DESCRIPTION
## Summary
- Hide library borrowing actions for users with only the `singer` role
- Redirect singer-only users away from the loan cart page

## Testing
- `npm test --silent >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5902aa6648320be10e30a133e805c