### PR TITLE
feat: show singer borrowings without admin rights

### DIFF
--- a/choir-app-backend/src/controllers/choir-lending.controller.js
+++ b/choir-app-backend/src/controllers/choir-lending.controller.js
@@ -12,6 +12,16 @@ exports.list = async (req, res) => {
   res.status(200).send(copies);
 };
 
+// List copies borrowed by current user
+exports.listForUser = async (req, res) => {
+  const copies = await Lending.findAll({
+    where: { borrowerId: req.userId },
+    include: [{ model: db.collection, as: 'collection', attributes: ['id', 'title'] }],
+    order: [['copyNumber', 'ASC']]
+  });
+  res.status(200).send(copies);
+};
+
 // Initialize copies for a collection
 exports.init = async (req, res) => {
   const { id } = req.params;

--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -22,6 +22,7 @@ router.get("/logs", role.requireChoirAdmin, wrap(controller.getChoirLogs));
 router.get("/participation/pdf", role.requireChoirAdmin, wrap(controller.downloadParticipationPdf));
 // Sammlungen können von allen Mitgliedern eingesehen werden
 router.get("/collections", wrap(controller.getChoirCollections));
+router.get("/borrowings", wrap(lendingController.listForUser));
 router.delete("/collections/:id", role.requireChoirAdmin, wrap(controller.removeCollectionFromChoir));
 router.get("/collections/:id/copies", role.requireChoirAdmin, wrap(lendingController.list));
 router.post("/collections/:id/copies", role.requireChoirAdmin, role.requireNonDemo, wrap(lendingController.init));

--- a/choir-app-frontend/src/app/core/models/lending.ts
+++ b/choir-app-frontend/src/app/core/models/lending.ts
@@ -1,3 +1,5 @@
+import { Collection } from './collection';
+
 export interface Lending {
   id: number;
   copyNumber: number;
@@ -6,4 +8,6 @@ export interface Lending {
   status: 'available' | 'borrowed';
   borrowedAt?: string;
   returnedAt?: string;
+  collectionId?: number;
+  collection?: Collection;
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -607,6 +607,10 @@ export class ApiService {
     return this.choirLendingService.updateCopy(id, data);
   }
 
+  getMyBorrowings(): Observable<Lending[]> {
+    return this.choirLendingService.getMyBorrowings();
+  }
+
   getMyChoirDetails(options?: { choirId?: number }): Observable<Choir> {
     return this.choirService.getMyChoirDetails(options?.choirId);
   }

--- a/choir-app-frontend/src/app/core/services/choir-lending.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir-lending.service.ts
@@ -21,4 +21,8 @@ export class ChoirLendingService {
   updateCopy(id: number, data: Partial<Lending>): Observable<Lending> {
     return this.http.put<Lending>(`${environment.apiUrl}/choir-management/collections/copies/${id}`, data);
   }
+
+  getMyBorrowings(): Observable<Lending[]> {
+    return this.http.get<Lending[]>(`${environment.apiUrl}/choir-management/borrowings`);
+  }
 }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -237,23 +237,27 @@
           <ng-container matColumnDef="actions">
             <mat-header-cell *matHeaderCellDef></mat-header-cell>
             <mat-cell *matCellDef="let col" class="actions-cell">
-              <mat-icon
-                *ngIf="collectionCopyIds.has(col.id)"
-                class="library-icon"
-                matTooltip="Exemplare vorhanden">
-                library_music
-              </mat-icon>
-              <button
-                *ngIf="(isChoirAdmin || isAdmin)"
-                mat-icon-button
-                (click)="manageCopies(col, $event)"
-                [disabled]="!libraryItemsLoaded"
-                matTooltip="Exemplare verwalten">
-                <mat-icon>list</mat-icon>
-              </button>
-              <button *ngIf="isChoirAdmin" mat-icon-button color="warn" (click)="removeCollection(col)" matTooltip="Sammlung entfernen">
-                <mat-icon>delete</mat-icon>
-              </button>
+              <ng-container *ngIf="isChoirAdmin || isAdmin; else singerBorrowing">
+                <mat-icon
+                  *ngIf="collectionCopyIds.has(col.id)"
+                  class="library-icon"
+                  matTooltip="Exemplare vorhanden">
+                  library_music
+                </mat-icon>
+                <button
+                  mat-icon-button
+                  (click)="manageCopies(col, $event)"
+                  [disabled]="!libraryItemsLoaded"
+                  matTooltip="Exemplare verwalten">
+                  <mat-icon>list</mat-icon>
+                </button>
+                <button *ngIf="isChoirAdmin" mat-icon-button color="warn" (click)="removeCollection(col)" matTooltip="Sammlung entfernen">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </ng-container>
+              <ng-template #singerBorrowing>
+                <span *ngIf="borrowedCopies.has(col.id)">Nr. {{ borrowedCopies.get(col.id) }}</span>
+              </ng-template>
             </mat-cell>
           </ng-container>
           <mat-header-row *matHeaderRowDef="displayedCollectionColumns"></mat-header-row>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -89,6 +89,7 @@ export class ManageChoirComponent implements OnInit {
   libraryItemIds = new Set<number>();
   private libraryItemsByCollection = new Map<number, LibraryItem>();
   libraryItemsLoaded = false;
+  borrowedCopies = new Map<number, number>();
 
 
   displayedLogColumns: string[] = ['timestamp', 'user', 'action'];
@@ -175,14 +176,25 @@ export class ManageChoirComponent implements OnInit {
         this.logDataSource.data = pageData.logs;
 
         this.collectionCopyIds.clear();
-        pageData.collections.forEach((col: Collection) => {
-          this.apiService.getCollectionCopies(col.id).subscribe(copies => {
-            if (copies.length > 0) {
-              this.collectionCopyIds.add(col.id);
-            }
+        if (this.isChoirAdmin || this.isAdmin) {
+          pageData.collections.forEach((col: Collection) => {
+            this.apiService.getCollectionCopies(col.id).subscribe(copies => {
+              if (copies.length > 0) {
+                this.collectionCopyIds.add(col.id);
+              }
+            });
+            this.libraryItemsLoaded = true;
           });
-          this.libraryItemsLoaded = true;
-        });
+        } else {
+          this.apiService.getMyBorrowings().subscribe(borrowings => {
+            borrowings.forEach(b => {
+              if (b.collectionId) {
+                this.borrowedCopies.set(b.collectionId, b.copyNumber);
+              }
+            });
+            this.libraryItemsLoaded = true;
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- allow singers to fetch their own borrowings via `/api/choir-management/borrowings`
- expose borrowings in frontend without accessing admin-only copy data
- extend lending model with collection info for borrower view

## Testing
- `npm test --prefix choir-app-backend`
- `npm test --prefix choir-app-frontend` *(fails: hangs due to missing browser)*

------
https://chatgpt.com/codex/tasks/task_e_68c71d5043a483208d3462fcc07676d6