### PR TITLE
Include current day in date filters

### DIFF
--- a/choir-app-backend/src/controllers/choir-management.controller.js
+++ b/choir-app-backend/src/controllers/choir-management.controller.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const emailService = require('../services/email.service');
 const { Op } = require('sequelize');
 const { participationPdf } = require('../services/pdf.service');
+const { parseDateOnly } = require('../utils/date.utils');
 
 async function cleanupExpiredInvitations() {
     const expired = await db.user_choir.findAll({
@@ -394,7 +395,8 @@ exports.downloadParticipationPdf = async (req, res, next) => {
                 eventWhere.date[Op.lte] = new Date(endDate);
             }
         } else {
-            eventWhere.date = { [Op.gte]: new Date() };
+            const today = parseDateOnly(new Date());
+            eventWhere.date = { [Op.gte]: today };
         }
         const events = await db.event.findAll({
             where: eventWhere,

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -59,8 +59,8 @@ export class ParticipationComponent implements OnInit {
     this.api.getEvents(undefined, false, this.startDate, this.endDate).subscribe(events => {
       let filtered = events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
       if (!this.startDate && !this.endDate) {
-        const now = new Date();
-        filtered = filtered.filter(e => new Date(e.date) >= now);
+        const today = parseDateOnly(new Date());
+        filtered = filtered.filter(e => parseDateOnly(e.date) >= today);
       }
 
       if (filtered.length <= 5) {


### PR DESCRIPTION
## Summary
- Ensure participation view includes events from the current day
- Default choir management event queries to start of today

## Testing
- `npm test` *(fails: error loading shared libraries: libcups.so.2)*
- `npm run test:backend` *(terminated: excessive output)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e2dbf04483209de078e25759c277