### PR TITLE
Guard choir management role checks

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -42,6 +42,7 @@ exports.getMyChoirDetails = async (req, res, next) => {
 // Details des aktiven Chors aktualisieren
 exports.updateMyChoir = async (req, res, next) => {
     const { name, description, location, modules } = req.body;
+    const roles = Array.isArray(req.userRoles) ? req.userRoles : [];
 
     try {
         const choir = await db.choir.findByPk(req.activeChoirId);
@@ -50,7 +51,7 @@ exports.updateMyChoir = async (req, res, next) => {
             return res.status(404).send({ message: "Active choir not found." });
         }
 
-        if (!req.userRoles.includes('admin')) {
+        if (!roles.includes('admin')) {
             const association = await db.user_choir.findOne({
                 where: { userId: req.userId, choirId: req.activeChoirId }
             });
@@ -99,6 +100,7 @@ exports.getChoirMemberCount = async (req, res, next) => {
 
 // Alle Mitglieder (Direktoren) des aktiven Chors abrufen
 exports.getChoirMembers = async (req, res, next) => {
+    const roles = Array.isArray(req.userRoles) ? req.userRoles : [];
     try {
         await cleanupExpiredInvitations();
         const choir = await db.choir.findByPk(req.activeChoirId, {
@@ -134,7 +136,7 @@ exports.getChoirMembers = async (req, res, next) => {
                     registrationStatus: user.user_choir.registrationStatus
                 }
             };
-            if (req.userRoles.includes('admin') || user.shareWithChoir) {
+            if (roles.includes('admin') || user.shareWithChoir) {
                 return Object.assign(base, {
                     street: user.street,
                     postalCode: user.postalCode,


### PR DESCRIPTION
## Summary
- Avoid crashes when `req.userRoles` is missing by validating roles in choir management endpoints
- Use a sanitized roles array for admin checks in `updateMyChoir` and `getChoirMembers`

## Testing
- `npx --prefix choir-app-backend eslint choir-app-backend/src/controllers/choir-management.controller.js`
- `npm run lint --prefix choir-app-backend` *(fails: adoptedCollectionIds assigned value but never used, link assigned value but never used, etc.)*
- `node choir-app-backend/tests/choir-management.controller.test.js`
- `npm test --prefix choir-app-backend` *(terminated: process produced extensive SQL logs and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c713e9f6088320968c691d5045b639