### PR TITLE
Notify choir admins when singer registers

### DIFF
--- a/choir-app-backend/src/controllers/join.controller.js
+++ b/choir-app-backend/src/controllers/join.controller.js
@@ -1,5 +1,6 @@
 const db = require('../models');
 const bcrypt = require('bcryptjs');
+const emailService = require('../services/email.service');
 
 exports.getJoinInfo = async (req, res) => {
   try {
@@ -27,6 +28,7 @@ exports.joinChoir = async (req, res) => {
     if (existing) return res.status(409).send({ message: 'User already exists.' });
     const user = await db.user.create({ firstName, name, email, password: bcrypt.hashSync(password, 8), roles: ['singer'] });
     await choir.addUser(user, { through: { rolesInChoir: ['singer'], registrationStatus: 'REGISTERED' } });
+    await emailService.sendNewMemberNotification(choir.id, user);
     res.status(201).send({ message: 'Registration completed.' });
   } catch (err) {
     res.status(500).send({ message: err.message });

--- a/choir-app-backend/tests/join.controller.test.js
+++ b/choir-app-backend/tests/join.controller.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 
 process.env.DB_DIALECT = 'sqlite';
 process.env.DB_NAME = ':memory:';
+process.env.DISABLE_EMAIL = 'true';
 
 const db = require('../src/models');
 const controller = require('../src/controllers/join.controller');


### PR DESCRIPTION
## Summary
- inform choir admins/directors via email when a singer completes registration
- implement helper in email service and invoke from join and invitation controllers
- adjust tests to run with email disabled

## Testing
- `npm test`
- `npm run lint` *(fails: 'no-unused-vars', 'no-dupe-else-if', 'no-case-declarations')*

------
https://chatgpt.com/codex/tasks/task_e_68c82584ee548320b1bd5387f0790d6d