### PR TITLE
Add congregation management and seeds

### DIFF
--- a/choir-app-backend/src/app.js
+++ b/choir-app-backend/src/app.js
@@ -86,7 +86,7 @@ const postRoutes = require("./routes/post.routes");
 const libraryRoutes = require("./routes/library.routes");
 const programRoutes = require("./routes/program.routes");
 const districtRoutes = require("./routes/district.routes");
-
+const congregationRoutes = require("./routes/congregation.routes");
 app.use("/api/auth", authRoutes);
 app.use("/api/pieces", pieceRoutes);
 app.use("/api/events", eventRoutes);
@@ -118,7 +118,7 @@ app.use("/api/posts", postRoutes);
 app.use("/api/library", libraryRoutes);
 app.use("/api/programs", programRoutes);
 app.use("/api/districts", districtRoutes);
-
+app.use("/api/congregations", congregationRoutes);
 // Handle 404 for unknown routes
 app.use((req, res, _next) => {
     logger.warn(`404 - Not Found - ${req.originalUrl} - ${req.method} - ${req.ip}`);

--- a/choir-app-backend/src/controllers/congregation.controller.js
+++ b/choir-app-backend/src/controllers/congregation.controller.js
@@ -1,0 +1,38 @@
+const db = require("../models");
+const asyncHandler = require("express-async-handler");
+
+exports.findAll = asyncHandler(async (req, res) => {
+  const congregations = await db.congregation.findAll({
+    order: [['name', 'ASC']],
+  });
+  res.status(200).send(congregations);
+});
+
+exports.create = asyncHandler(async (req, res) => {
+  const { name, districtId } = req.body;
+  const congregation = await db.congregation.create({ name, districtId });
+  res.status(201).send(congregation);
+});
+
+exports.update = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { name, districtId } = req.body;
+  const congregation = await db.congregation.findByPk(id);
+  if (!congregation) {
+    return res.status(404).send({ message: 'Gemeinde nicht gefunden' });
+  }
+  congregation.name = name;
+  congregation.districtId = districtId;
+  await congregation.save();
+  res.status(200).send(congregation);
+});
+
+exports.remove = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const congregation = await db.congregation.findByPk(id);
+  if (!congregation) {
+    return res.status(404).send({ message: 'Gemeinde nicht gefunden' });
+  }
+  await congregation.destroy();
+  res.status(204).send();
+});

--- a/choir-app-backend/src/models/congregation.model.js
+++ b/choir-app-backend/src/models/congregation.model.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const Congregation = sequelize.define('congregation', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    districtId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  });
+  return Congregation;
+};

--- a/choir-app-backend/src/models/index.js
+++ b/choir-app-backend/src/models/index.js
@@ -50,6 +50,7 @@ db.program = require("./program.model.js")(sequelize, Sequelize);
 db.program_element = require("./program_element.model.js")(sequelize, Sequelize);
 db.program_item = require("./program_item.model.js")(sequelize, Sequelize);
 db.district = require("./district.model.js")(sequelize, Sequelize);
+ db.congregation = require("./congregation.model.js")(sequelize, Sequelize);
 db.donation = require("./donation.model.js")(sequelize, Sequelize);
 db.choir_log = require("./choir_log.model.js")(sequelize, Sequelize);
 
@@ -209,4 +210,8 @@ db.user.hasMany(db.choir_log, { as: 'choirLogs' });
 db.choir_log.belongsTo(db.user, { foreignKey: 'userId', as: 'user' });
 
 
+// Districts and congregations
+ db.district.hasMany(db.congregation, { as: "congregations" });
+ db.congregation.belongsTo(db.district, { foreignKey: "districtId", as: "district" });
 module.exports = db;
+

--- a/choir-app-backend/src/routes/congregation.routes.js
+++ b/choir-app-backend/src/routes/congregation.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const controller = require('../controllers/congregation.controller');
+
+router.get('/', controller.findAll);
+router.post('/', controller.create);
+router.put('/:id', controller.update);
+router.delete('/:id', controller.remove);
+
+module.exports = router;

