### PR TITLE
Include availability statuses in participation PDF

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -359,7 +359,7 @@ exports.downloadParticipationPdf = async (req, res, next) => {
                     attributes: [],
                     through: { attributes: [] }
                 }],
-                attributes: ['firstName', 'name', 'email', 'voice', 'district', 'congregation'],
+                attributes: ['id', 'firstName', 'name', 'email', 'voice', 'district', 'congregation'],
                 order: [['name', 'ASC']]
             });
             logger.debug(`Fetched ${members.length} members for choirId ${req.activeChoirId}`);
@@ -386,7 +386,17 @@ exports.downloadParticipationPdf = async (req, res, next) => {
             order: [['date', 'ASC']]
         });
         logger.debug(`Fetched ${events.length} upcoming events for choirId ${req.activeChoirId}`);
-        const pdf = participationPdf(members, events);
+
+        const dates = events.map(e => e.date);
+        const availabilities = await db.user_availability.findAll({
+            where: {
+                choirId: req.activeChoirId,
+                date: { [Op.in]: dates }
+            },
+            attributes: ['userId', 'date', 'status']
+        });
+
+        const pdf = participationPdf(members, events, availabilities);
         logger.debug(`Generated participation PDF with ${pdf.length} bytes for choirId ${req.activeChoirId}`);
         res.setHeader('Content-Type', 'application/pdf');
         res.status(200).send(pdf);


### PR DESCRIPTION
## Summary
- populate participation PDF with member availability symbols
- fetch member availability data and forward to PDF generator

## Testing
- `npm test --prefix choir-app-backend` *(incomplete: exceeded environment limits)*
- `npm run lint --prefix choir-app-backend` *(fails: 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aaad83b08320a7ec0e56070c1db1