### PR TITLE
Verify backend restart in deploy scripts

### DIFF
--- a/deploy-server.sh
+++ b/deploy-server.sh
@@ -12,7 +12,16 @@ npm --prefix choir-app-backend run check
 # Install backend dependencies and restart process manager
 npm --prefix choir-app-backend install >/dev/null 2>&1 || true
 
+LOG_FILE="choir-app-backend/logs/exceptions.log"
+
 echo "Restarting backend..."
 pm2 restart chorleiter-api || true
+
+echo "Checking backend status..."
+if ! pm2 describe chorleiter-api | grep -qi 'status.*online' >/dev/null 2>&1; then
+    echo "Backend failed to start. Recent log output:"
+    tail -n 20 "$LOG_FILE" 2>/dev/null || echo "No exceptions log found"
+    exit 1
+fi
 
 echo "Deployment completed."

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -158,6 +158,16 @@ Invoke-Ssh "cd '$BackendDest' && npm install"
 # Restart backend
 Invoke-Ssh "pm2 restart chorleiter-api"
 
+# Verify backend started
+$pm2Status = Invoke-Ssh "pm2 describe chorleiter-api | grep -i status" 2>$null
+if ($pm2Status -notmatch 'online') {
+    Write-Host "Backend failed to start. Recent log output:" -ForegroundColor Red
+    Invoke-Ssh "tail -n 20 '$BackendDest/logs/exceptions.log' 2>/dev/null || echo 'No exceptions log found'"
+    Remove-Item $BackendArchive
+    Remove-Item $FrontendArchive
+    exit 1
+}
+
 Remove-Item $BackendArchive
 Remove-Item $FrontendArchive
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -124,6 +124,15 @@ ssh_cmd "$REMOTE" "cd \"$BACKEND_DEST\" && npm install"
 # Restart backend
 ssh_cmd "$REMOTE" "pm2 restart chorleiter-api"
 
+# Verify backend started
+if ! ssh_cmd "$REMOTE" "pm2 describe chorleiter-api | grep -qi 'status.*online'" >/dev/null 2>&1; then
+    echo "Backend failed to start. Recent log output:"
+    ssh_cmd "$REMOTE" "tail -n 20 '$BACKEND_DEST/logs/exceptions.log' 2>/dev/null || echo 'No exceptions log found'"
+    # Remove local archives before exiting
+    rm -f "$BACKEND_ARCHIVE" "$FRONTEND_ARCHIVE"
+    exit 1
+fi
+
 # Remove local archives
 rm -f "$BACKEND_ARCHIVE" "$FRONTEND_ARCHIVE"
 


### PR DESCRIPTION
## Summary
- Ensure remote deploy script checks pm2 status and prints recent exception logs if the backend fails to start
- Add backend status verification with log tailing for the local deploy helper
- Mirror the restart verification in the PowerShell deploy script

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_68c7cf2f7380832097b9c17287e70fe5