--- a/choir-app-backend/src/routes/congregation.routes.js
+++ b/choir-app-backend/src/routes/congregation.routes.js
@@ -1,9 +1,14 @@
-const router = require('express').Router();
-const controller = require('../controllers/congregation.controller');
+const router = require("express").Router();
+const authJwt = require("../middleware/auth.middleware");
+const role = require("../middleware/role.middleware");
+const controller = require("../controllers/congregation.controller");
+const { handler: wrap } = require("../utils/async");
 
-router.get('/', controller.findAll);
-router.post('/', controller.create);
-router.put('/:id', controller.update);
-router.delete('/:id', controller.remove);
+router.use(authJwt.verifyToken);
+
+router.get("/", wrap(controller.findAll));
+router.post("/", role.requireAdmin, wrap(controller.create));
+router.put("/:id", role.requireAdmin, wrap(controller.update));
+router.delete("/:id", role.requireAdmin, wrap(controller.remove));
 
 module.exports = router;

--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -101,22 +101,25 @@ async function seedDatabase(options = {}) {
                 defaults: { value: process.env.SYSTEM_ADMIN_EMAIL || '' }
             });
             const districts = [
-                { name: 'Braunschweig', code: 'BS' },
-                { name: 'Göttingen', code: 'GÖ' },
-                { name: 'Hannover-Nordost', code: 'H-NO' },
-                { name: 'Hannover-Südwest', code: 'H-SW' },
-                { name: 'Hildesheim', code: 'HI' },
-                { name: 'Lübeck-Schwerin', code: 'L-S' },
-                { name: 'Lüneburg', code: 'LG' },
-                { name: 'Magdeburg', code: 'MD' },
-                { name: 'Wolfenbüttel', code: 'WF' }
+                { name: 'Braunschweig', code: 'BS', congregations: ['Braunschweig','Peine','Salzgitter'] },
+                { name: 'Göttingen', code: 'GÖ', congregations: ['Göttingen','Northeim','Einbeck'] },
+                { name: 'Hannover-Nordost', code: 'H-NO', congregations: ['Hannover-Mitte','Celle','Lehrte'] },
+                { name: 'Hannover-Südwest', code: 'H-SW', congregations: ['Hannover-Süd','Hameln','Stadthagen'] },
+                { name: 'Hildesheim', code: 'HI', congregations: ['Hildesheim','Alfeld','Sarstedt'] },
+                { name: 'Lübeck-Schwerin', code: 'L-S', congregations: ['Lübeck','Schwerin','Wismar'] },
+                { name: 'Lüneburg', code: 'LG', congregations: ['Lüneburg','Uelzen','Soltau'] },
+                { name: 'Magdeburg', code: 'MD', congregations: ['Magdeburg','Dessau','Halberstadt'] },
+                { name: 'Wolfenbüttel', code: 'WF', congregations: ['Wolfenbüttel','Helmstedt','Goslar'] }
             ];
             for (const d of districts) {
-                const [district, created] = await db.district.findOrCreate({ where: { name: d.name }, defaults: d });
+                const [district, created] = await db.district.findOrCreate({ where: { name: d.name }, defaults: { name: d.name, code: d.code } });
                 // Backfill missing codes for existing districts
                 if (!created && !district.code) {
                     district.code = d.code;
                     await district.save();
+                }
+                for (const cName of d.congregations || []) {
+                    await db.congregation.findOrCreate({ where: { name: cName }, defaults: { name: cName, districtId: district.id } });
                 }
             }
             logger.info("Initial seeding completed successfully.");

