### PR TITLE
Restore lending list printing in collection dialog

### DIFF
--- a/choir-app-backend/src/controllers/lending.controller.js
+++ b/choir-app-backend/src/controllers/lending.controller.js
@@ -57,7 +57,18 @@ exports.downloadPdf = async (req, res) => {
       }
     }
   }
-  const copies = await Lending.findAll({ where: { libraryItemId: item.id }, order: [['copyNumber', 'ASC']] });
+  const rawCopies = await Lending.findAll({
+    where: { libraryItemId: item.id },
+    include: [{ model: db.user, as: 'borrower', attributes: ['name'] }],
+    order: [['copyNumber', 'ASC']]
+  });
+
+  const copies = rawCopies.map(c => ({
+    copyNumber: c.copyNumber,
+    borrowerName: c.borrowerName || (c.borrower ? c.borrower.name : ''),
+    borrowedAt: c.borrowedAt,
+    returnedAt: c.returnedAt
+  }));
 
   const pdf = lendingListPdf(item.collection ? item.collection.title : 'Ausleihe', copies);
   res.setHeader('Content-Type', 'application/pdf');

--- a/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.html
@@ -56,6 +56,7 @@
   </mat-autocomplete>
 </div>
 <div mat-dialog-actions>
+  <button mat-button (click)="print()">Ausleihliste drucken</button>
   <span class="spacer"></span>
   <button mat-button (click)="close()">Schließen</button>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.ts
@@ -71,6 +71,17 @@ export class CollectionCopiesDialogComponent implements OnInit {
     });
   }
 
+  print(): void {
+    this.api.downloadLibraryCopiesPdf(this.data.collectionId).subscribe(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'ausleihliste.pdf';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    });
+  }
+
   close(): void {
     this.dialogRef.close();
   }


### PR DESCRIPTION
## Summary
- add print button to collection copies dialog
- expose `print()` method to download PDF
- include borrower info when generating lending list PDF

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run test:backend`


------
https://chatgpt.com/codex/tasks/task_e_68c72025dd408320ae44725e8e9ada68