### PR TITLE
Avoid double counting in participation month totals

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
@@ -58,4 +58,26 @@ describe('ParticipationComponent', () => {
     expect(component.monthStatusCount(col, 'MAYBE')).toBe(1);
     expect(component.monthStatusCount(col, 'UNAVAILABLE')).toBe(1);
   });
+
+  it('monthStatusCount counts unique dates only once', () => {
+    const component = new ParticipationComponent({} as any, { currentUser$: new BehaviorSubject<any>(null) } as any);
+    component.members = [
+      { id: 1, name: 'A', email: '', voice: 'SOPRAN' },
+      { id: 2, name: 'B', email: '', voice: 'ALT' }
+    ];
+    (component as any).availabilityMap = {
+      1: { '2024-01-01': 'AVAILABLE' },
+      2: { '2024-01-01': 'MAYBE' }
+    };
+    const col = {
+      key: '2024-01',
+      label: 'Jan 2024',
+      events: [
+        { date: '2024-01-01' } as Event,
+        { date: '2024-01-01' } as Event
+      ]
+    };
+    expect(component.monthStatusCount(col, 'AVAILABLE')).toBe(1);
+    expect(component.monthStatusCount(col, 'MAYBE')).toBe(1);
+  });
 });

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -146,9 +146,10 @@ export class ParticipationComponent implements OnInit {
   }
 
   monthStatusCount(col: MonthColumn, type: 'AVAILABLE' | 'MAYBE' | 'UNAVAILABLE' | 'UNKNOWN'): number {
+    const uniqueDates = new Set(col.events.map(ev => this.dateKey(ev.date)));
     let total = 0;
-    for (const ev of col.events) {
-      total += this.statusCount(this.dateKey(ev.date), type);
+    for (const dateKey of uniqueDates) {
+      total += this.statusCount(dateKey, type);
     }
     return total;
   }


### PR DESCRIPTION
## Summary
- count each event date only once when aggregating monthly participation
- add regression test verifying unique date handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72129a0548320abd6bafeed68dcdc