### PR TITLE
Add summary row for Participation month view

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -72,7 +72,20 @@
           </span>
         </ng-container>
       </mat-cell>
-      <mat-footer-cell *matFooterCellDef></mat-footer-cell>
+      <mat-footer-cell *matFooterCellDef>
+        <span class="summary-item">
+          <mat-icon class="status-icon available">check</mat-icon>{{ monthStatusCount(col, 'AVAILABLE') }}
+        </span>
+        <span class="summary-item">
+          <mat-icon class="status-icon maybe">check</mat-icon>{{ monthStatusCount(col, 'MAYBE') }}
+        </span>
+        <span class="summary-item">
+          <mat-icon class="status-icon unavailable">close</mat-icon>{{ monthStatusCount(col, 'UNAVAILABLE') }}
+        </span>
+        <span class="summary-item">
+          <mat-icon class="status-icon unknown">help</mat-icon>{{ monthStatusCount(col, 'UNKNOWN') }}
+        </span>
+      </mat-footer-cell>
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>

--- a/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
@@ -1,5 +1,6 @@
 import { ParticipationComponent } from './participation.component';
 import { UserInChoir } from '@core/models/user';
+import { Event } from '@core/models/event';
 import { BehaviorSubject } from 'rxjs';
 
 describe('ParticipationComponent', () => {
@@ -33,5 +34,28 @@ describe('ParticipationComponent', () => {
     expect(component.statusCount(key, 'MAYBE')).toBe(1);
     expect(component.statusCount(key, 'UNAVAILABLE')).toBe(1);
     expect(component.statusCount(key, 'UNKNOWN')).toBe(1);
+  });
+
+  it('monthStatusCount aggregates events', () => {
+    const component = new ParticipationComponent({} as any, { currentUser$: new BehaviorSubject<any>(null) } as any);
+    component.members = [
+      { id: 1, name: 'A', email: '', voice: 'SOPRAN' },
+      { id: 2, name: 'B', email: '', voice: 'ALT' }
+    ];
+    (component as any).availabilityMap = {
+      1: { '2024-01-01': 'AVAILABLE', '2024-01-02': 'UNAVAILABLE' },
+      2: { '2024-01-01': 'MAYBE', '2024-01-02': 'AVAILABLE' }
+    };
+    const col = {
+      key: '2024-01',
+      label: 'Jan 2024',
+      events: [
+        { date: '2024-01-01' } as Event,
+        { date: '2024-01-02' } as Event
+      ]
+    };
+    expect(component.monthStatusCount(col, 'AVAILABLE')).toBe(2);
+    expect(component.monthStatusCount(col, 'MAYBE')).toBe(1);
+    expect(component.monthStatusCount(col, 'UNAVAILABLE')).toBe(1);
   });
 });

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -145,6 +145,14 @@ export class ParticipationComponent implements OnInit {
     return count;
   }
 
+  monthStatusCount(col: MonthColumn, type: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE' | 'UNKNOWN'): number {
+    let total = 0;
+    for (const ev of col.events) {
+      total += this.statusCount(this.dateKey(ev.date), type);
+    }
+    return total;
+  }
+
   formatDate(date: string | Date): string {
     return parseDateOnly(date).toLocaleDateString('de-DE', {
       day: '2-digit',


### PR DESCRIPTION
## Summary
- show aggregated status counts in Participation month view footer
- add `monthStatusCount` helper for month-based summaries
- test month summary aggregation

## Testing
- `npm test` *(fails: libatk-1.0.so.0 cannot open shared object file)*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_68c712e9b3b48320ac61b938843c6f9c