### PR TITLE
feat: show participation per date

### DIFF
--- a/choir-app-frontend/src/app/features/participation/participation.component.html
+++ b/choir-app-frontend/src/app/features/participation/participation.component.html
@@ -28,69 +28,98 @@
 <div class="table-container mat-elevation-z4" *ngIf="members.length > 0">
   <mat-table [dataSource]="members">
     <ng-container matColumnDef="name">
-      <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef [attr.rowspan]="displayMode === 'months' ? 2 : 1">Name</mat-header-cell>
       <mat-cell *matCellDef="let m">{{ m.name }}, {{ m.firstName }}</mat-cell>
       <mat-footer-cell *matFooterCellDef>Summe</mat-footer-cell>
     </ng-container>
 
     <ng-container matColumnDef="voice">
-      <mat-header-cell *matHeaderCellDef>Stimme</mat-header-cell>
+      <mat-header-cell *matHeaderCellDef [attr.rowspan]="displayMode === 'months' ? 2 : 1">Stimme</mat-header-cell>
       <mat-cell *matCellDef="let m">{{ voiceOf(m) }}</mat-cell>
       <mat-footer-cell *matFooterCellDef></mat-footer-cell>
     </ng-container>
 
-    <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
-      <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
-      <mat-cell *matCellDef="let m" (click)="changeStatus(m.id, col.key)">
-        <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, col.key))">{{ iconFor(status(m.id, col.key)) }}</mat-icon>
-      </mat-cell>
-      <mat-footer-cell *matFooterCellDef>
-        <span class="summary-item">
-          <mat-icon class="status-icon available">check</mat-icon>{{ statusCount(col.key, 'AVAILABLE') }}
-        </span>
-        <span class="summary-item">
-          <mat-icon class="status-icon maybe">check</mat-icon>{{ statusCount(col.key, 'MAYBE') }}
-        </span>
-        <span class="summary-item">
-          <mat-icon class="status-icon unavailable">close</mat-icon>{{ statusCount(col.key, 'UNAVAILABLE') }}
-        </span>
-        <span class="summary-item">
-          <mat-icon class="status-icon unknown">help</mat-icon>{{ statusCount(col.key, 'UNKNOWN') }}
-        </span>
-      </mat-footer-cell>
-    </ng-container>
-
-    <ng-container *ngFor="let col of monthColumns" [matColumnDef]="col.key">
-      <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
-      <mat-cell *matCellDef="let m">
-        <ng-container *ngFor="let ev of col.events">
-          <span class="event-item">
-            <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, ev.date))" (click)="changeStatus(m.id, ev.date)">
-              {{ iconFor(status(m.id, ev.date)) }}
-            </mat-icon>
-            <span class="event-date">{{ formatDate(ev.date) }}</span>
+    <ng-container *ngIf="displayMode === 'events'">
+      <ng-container *ngFor="let col of eventColumns" [matColumnDef]="col.key">
+        <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
+        <mat-cell *matCellDef="let m">
+          <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, col.key))" (click)="changeStatus(m.id, col.key)">
+            {{ iconFor(status(m.id, col.key)) }}
+          </mat-icon>
+        </mat-cell>
+        <mat-footer-cell *matFooterCellDef>
+          <span class="summary-item">
+            <mat-icon class="status-icon available">check</mat-icon>{{ statusCount(col.key, 'AVAILABLE') }}
           </span>
