### PR TITLE
Add district abbreviations and user district selection

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -410,7 +410,7 @@ exports.downloadParticipationPdf = async (req, res, next) => {
             attributes: ['userId', 'date', 'status']
         });
 
-        const pdf = participationPdf(members, events, availabilities);
+        const pdf = await participationPdf(members, events, availabilities);
         logger.debug(`Generated participation PDF with ${pdf.length} bytes for choirId ${req.activeChoirId}`);
         res.setHeader('Content-Type', 'application/pdf');
         res.status(200).send(pdf);

--- a/choir-app-backend/src/controllers/district.controller.js
+++ b/choir-app-backend/src/controllers/district.controller.js
@@ -11,13 +11,36 @@ exports.getAll = async (_req, res) => {
 };
 
 exports.create = async (req, res) => {
-  const { name } = req.body;
-  if (!name) {
-    return res.status(400).send({ message: 'Name is required.' });
+  const { name, code } = req.body;
+  if (!name || !code) {
+    return res.status(400).send({ message: 'Name and code are required.' });
   }
   try {
-    const district = await District.create({ name });
+    const district = await District.create({ name, code });
     res.status(201).send(district);
+  } catch (err) {
+    if (err.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).send({ message: 'District already exists.' });
+    }
+    res.status(500).send({ message: err.message });
+  }
+};
+
+exports.update = async (req, res) => {
+  const { name, code } = req.body;
+  if (!name || !code) {
+    return res.status(400).send({ message: 'Name and code are required.' });
+  }
+  try {
+    const id = req.params.id;
+    const district = await District.findByPk(id);
+    if (!district) {
+      return res.status(404).send({ message: 'District not found.' });
+    }
+    district.name = name;
+    district.code = code;
+    await district.save();
+    res.status(200).send(district);
   } catch (err) {
     if (err.name === 'SequelizeUniqueConstraintError') {
       return res.status(409).send({ message: 'District already exists.' });

--- a/choir-app-backend/src/models/district.model.js
+++ b/choir-app-backend/src/models/district.model.js
@@ -5,6 +5,11 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       unique: true,
     },
+    code: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
   });
   return District;
 };

--- a/choir-app-backend/src/models/district.model.js
+++ b/choir-app-backend/src/models/district.model.js
@@ -7,7 +7,9 @@ module.exports = (sequelize, DataTypes) => {
     },
     code: {
       type: DataTypes.STRING,
-      allowNull: false,
+      // Allow null temporarily so existing installations can backfill codes
+      // before enforcing a NOT NULL constraint in a future migration
+      allowNull: true,
       unique: true,
     },
   });

--- a/choir-app-backend/src/routes/district.routes.js
+++ b/choir-app-backend/src/routes/district.routes.js
@@ -8,6 +8,7 @@ router.use(authJwt.verifyToken);
 
 router.get("/", wrap(controller.getAll));
 router.post("/", role.requireAdmin, wrap(controller.create));
+router.put("/:id", role.requireAdmin, wrap(controller.update));
 router.delete("/:id", role.requireAdmin, wrap(controller.remove));
 
 module.exports = router;

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -112,7 +112,12 @@ async function seedDatabase(options = {}) {
                 { name: 'Wolfenbüttel', code: 'WF' }
             ];
             for (const d of districts) {
-                await db.district.findOrCreate({ where: { name: d.name }, defaults: d });
+                const [district, created] = await db.district.findOrCreate({ where: { name: d.name }, defaults: d });
+                // Backfill missing codes for existing districts
+                if (!created && !district.code) {
+                    district.code = d.code;
+                    await district.save();
+                }
             }
             logger.info("Initial seeding completed successfully.");
         } else {

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -100,9 +100,19 @@ async function seedDatabase(options = {}) {
                 where: { key: 'SYSTEM_ADMIN_EMAIL' },
                 defaults: { value: process.env.SYSTEM_ADMIN_EMAIL || '' }
             });
