### PR TITLE
Show role tooltip for username

### DIFF
--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.html
@@ -55,7 +55,7 @@
       <mat-icon>shopping_cart</mat-icon>
     </button>
 
-    <span class="user-name" [ngClass]="{'hide-on-handset': (isHandset$ | async)}">{{ userName$ | async }}</span>
+    <span class="user-name" [ngClass]="{'hide-on-handset': (isHandset$ | async)}" [matTooltip]="userRole$ | async">{{ userName$ | async }}</span>
 
     <button mat-icon-button [matMenuTriggerFor]="userMenu" matTooltip="Benutzerprofil">
       <mat-icon>

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -104,4 +104,15 @@ describe('MainLayoutComponent', () => {
     visible = await firstValueFrom(item!.visibleSubject!);
     expect(visible).toBeFalse();
   });
+
+  it('translates user roles and updates tooltip on changes', async () => {
+    let role = await firstValueFrom(component.userRole$);
+    expect(role).toBe('Sänger');
+
+    authServiceMock.currentUser$.next({ roles: ['director'] });
+    authServiceMock.activeChoir$.next({ modules: {} });
+    fixture.detectChanges();
+    role = await firstValueFrom(component.userRole$);
+    expect(role).toBe('Dirigent');
+  });
 });

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -51,6 +51,16 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
   isAdmin$: Observable<boolean>;
   donatedRecently$: Observable<boolean>;
   userName$: Observable<string | undefined>;
+  userRole$: Observable<string | undefined>;
+  private readonly roleTranslations: Record<string, string> = {
+    director: 'Dirigent',
+    choir_admin: 'Chor-Admin',
+    admin: 'Administrator',
+    demo: 'Demo',
+    singer: 'Sänger',
+    librarian: 'Bibliothekar',
+    organist: 'Organist'
+  };
   currentTheme: Theme;
   showAdminSubmenu: boolean = true;
   isExpanded = true;
@@ -105,6 +115,17 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
     this.isLoggedIn$ = this.authService.isLoggedIn$;
     this.isAdmin$ = this.authService.isAdmin$;
     this.userName$ = this.authService.currentUser$.pipe(map(u => u?.firstName + ' ' + u?.name));
+    this.userRole$ = combineLatest([this.authService.currentUser$, this.authService.activeChoir$]).pipe(
+      map(([user]) => {
+        const roles = Array.isArray(user?.roles)
+          ? user.roles
+          : user?.roles ? [user.roles] : [];
+        if (roles.length === 0) {
+          return undefined;
+        }
+        return roles.map(r => this.roleTranslations[r] ?? r).join(', ');
+      })
+    );
     this.donatedRecently$ = this.authService.currentUser$.pipe(
       map(u => {
         if (!u?.lastDonation) return false;


### PR DESCRIPTION
## Summary
- display current user's role in German as tooltip on their name
- add translation mapping and reactive observable for role updates
- test role tooltip generation and updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c808a8159c83208da3dffb297fbd47