### PR TITLE
feat: show participation dates and icons

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -24,7 +24,7 @@
     <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
       <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
       <mat-cell *matCellDef="let m" (click)="changeStatus(m.id, col.key)">
-        <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, col.key)) as icon" [ngClass]="classFor(status(m.id, col.key))">{{ icon }}</mat-icon>
+        <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, col.key))">{{ iconFor(status(m.id, col.key)) }}</mat-icon>
       </mat-cell>
     </ng-container>
 
@@ -32,7 +32,12 @@
       <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
       <mat-cell *matCellDef="let m">
         <ng-container *ngFor="let ev of col.events">
-          <mat-icon class="status-icon" *ngIf="iconFor(status(m.id, ev.date)) as icon" [ngClass]="classFor(status(m.id, ev.date))" (click)="changeStatus(m.id, ev.date)">{{ icon }}</mat-icon>
+          <span class="event-item">
+            <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, ev.date))" (click)="changeStatus(m.id, ev.date)">
+              {{ iconFor(status(m.id, ev.date)) }}
+            </mat-icon>
+            <span class="event-date">{{ formatDate(ev.date) }}</span>
+          </span>
         </ng-container>
       </mat-cell>
     </ng-container>

--- a/choir-app-frontend/src/app/features/participation/participation.component.scss
+++ b/choir-app-frontend/src/app/features/participation/participation.component.scss
@@ -23,3 +23,18 @@
 .unavailable {
   color: #d32f2f;
 }
+
+.unknown {
+  color: #9e9e9e;
+}
+
+.event-item {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 4px;
+}
+
+.event-date {
+  font-size: 12px;
+  margin-left: 2px;
+}

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -63,7 +63,12 @@ export class ParticipationComponent implements OnInit {
         this.displayMode = 'events';
         this.eventColumns = future.map(ev => ({
           key: this.dateKey(ev.date),
-          label: parseDateOnly(ev.date).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', timeZone: 'Europe/Berlin' })
+          label: parseDateOnly(ev.date).toLocaleDateString('de-DE', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            timeZone: 'Europe/Berlin',
+          })
         }));
         this.displayedColumns = ['name', 'voice', ...this.eventColumns.map(c => c.key)];
         const months = Array.from(new Set(future.map(e => this.monthKey(e.date))));
@@ -112,9 +117,9 @@ export class ParticipationComponent implements OnInit {
   iconFor(status?: string): string {
     switch (status) {
       case 'AVAILABLE': return 'check';
-      case 'MAYBE': return 'help';
+      case 'MAYBE': return 'check';
       case 'UNAVAILABLE': return 'close';
-      default: return '';
+      default: return 'help';
     }
   }
 
@@ -123,8 +128,16 @@ export class ParticipationComponent implements OnInit {
       case 'AVAILABLE': return 'available';
       case 'MAYBE': return 'maybe';
       case 'UNAVAILABLE': return 'unavailable';
-      default: return '';
+      default: return 'unknown';
     }
+  }
+
+  formatDate(date: string | Date): string {
+    return parseDateOnly(date).toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      timeZone: 'Europe/Berlin',
+    });
   }
 
   private nextStatus(current?: string): string {


### PR DESCRIPTION
## Summary
- display exact dates in participation table
- show status icons for all members and events

## Testing
- `npm test`
- `npm run lint --prefix choir-app-frontend` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c59b6236b08320b27dbb07efea5281