-            const districts = ['Braunschweig', 'Göttingen', 'Hannover-Nordost', 'Hannover-Südwest', 'Hildesheim', 'Lübeck-Schwerin', 'Lüneburg', 'Wolfenbüttel'];
-            for (const name of districts) {
-                await db.district.findOrCreate({ where: { name }, defaults: { name } });
+            const districts = [
+                { name: 'Braunschweig', code: 'BS' },
+                { name: 'Göttingen', code: 'GÖ' },
+                { name: 'Hannover-Nordost', code: 'H-NO' },
+                { name: 'Hannover-Südwest', code: 'H-SW' },
+                { name: 'Hildesheim', code: 'HI' },
+                { name: 'Lübeck-Schwerin', code: 'L-S' },
+                { name: 'Lüneburg', code: 'LG' },
+                { name: 'Magdeburg', code: 'MD' },
+                { name: 'Wolfenbüttel', code: 'WF' }
+            ];
+            for (const d of districts) {
+                await db.district.findOrCreate({ where: { name: d.name }, defaults: d });
             }
             logger.info("Initial seeding completed successfully.");
         } else {

--- a/choir-app-backend/src/services/pdf.service.js
+++ b/choir-app-backend/src/services/pdf.service.js
@@ -290,20 +290,15 @@ function lendingListPdf(title, copies) {
     return Buffer.from(pdf, 'binary');
 }
 
-const districtCodes = {
-  'Braunschweig': 'BS',
-  'Göttingen': 'GÖ',
-  'Hannover-Nordost': 'H-NO',
-  'Hannover-Südwest': 'H-SW',
-  'Hildesheim': 'HI',
-  'Lübeck-Schwerin': 'L-S',
-  'Lüneburg': 'LG',
-  'Magdeburg': 'MD',
-  'Wolfenbüttel': 'WF'
-};
+const db = require('../models');
 
-function participationPdf(members, events, availabilities = []) {
+async function participationPdf(members, events, availabilities = []) {
   logger.debug(`Generating participation PDF: ${members.length} members, ${events.length} events`);
+  const districtEntries = await db.district.findAll();
+  const districtCodes = {};
+  for (const d of districtEntries) {
+    districtCodes[d.name] = d.code;
+  }
   const left = 40;
   const right = 802;
   const top = 550;

--- a/choir-app-frontend/src/app/core/models/district.ts
+++ b/choir-app-frontend/src/app/core/models/district.ts
@@ -1,4 +1,5 @@
 export interface District {
   id: number;
   name: string;
+  code: string;
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -182,8 +182,12 @@ export class ApiService {
     return this.districtService.getDistricts();
   }
 
-  createDistrict(name: string): Observable<District> {
-    return this.districtService.createDistrict({ name });
+  createDistrict(name: string, code: string): Observable<District> {
+    return this.districtService.createDistrict({ name, code });
+  }
+
+  updateDistrict(id: number, name: string, code: string): Observable<District> {
+    return this.districtService.updateDistrict(id, { name, code });
   }
 
   deleteDistrict(id: number): Observable<any> {

--- a/choir-app-frontend/src/app/core/services/district.service.ts
+++ b/choir-app-frontend/src/app/core/services/district.service.ts
@@ -9,6 +9,7 @@ export class DistrictService extends CreatorService<District> {
   constructor(http: HttpClient) { super(http, 'districts'); }
 
   getDistricts(): Observable<District[]> { return this.getAll(); }
-  createDistrict(data: { name: string }): Observable<District> { return this.create(data); }
+  createDistrict(data: { name: string; code: string }): Observable<District> { return this.create(data); }
+  updateDistrict(id: number, data: { name: string; code: string }): Observable<District> { return this.update(id, data); }
   deleteDistrict(id: number): Observable<any> { return this.delete(id); }
 }

--- a/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.html
@@ -1,11 +1,16 @@
 <h2>Bezirke verwalten</h2>
 
-<form [formGroup]="form" (ngSubmit)="add()" class="add-form">
+<form [formGroup]="form" (ngSubmit)="save()" class="add-form">
   <mat-form-field appearance="outline">
     <mat-label>Bezirk</mat-label>
     <input matInput formControlName="name">
   </mat-form-field>
-  <button mat-flat-button color="primary" type="submit">Hinzufügen</button>
+  <mat-form-field appearance="outline">
+    <mat-label>Abkürzung</mat-label>
+    <input matInput formControlName="code">
+  </mat-form-field>
+  <button mat-flat-button color="primary" type="submit">{{ editing ? 'Speichern' : 'Hinzufügen' }}</button>
+  <button *ngIf="editing" mat-button type="button" (click)="cancel()">Abbrechen</button>
 </form>
 
 <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
@@ -13,9 +18,14 @@
     <th mat-header-cell *matHeaderCellDef>Bezirk</th>
     <td mat-cell *matCellDef="let d">{{ d.name }}</td>
   </ng-container>
+  <ng-container matColumnDef="code">
+    <th mat-header-cell *matHeaderCellDef>Abkürzung</th>
+    <td mat-cell *matCellDef="let d">{{ d.code }}</td>
+  </ng-container>
   <ng-container matColumnDef="actions">
     <th mat-header-cell *matHeaderCellDef>Aktionen</th>
     <td mat-cell *matCellDef="let d">
+      <button mat-icon-button (click)="edit(d)"><mat-icon>edit</mat-icon></button>
       <button mat-icon-button color="warn" (click)="delete(d)"><mat-icon>delete</mat-icon></button>
     </td>
   </ng-container>

--- a/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-districts/manage-districts.component.spec.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@core/services/api.service';
 class MockApiService {
   getDistricts() { return of([]); }
   createDistrict() { return of({}); }
+  updateDistrict() { return of({}); }
   deleteDistrict() { return of({}); }
 }
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -29,7 +29,10 @@
     </mat-form-field>
     <mat-form-field appearance="outline">
       <mat-label>Bezirk</mat-label>
-      <input matInput formControlName="district">
+      <mat-select formControlName="district">
+        <mat-option value="">-</mat-option>
+        <mat-option *ngFor="let d of districts" [value]="d.name">{{ d.name }}</mat-option>
+      </mat-select>
     </mat-form-field>
     <mat-form-field appearance="outline">
       <mat-label>Gemeinde</mat-label>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -1,9 +1,11 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
 import { User } from 'src/app/core/models/user';
+import { ApiService } from '@core/services/api.service';
+import { District } from '@core/models/district';
 
 @Component({
   selector: 'app-user-dialog',
@@ -12,12 +14,14 @@ import { User } from 'src/app/core/models/user';
   templateUrl: './user-dialog.component.html',
   styleUrls: ['./user-dialog.component.scss']
 })
-export class UserDialogComponent {
+export class UserDialogComponent implements OnInit {
   form: FormGroup;
   title = 'Benutzer hinzufügen';
+  districts: District[] = [];
 
   constructor(
     private fb: FormBuilder,
+    private api: ApiService,
     public dialogRef: MatDialogRef<UserDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: User | null
   ) {
@@ -36,6 +40,10 @@ export class UserDialogComponent {
       roles: [data?.roles || ['director'], Validators.required],
       password: ['', data ? [] : [Validators.required]]
     });
+  }
+
+  ngOnInit(): void {
+    this.api.getDistricts().subscribe(ds => this.districts = ds);
   }
 
   onCancel(): void {


### PR DESCRIPTION
## Summary
- allow districts to have unique abbreviations and manage them via admin UI
- populate user dialog with selectable districts
- use stored district abbreviations when generating participation PDFs

## Testing
- `npm test` *(fails: MainLayoutComponent tests)*
- `npm test --prefix choir-app-backend`


------
https://chatgpt.com/codex/tasks/task_e_68c70d7cfe0083209d050083362921db