-        </ng-container>
-      </mat-cell>
-      <mat-footer-cell *matFooterCellDef>
-        <span class="summary-item">
-          <mat-icon class="status-icon available">check</mat-icon>{{ monthStatusCount(col, 'AVAILABLE') }}
-        </span>
-        <span class="summary-item">
-          <mat-icon class="status-icon maybe">check</mat-icon>{{ monthStatusCount(col, 'MAYBE') }}
-        </span>
-        <span class="summary-item">
-          <mat-icon class="status-icon unavailable">close</mat-icon>{{ monthStatusCount(col, 'UNAVAILABLE') }}
-        </span>
-        <span class="summary-item">
-          <mat-icon class="status-icon unknown">help</mat-icon>{{ monthStatusCount(col, 'UNKNOWN') }}
-        </span>
-      </mat-footer-cell>
+          <span class="summary-item">
+            <mat-icon class="status-icon maybe">check</mat-icon>{{ statusCount(col.key, 'MAYBE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon unavailable">close</mat-icon>{{ statusCount(col.key, 'UNAVAILABLE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon unknown">help</mat-icon>{{ statusCount(col.key, 'UNKNOWN') }}
+          </span>
+        </mat-footer-cell>
+      </ng-container>
     </ng-container>
 
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <ng-container *ngIf="displayMode === 'months'">
+      <ng-container *ngFor="let col of dateColumns" [matColumnDef]="col.key">
+        <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
+        <mat-cell *matCellDef="let m">
+          <mat-icon class="status-icon" [ngClass]="classFor(status(m.id, col.key))" (click)="changeStatus(m.id, col.key)">
+            {{ iconFor(status(m.id, col.key)) }}
+          </mat-icon>
+        </mat-cell>
+        <mat-footer-cell *matFooterCellDef>
+          <span class="summary-item">
+            <mat-icon class="status-icon available">check</mat-icon>{{ statusCount(col.key, 'AVAILABLE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon maybe">check</mat-icon>{{ statusCount(col.key, 'MAYBE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon unavailable">close</mat-icon>{{ statusCount(col.key, 'UNAVAILABLE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon unknown">help</mat-icon>{{ statusCount(col.key, 'UNKNOWN') }}
+          </span>
+        </mat-footer-cell>
+      </ng-container>
+
+      <ng-container *ngFor="let month of monthColumns" [matColumnDef]="month.key">
+        <mat-header-cell *matHeaderCellDef [attr.colspan]="month.dates.length">{{ month.label }}</mat-header-cell>
+        <mat-footer-cell *matFooterCellDef>
+          <span class="summary-item">
+            <mat-icon class="status-icon available">check</mat-icon>{{ monthStatusCount(month, 'AVAILABLE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon maybe">check</mat-icon>{{ monthStatusCount(month, 'MAYBE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon unavailable">close</mat-icon>{{ monthStatusCount(month, 'UNAVAILABLE') }}
+          </span>
+          <span class="summary-item">
+            <mat-icon class="status-icon unknown">help</mat-icon>{{ monthStatusCount(month, 'UNKNOWN') }}
+          </span>
+        </mat-footer-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="monthHeaderColumns"></mat-header-row>
+      <mat-header-row *matHeaderRowDef="dateHeaderColumns"></mat-header-row>
+    </ng-container>
+    <ng-container *ngIf="displayMode === 'events'">
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    </ng-container>
     <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
-    <mat-footer-row *matFooterRowDef="displayedColumns"></mat-footer-row>
+    <ng-container *ngIf="displayMode === 'months'">
+      <mat-footer-row *matFooterRowDef="displayedColumns"></mat-footer-row>
+      <mat-footer-row *matFooterRowDef="monthHeaderColumns"></mat-footer-row>
+    </ng-container>
+    <ng-container *ngIf="displayMode === 'events'">
+      <mat-footer-row *matFooterRowDef="displayedColumns"></mat-footer-row>
+    </ng-container>
     <ng-container matNoDataRow>
       <tr class="mat-row" *matNoDataRow>
         <td class="mat-cell" [attr.colspan]="displayedColumns.length">

--- a/choir-app-frontend/src/app/features/participation/participation.component.scss
+++ b/choir-app-frontend/src/app/features/participation/participation.component.scss
@@ -14,6 +14,10 @@
   font-size: 16px;
   vertical-align: middle;
   margin-right: 2px;
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  padding: 2px;
+  cursor: pointer;
 }
 
 .available {
@@ -32,19 +36,8 @@
   color: #9e9e9e;
 }
 
-.event-item {
-  display: inline-flex;
-  align-items: center;
-  margin-right: 4px;
-}
-
 .summary-item {
   display: inline-flex;
   align-items: center;
   margin-right: 4px;
-}
-
-.event-date {
-  font-size: 12px;
-  margin-left: 2px;
 }

--- a/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.spec.ts
@@ -1,6 +1,5 @@
 import { ParticipationComponent } from './participation.component';
 import { UserInChoir } from '@core/models/user';
-import { Event } from '@core/models/event';
 import { BehaviorSubject } from 'rxjs';
 
 describe('ParticipationComponent', () => {
@@ -49,11 +48,8 @@ describe('ParticipationComponent', () => {
     const col = {
       key: '2024-01',
       label: 'Jan 2024',
-      events: [
-        { date: '2024-01-01' } as Event,
-        { date: '2024-01-02' } as Event
-      ]
-    };
+      dates: ['2024-01-01', '2024-01-02']
+    } as any;
     expect(component.monthStatusCount(col, 'AVAILABLE')).toBe(2);
     expect(component.monthStatusCount(col, 'MAYBE')).toBe(1);
     expect(component.monthStatusCount(col, 'UNAVAILABLE')).toBe(1);
@@ -72,11 +68,8 @@ describe('ParticipationComponent', () => {
     const col = {
       key: '2024-01',
       label: 'Jan 2024',
-      events: [
-        { date: '2024-01-01' } as Event,
-        { date: '2024-01-01' } as Event
-      ]
-    };
+      dates: ['2024-01-01', '2024-01-01']
+    } as any;
     expect(component.monthStatusCount(col, 'AVAILABLE')).toBe(1);
     expect(component.monthStatusCount(col, 'MAYBE')).toBe(1);
   });


### PR DESCRIPTION
## Summary
- split participation view into monthly columns subdivided by date
- show per-date and per-month participation sums
- highlight participation buttons with a thin border

## Testing
- `npm test` *(failed: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file)*
- `npm run lint` *(failed: 702 problems (702 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c805f582708320b31868d4c102af61