--- a/choir-app-frontend/src/app/core/models/congregation.ts
+++ b/choir-app-frontend/src/app/core/models/congregation.ts
@@ -1,0 +1,5 @@
+export interface Congregation {
+  id: number;
+  name: string;
+  districtId: number;
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -59,6 +59,8 @@ import { ChoirLendingService } from './choir-lending.service';
 import { ProgramService } from './program.service';
 import { District } from '../models/district';
 import { DistrictService } from './district.service';
+import { Congregation } from '../models/congregation';
+import { CongregationService } from './congregation.service';
 
 @Injectable({
   providedIn: 'root'
@@ -88,7 +90,8 @@ export class ApiService {
               private choirLendingService: ChoirLendingService,
               private libraryService: LibraryService,
               private programService: ProgramService,
-              private districtService: DistrictService) {
+              private districtService: DistrictService,
+              private congregationService: CongregationService) {
 
   }
 
@@ -192,6 +195,24 @@ export class ApiService {
 
   deleteDistrict(id: number): Observable<any> {
     return this.districtService.deleteDistrict(id);
+  }
+
+  // --- Congregations ---
+
+  getCongregations(): Observable<Congregation[]> {
+    return this.congregationService.getCongregations();
+  }
+
+  createCongregation(name: string, districtId: number): Observable<Congregation> {
+    return this.congregationService.createCongregation({ name, districtId });
+  }
+
+  updateCongregation(id: number, name: string, districtId: number): Observable<Congregation> {
+    return this.congregationService.updateCongregation(id, { name, districtId });
+  }
+
+  deleteCongregation(id: number): Observable<any> {
+    return this.congregationService.deleteCongregation(id);
   }
 
   // --- Global Piece Methods ---

--- a/choir-app-frontend/src/app/core/services/congregation.service.ts
+++ b/choir-app-frontend/src/app/core/services/congregation.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CreatorService } from './creator.service';
+import { Congregation } from '../models/congregation';
+
+@Injectable({ providedIn: 'root' })
+export class CongregationService extends CreatorService<Congregation> {
+  constructor(http: HttpClient) { super(http, 'congregations'); }
+
+  getCongregations(): Observable<Congregation[]> { return this.getAll(); }
+  createCongregation(data: { name: string; districtId: number }): Observable<Congregation> { return this.create(data); }
+  updateCongregation(id: number, data: { name: string; districtId: number }): Observable<Congregation> { return this.update(id, data); }
+  deleteCongregation(id: number): Observable<any> { return this.delete(id); }
+}

--- a/choir-app-frontend/src/app/features/admin/admin.routes.ts
+++ b/choir-app-frontend/src/app/features/admin/admin.routes.ts
@@ -19,6 +19,7 @@ export const adminRoutes: Routes = [
       { path: 'choirs', loadComponent: () => import('./manage-choirs/manage-choirs.component').then(m => m.ManageChoirsComponent), data: { title: 'Admin – Chöre' } },
       { path: 'users', loadComponent: () => import('./manage-users/manage-users.component').then(m => m.ManageUsersComponent), data: { title: 'Admin – Benutzer' } },
       { path: 'districts', loadComponent: () => import('./manage-districts/manage-districts.component').then(m => m.ManageDistrictsComponent), data: { title: 'Admin – Bezirke' } },
+      { path: 'congregations', loadComponent: () => import('./manage-congregations/manage-congregations.component').then(m => m.ManageCongregationsComponent), data: { title: 'Admin – Gemeinden' } },
       { path: 'piece-changes', loadComponent: () => import('./manage-piece-changes/manage-piece-changes.component').then(m => m.ManagePieceChangesComponent), data: { title: 'Admin – Änderungen' } },
       { path: 'protocols', loadComponent: () => import('./protocols/protocols.component').then(m => m.ProtocolsComponent), data: { title: 'Admin – Protokolle' } },
       { path: 'donations', loadComponent: () => import('./donations/donations.component').then(m => m.DonationsComponent), data: { title: 'Admin – Spenden' } },

--- a/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.html
@@ -1,0 +1,36 @@
+<h2>Gemeinden verwalten</h2>
+
+<form [formGroup]="form" (ngSubmit)="save()" class="add-form">
+  <mat-form-field appearance="outline">
+    <mat-label>Gemeinde</mat-label>
+    <input matInput formControlName="name">
+  </mat-form-field>
+  <mat-form-field appearance="outline">
+    <mat-label>Bezirk</mat-label>
+    <mat-select formControlName="districtId">
+      <mat-option *ngFor="let d of districts" [value]="d.id">{{ d.name }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+  <button mat-flat-button color="primary" type="submit">{{ editing ? 'Speichern' : 'Hinzufügen' }}</button>
+  <button *ngIf="editing" mat-button type="button" (click)="cancel()">Abbrechen</button>
+</form>
+
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef>Gemeinde</th>
+    <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+  </ng-container>
+  <ng-container matColumnDef="district">
+    <th mat-header-cell *matHeaderCellDef>Bezirk</th>
+    <td mat-cell *matCellDef="let c">{{ districtName(c.districtId) }}</td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef>Aktionen</th>
+    <td mat-cell *matCellDef="let c">
+      <button mat-icon-button (click)="edit(c)"><mat-icon>edit</mat-icon></button>
+      <button mat-icon-button color="warn" (click)="delete(c)"><mat-icon>delete</mat-icon></button>
+    </td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+</table>

--- a/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.scss
+++ b/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.scss
@@ -1,0 +1,5 @@
+.add-form {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}

--- a/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.spec.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ManageCongregationsComponent } from './manage-congregations.component';
+import { of } from 'rxjs';
+import { ApiService } from '@core/services/api.service';
+
+class MockApiService {
+  getCongregations() { return of([]); }
+  createCongregation() { return of({}); }
+  updateCongregation() { return of({}); }
+  deleteCongregation() { return of({}); }
+  getDistricts() { return of([]); }
+}
+
+describe('ManageCongregationsComponent', () => {
+  let component: ManageCongregationsComponent;
+  let fixture: ComponentFixture<ManageCongregationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ManageCongregationsComponent],
+      providers: [{ provide: ApiService, useClass: MockApiService }]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ManageCongregationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-congregations/manage-congregations.component.ts
@@ -1,0 +1,83 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MaterialModule } from '@modules/material.module';
+import { ApiService } from '@core/services/api.service';
+import { Congregation } from '@core/models/congregation';
+import { District } from '@core/models/district';
+import { MatTableDataSource } from '@angular/material/table';
+import { Subject, takeUntil } from 'rxjs';
+
+@Component({
+  selector: 'app-manage-congregations',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialModule],
+  templateUrl: './manage-congregations.component.html',
+  styleUrls: ['./manage-congregations.component.scss']
+})
+export class ManageCongregationsComponent implements OnInit, OnDestroy {
+  displayedColumns = ['name', 'district', 'actions'];
+  dataSource = new MatTableDataSource<Congregation>([]);
+  form: FormGroup;
+  editing: Congregation | null = null;
+  districts: District[] = [];
+  private destroy$ = new Subject<void>();
+
+  constructor(private api: ApiService, private fb: FormBuilder) {
+    this.form = this.fb.group({ name: [''], districtId: [null] });
+  }
+
+  ngOnInit(): void {
+    this.load();
+    this.api.getDistricts().subscribe(ds => this.districts = ds);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  load(): void {
+    this.api.getCongregations().pipe(takeUntil(this.destroy$)).subscribe(cs => {
+      this.dataSource.data = cs;
+    });
+  }
+
+  save(): void {
+    const name = this.form.value.name?.trim();
+    const districtId = this.form.value.districtId;
+    if (!name || !districtId) { return; }
+    if (this.editing) {
+      this.api.updateCongregation(this.editing.id, name, districtId).pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.editing = null;
+        this.form.reset();
+        this.load();
+      });
+    } else {
+      this.api.createCongregation(name, districtId).pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.form.reset();
+        this.load();
+      });
+    }
+  }
+
+  edit(c: Congregation): void {
+    this.editing = c;
+    this.form.setValue({ name: c.name, districtId: c.districtId });
+  }
+
+  cancel(): void {
+    this.editing = null;
+    this.form.reset();
+  }
+
+  delete(c: Congregation): void {
+    if (confirm(`Gemeinde "${c.name}" löschen?`)) {
+      this.api.deleteCongregation(c.id).pipe(takeUntil(this.destroy$)).subscribe(() => this.load());
+    }
+  }
+
+  districtName(id: number): string {
+    return this.districts.find(d => d.id === id)?.name || '';
+  }
+}

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -36,7 +36,10 @@
     </mat-form-field>
     <mat-form-field appearance="outline">
       <mat-label>Gemeinde</mat-label>
