### PR TITLE
feat: allow adjusting copy count for choir loans

### DIFF
--- a/choir-app-backend/src/controllers/choir-lending.controller.js
+++ b/choir-app-backend/src/controllers/choir-lending.controller.js
@@ -1,5 +1,6 @@
 const db = require('../models');
 const Lending = db.lending;
+const { Op } = require('sequelize');
 
 // List copies for a choir collection
 exports.list = async (req, res) => {
@@ -41,6 +42,32 @@ exports.init = async (req, res) => {
     order: [['copyNumber', 'ASC']]
   });
   res.status(201).send(result);
+};
+
+// Adjust number of copies for a collection
+exports.setCount = async (req, res) => {
+  const { id } = req.params;
+  const { copies } = req.body;
+  if (copies === undefined || copies < 1) {
+    return res.status(400).send({ message: 'copies must be >= 1' });
+  }
+  const existing = await Lending.count({ where: { collectionId: id } });
+  if (copies > existing) {
+    for (let i = existing + 1; i <= copies; i++) {
+      await Lending.create({ collectionId: id, copyNumber: i });
+    }
+  } else if (copies < existing) {
+    const borrowed = await Lending.count({ where: { collectionId: id, status: 'borrowed' } });
+    if (borrowed > 0) {
+      return res.status(400).send({ message: 'Cannot reduce copies while borrowed copies exist.' });
+    }
+    await Lending.destroy({ where: { collectionId: id, copyNumber: { [Op.gt]: copies } } });
+  }
+  const result = await Lending.findAll({
+    where: { collectionId: id },
+    order: [['copyNumber', 'ASC']]
+  });
+  res.status(200).send(result);
 };
 
 // Update borrower of a copy

--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -26,6 +26,7 @@ router.get("/borrowings", wrap(lendingController.listForUser));
 router.delete("/collections/:id", role.requireChoirAdmin, wrap(controller.removeCollectionFromChoir));
 router.get("/collections/:id/copies", role.requireChoirAdmin, wrap(lendingController.list));
 router.post("/collections/:id/copies", role.requireChoirAdmin, role.requireNonDemo, wrap(lendingController.init));
+router.put("/collections/:id/copies", role.requireChoirAdmin, role.requireNonDemo, wrap(lendingController.setCount));
 router.put("/collections/copies/:id", role.requireChoirAdmin, role.requireNonDemo, wrap(lendingController.update));
 
 module.exports = router;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -607,6 +607,10 @@ export class ApiService {
     return this.choirLendingService.initCopies(id, copies);
   }
 
+  setCollectionCopies(id: number, copies: number): Observable<Lending[]> {
+    return this.choirLendingService.setCopies(id, copies);
+  }
+
   updateCollectionCopy(id: number, data: Partial<Lending>): Observable<Lending> {
     return this.choirLendingService.updateCopy(id, data);
   }

--- a/choir-app-frontend/src/app/core/services/choir-lending.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir-lending.service.ts
@@ -18,6 +18,10 @@ export class ChoirLendingService {
     return this.http.post<Lending[]>(`${this.baseUrl}/${collectionId}/copies`, { copies });
   }
 
+  setCopies(collectionId: number, copies: number): Observable<Lending[]> {
+    return this.http.put<Lending[]>(`${this.baseUrl}/${collectionId}/copies`, { copies });
+  }
+
   updateCopy(id: number, data: Partial<Lending>): Observable<Lending> {
     return this.http.put<Lending>(`${environment.apiUrl}/choir-management/collections/copies/${id}`, data);
   }

--- a/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.html
+++ b/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.html
@@ -56,6 +56,7 @@
   </mat-autocomplete>
 </div>
 <div mat-dialog-actions>
+  <button mat-button color="primary" (click)="adjustCopies()">Exemplare anpassen</button>
   <span class="spacer"></span>
   <button mat-button (click)="close()">Schließen</button>
 </div>

--- a/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-copies-dialog.component.ts
@@ -71,6 +71,27 @@ export class CollectionCopiesDialogComponent implements OnInit {
     });
   }
 
+  adjustCopies(): void {
+    const copiesStr = prompt('Neue Anzahl der Exemplare eingeben:');
+    const copies = copiesStr ? parseInt(copiesStr, 10) : NaN;
+    if (isNaN(copies) || copies < 1) {
+      return;
+    }
+    if (copies < this.copies.length && this.copies.some(c => c.status === 'borrowed')) {
+      this.snack.open('Reduzierung nicht möglich: Ausleihen vorhanden.', undefined, { duration: 3000 });
+      return;
+    }
+    this.api.setCollectionCopies(this.data.collectionId, copies).subscribe({
+      next: () => {
+        this.snack.open('Gespeichert', undefined, { duration: 2000 });
+        this.load();
+      },
+      error: err => {
+        this.snack.open(err.error?.message || 'Fehler beim Speichern', undefined, { duration: 3000 });
+      }
+    });
+  }
+
   close(): void {
     this.dialogRef.close();
   }


### PR DESCRIPTION
## Summary
- add backend endpoint to set collection copy count and prevent reductions when items are borrowed
- expose copy-count update in API and dialog with button to adjust number of copies

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*
- `npm run lint` *(fails: many lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c7209ef07083209a98a073d69e567a