### PR TITLE
Add participation status summary

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -30,11 +30,13 @@
     <ng-container matColumnDef="name">
       <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
       <mat-cell *matCellDef="let m">{{ m.name }}, {{ m.firstName }}</mat-cell>
+      <mat-footer-cell *matFooterCellDef>Summe</mat-footer-cell>
     </ng-container>
 
     <ng-container matColumnDef="voice">
       <mat-header-cell *matHeaderCellDef>Stimme</mat-header-cell>
       <mat-cell *matCellDef="let m">{{ voiceOf(m) }}</mat-cell>
+      <mat-footer-cell *matFooterCellDef></mat-footer-cell>
     </ng-container>
 
     <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
@@ -42,6 +44,20 @@
       <mat-cell *matCellDef="let m" (click)="changeStatus(m.id, col.key)">
         <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, col.key))">{{ iconFor(status(m.id, col.key)) }}</mat-icon>
       </mat-cell>
+      <mat-footer-cell *matFooterCellDef>
+        <span class="summary-item">
+          <mat-icon class="status-icon available">check</mat-icon>{{ statusCount(col.key, 'AVAILABLE') }}
+        </span>
+        <span class="summary-item">
+          <mat-icon class="status-icon maybe">check</mat-icon>{{ statusCount(col.key, 'MAYBE') }}
+        </span>
+        <span class="summary-item">
+          <mat-icon class="status-icon unavailable">close</mat-icon>{{ statusCount(col.key, 'UNAVAILABLE') }}
+        </span>
+        <span class="summary-item">
+          <mat-icon class="status-icon unknown">help</mat-icon>{{ statusCount(col.key, 'UNKNOWN') }}
+        </span>
+      </mat-footer-cell>
     </ng-container>
 
     <ng-container *ngFor="let col of monthColumns" [matColumnDef]="col.key">
@@ -56,10 +72,12 @@
           </span>
         </ng-container>
       </mat-cell>
+      <mat-footer-cell *matFooterCellDef></mat-footer-cell>
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
     <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+    <mat-footer-row *matFooterRowDef="displayedColumns"></mat-footer-row>
     <ng-container matNoDataRow>
       <tr class="mat-row" *matNoDataRow>
         <td class="mat-cell" [attr.colspan]="displayedColumns.length">

--- a/choir-app-frontend/src/app/features/participation/participation.component.scss
+++ b/choir-app-frontend/src/app/features/participation/participation.component.scss
@@ -38,6 +38,12 @@
   margin-right: 4px;
 }
 
+.summary-item {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 4px;
+}
+
 .event-date {
   font-size: 12px;
   margin-left: 2px;

--- a/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
@@ -13,4 +13,25 @@ describe('ParticipationComponent', () => {
     const sorted = component['sortByVoice'](members);
     expect(sorted.length).toBe(2);
   });
+
+  it('statusCount counts all statuses', () => {
+    const component = new ParticipationComponent({} as any, { currentUser$: new BehaviorSubject<any>(null) } as any);
+    component.members = [
+      { id: 1, name: 'A', email: '', voice: 'SOPRAN' },
+      { id: 2, name: 'B', email: '', voice: 'ALT' },
+      { id: 3, name: 'C', email: '', voice: 'TENOR' },
+      { id: 4, name: 'D', email: '', voice: 'BASS' }
+    ];
+    (component as any).availabilityMap = {
+      1: { '2024-01-01': 'AVAILABLE' },
+      2: { '2024-01-01': 'MAYBE' },
+      3: { '2024-01-01': 'UNAVAILABLE' },
+      4: {}
+    };
+    const key = '2024-01-01';
+    expect(component.statusCount(key, 'AVAILABLE')).toBe(1);
+    expect(component.statusCount(key, 'MAYBE')).toBe(1);
+    expect(component.statusCount(key, 'UNAVAILABLE')).toBe(1);
+    expect(component.statusCount(key, 'UNKNOWN')).toBe(1);
+  });
 });

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -136,6 +136,15 @@ export class ParticipationComponent implements OnInit {
     }
   }
 
+  statusCount(dateKey: string, type: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE' | 'UNKNOWN'): number {
+    let count = 0;
+    for (const m of this.members) {
+      const s = this.status(m.id, dateKey);
+      if ((s ?? 'UNKNOWN') === type) count++;
+    }
+    return count;
+  }
+
   formatDate(date: string | Date): string {
     return parseDateOnly(date).toLocaleDateString('de-DE', {
       day: '2-digit',


### PR DESCRIPTION
## Summary
- show participation totals per date with icons for all four statuses
- cover counting logic with unit tests

## Testing
- `npm test --prefix choir-app-frontend` *(fails: Expected false to be true in main-layout.component.spec.ts)*
- `npm run lint --prefix choir-app-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68c6ff82c4908320a701dbf6d2c25058