-      <input matInput formControlName="congregation">
+      <mat-select formControlName="congregation">
+        <mat-option value="">-</mat-option>
+        <mat-option *ngFor="let c of congregations" [value]="c.name">{{ c.name }}</mat-option>
+      </mat-select>
     </mat-form-field>
     <mat-form-field appearance="outline">
       <mat-label>Stimmlage</mat-label>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -6,6 +6,7 @@ import { MaterialModule } from '@modules/material.module';
 import { User } from 'src/app/core/models/user';
 import { ApiService } from '@core/services/api.service';
 import { District } from '@core/models/district';
+import { Congregation } from '@core/models/congregation';
 
 @Component({
   selector: 'app-user-dialog',

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -18,6 +18,7 @@ export class UserDialogComponent implements OnInit {
   form: FormGroup;
   title = 'Benutzer hinzufügen';
   districts: District[] = [];
+  congregations: Congregation[] = [];
 
   constructor(
     private fb: FormBuilder,
@@ -44,6 +45,7 @@ export class UserDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.api.getDistricts().subscribe(ds => this.districts = ds);
+    this.api.getCongregations().subscribe(cs => this.congregations = cs);
   }
 
   onCancel(): void {

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -59,7 +59,10 @@
 
           <mat-form-field appearance="outline">
             <mat-label>Gemeinde</mat-label>
-            <input matInput formControlName="congregation">
+            <mat-select formControlName="congregation">
+              <mat-option value="">-</mat-option>
+              <mat-option *ngFor="let c of congregations" [value]="c.name">{{ c.name }}</mat-option>
+            </mat-select>
           </mat-form-field>
 
           <mat-form-field appearance="outline">

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -10,6 +10,7 @@ import { Choir } from '@core/models/choir';
 import { Observable } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
 import { District } from '@core/models/district';
+import { Congregation } from '@core/models/congregation';
 
 export function passwordsMatchValidator(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -36,6 +36,7 @@ export class ProfileComponent implements OnInit {
   isLoading = true;
   availableChoirs$: Observable<Choir[]>;
   districts: District[] = [];
+  congregations: Congregation[] = [];
 
   constructor(
     private fb: FormBuilder,
@@ -66,6 +67,7 @@ export class ProfileComponent implements OnInit {
 
   ngOnInit(): void {
     this.apiService.getDistricts().subscribe(ds => this.districts = ds);
+    this.apiService.getCongregations().subscribe(cs => this.congregations = cs);
     this.apiService.getCurrentUser().subscribe({
       next: (user) => {
         this.currentUser = user;


### PR DESCRIPTION
## Summary
- introduce `congregation` model with CRUD API and seed data
- expose congregation management in admin UI and suggestion lists in user forms

## Testing
- `npm run lint --prefix choir-app-backend` *(fails: no-unused-vars and other lint errors)*
- `npm test` *(terminated during Angular build)*
- `npm run test:backend` *(produced DB queries but no summary before exit)*

------
https://chatgpt.com/codex/tasks/task_e_68c726d8bd44832090d8318dbd3d3e80