### PR TITLE
Fix syntax error in seed script

### DIFF
--- a/choir-app-backend/src/seed.js
+++ b/choir-app-backend/src/seed.js
@@ -125,6 +125,7 @@ async function seedDatabase(options = {}) {
             logger.info("Initial seeding completed successfully.");
         } else {
             logger.info("Database already seeded. Skipping initial setup.");
+        }
     } catch (error) {
         logger.error("Error during initial seeding:", error);
     }


### PR DESCRIPTION
## Summary
- add missing closing brace in `seed.js` try block to allow server initialization

## Testing
- `cd choir-app-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7cedc2f048320a36e6229195e242d