### PR TITLE
Refine choir role checks to use active choir membership

### DIFF
--- a/choir-app-backend/src/middleware/role.middleware.js
+++ b/choir-app-backend/src/middleware/role.middleware.js
@@ -1,7 +1,34 @@
 const db = require('../models');
 
+const DIRECTOR_ROLES = ['choirleiter', 'director'];
+
+async function getActiveChoirMembership(req) {
+    if (!req.userId || !req.activeChoirId) {
+        return null;
+    }
+
+    if (!req._activeChoirMembership) {
+        req._activeChoirMembership = db.user_choir.findOne({
+            where: { userId: req.userId, choirId: req.activeChoirId }
+        });
+    }
+
+    return req._activeChoirMembership;
+}
+
+async function userHasChoirRole(req, choirRoles) {
+    const membership = await getActiveChoirMembership(req);
+    if (!membership || !Array.isArray(membership.rolesInChoir)) {
+        return false;
+    }
+
+    return choirRoles.some(role => membership.rolesInChoir.includes(role));
+}
+
 /**
  * Middleware to disallow actions for demo users.
+ *
+ * Checks the global roles provided in {@link req.userRoles}.
  */
 function requireNonDemo(req, res, next) {
     if (req.userRoles.includes('demo')) {
@@ -12,6 +39,8 @@ function requireNonDemo(req, res, next) {
 
 /**
  * Middleware that allows only global admins.
+ *
+ * Relies solely on the global roles listed in {@link req.userRoles}.
  */
 function requireAdmin(req, res, next) {
     if (req.userRoles.includes('admin')) {
@@ -21,17 +50,18 @@ function requireAdmin(req, res, next) {
 }
 
 /**
- * Middleware that allows choir admins or global admins.
+ * Middleware that allows choir admins for the active choir or global admins.
+ *
+ * Global access is granted via {@link req.userRoles}; choir-level access is
+ * resolved against {@link db.user_choir} for the current {@link req.activeChoirId}.
  */
 async function requireChoirAdmin(req, res, next) {
     if (req.userRoles.includes('admin')) {
         return next();
     }
     try {
-        const association = await db.user_choir.findOne({
-            where: { userId: req.userId, choirId: req.activeChoirId }
-        });
-        if (association && Array.isArray(association.rolesInChoir) && association.rolesInChoir.includes('choir_admin')) {
+        const hasChoirAdminRole = await userHasChoirRole(req, ['choir_admin']);
+        if (hasChoirAdminRole) {
             return next();
         }
         return res.status(403).send({ message: 'Require Choir Admin Role!' });
@@ -40,16 +70,20 @@ async function requireChoirAdmin(req, res, next) {
     }
 }
 
+/**
+ * Middleware that allows directors (choirleiter) or choir admins of the active
+ * choir as well as global librarians and admins.
+ *
+ * Global access is validated through {@link req.userRoles}; choir-specific
+ * permissions are read from {@link user_choir.rolesInChoir}.
+ */
 async function requireDirector(req, res, next) {
     if (['admin', 'librarian'].some(r => req.userRoles.includes(r))) {
         return next();
     }
     try {
-        const association = await db.user_choir.findOne({
-            where: { userId: req.userId, choirId: req.activeChoirId }
-        });
-        if (association && Array.isArray(association.rolesInChoir) &&
-            (association.rolesInChoir.includes('choirleiter') || association.rolesInChoir.includes('choir_admin'))) {
+        const hasDirectorRole = await userHasChoirRole(req, ['choir_admin', ...DIRECTOR_ROLES]);
+        if (hasDirectorRole) {
             return next();
         }
         return res.status(403).send({ message: 'Require Choirleiter Role!' });
@@ -58,6 +92,9 @@ async function requireDirector(req, res, next) {
     }
 }
 
+/**
+ * Middleware that allows only global librarians or admins.
+ */
 function requireLibrarian(req, res, next) {
     if (['librarian', 'admin'].some(r => req.userRoles.includes(r))) {
         return next();
@@ -65,19 +102,20 @@ function requireLibrarian(req, res, next) {
     return res.status(403).send({ message: 'Require Librarian Role!' });
 }
 
+/**
+ * Middleware that allows directors (choirleiter) or choir admins of the active
+ * choir in addition to global admins.
+ *
+ * Global access is validated through {@link req.userRoles}; choir-specific
+ * permissions are read from {@link user_choir.rolesInChoir}.
+ */
 async function requireDirectorOrHigher(req, res, next) {
     if (req.userRoles.includes('admin')) {
         return next();
     }
     try {
-        const association = await db.user_choir.findOne({
-            where: { userId: req.userId, choirId: req.activeChoirId }
-        });
-        if (
-            association &&
-            Array.isArray(association.rolesInChoir) &&
-            (association.rolesInChoir.includes('choir_admin') || association.rolesInChoir.includes('choirleiter'))
-        ) {
+        const hasDirectorRole = await userHasChoirRole(req, ['choir_admin', ...DIRECTOR_ROLES]);
+        if (hasDirectorRole) {
             return next();
         }
         return res.status(403).send({ message: 'Require Choirleiter Role!' });


### PR DESCRIPTION
## Summary
- load active choir membership once and reuse it for choir-level authorisation checks
- document how each middleware inspects global versus choir roles and allow director aliases via membership data
- broaden the role middleware tests to cover director cases and cross-choir access denials

## Testing
- node tests/role.middleware.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c910e92f4083208d33a712cb2766f4