### PR TITLE
Refactor role handling into global and choir scopes

### DIFF
--- a/choir-app-frontend/src/app/core/guards/program.guard.ts
+++ b/choir-app-frontend/src/app/core/guards/program.guard.ts
@@ -9,12 +9,11 @@ export class ProgramGuard implements CanActivate {
   constructor(private auth: AuthService, private router: Router) {}
 
   canActivate(): Observable<boolean | UrlTree> {
-    return combineLatest([this.auth.currentUser$, this.auth.activeChoir$]).pipe(
-      map(([user, choir]) => {
-        const roles = Array.isArray(user?.roles) ? user!.roles : [];
-        const allowedRoles = roles.some(r => ['director', 'choir_admin', 'admin'].includes(r));
+    return combineLatest([this.auth.isChoirAdmin$, this.auth.isDirector$, this.auth.activeChoir$]).pipe(
+      map(([isChoirAdmin, isDirector, choir]) => {
+        const allowed = isChoirAdmin || isDirector;
         const moduleEnabled = choir?.modules?.programs !== false;
-        return allowedRoles && moduleEnabled ? true : this.router.createUrlTree(['/dashboard']);
+        return allowed && moduleEnabled ? true : this.router.createUrlTree(['/dashboard']);
       })
     );
   }

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -1,3 +1,10 @@
+export type ChoirRole = 'director' | 'choir_admin' | 'organist' | 'singer';
+
+export interface ChoirMembership {
+    rolesInChoir: ChoirRole[];
+    registrationStatus: 'REGISTERED' | 'PENDING';
+}
+
 export interface Choir {
     id: number;
     name: string;
@@ -17,4 +24,5 @@ export interface Choir {
         singerMenu?: Record<string, boolean>;
     };
     joinHash?: string;
+    membership?: ChoirMembership;
 }

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -1,4 +1,4 @@
-import { Choir } from './choir';
+import { Choir, ChoirMembership } from './choir';
 
 /**
  * Represents the structure of a User object, typically received after
@@ -34,7 +34,7 @@ export interface User {
   shareWithChoir?: boolean;
 
 
-  roles?: ('director' | 'choir_admin' | 'admin' | 'demo' | 'singer' | 'librarian')[];
+  roles?: GlobalRole[];
 
   /**
    * Indicates whether the help wizard has been displayed for this user.
@@ -56,9 +56,8 @@ export interface User {
   resetTokenExpiry?: string | null;
 }
 
+export type GlobalRole = 'admin' | 'librarian' | 'demo' | 'user';
+
 export interface UserInChoir extends User {
-    membership?: { // Daten aus der Junction-Tabelle
-        rolesInChoir: ('director' | 'choir_admin' | 'organist' | 'singer')[];
-        registrationStatus: 'REGISTERED' | 'PENDING';
-    }
+    membership?: ChoirMembership; // Daten aus der Junction-Tabelle
 }

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { Piece } from '../models/piece';
 import { Composer } from '../models/composer';
 import { Category } from '../models/category';
-import { User, UserInChoir } from '../models/user';
+import { User, UserInChoir, GlobalRole } from '../models/user';
 import { LoginAttempt } from '../models/login-attempt';
 import { CreateEventResponse, Event } from '../models/event';
 import { MonthlyPlan } from '../models/monthly-plan';
@@ -524,7 +524,7 @@ export class ApiService {
     return this.userService.getCurrentUser();
   }
 
-  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] }): Observable<any> {
     return this.userService.updateCurrentUser(profileData);
   }
 

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { map, tap, catchError } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of, combineLatest } from 'rxjs';
+import { map, tap, catchError, distinctUntilChanged } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { environment } from 'src/environments/environment';
-import { User } from '../models/user';
-import { Choir } from '../models/choir';
+import { User, GlobalRole } from '../models/user';
+import { Choir, ChoirRole } from '../models/choir';
 import { SwitchChoirResponse } from '../models/auth';
 import { ThemeService } from './theme.service';
 import { UserPreferencesService } from './user-preferences.service';
@@ -30,8 +30,14 @@ export class AuthService {
   public availableChoirs$ = new BehaviorSubject<Choir[]>([]);
 
   // --- Wir leiten die Berechtigungen direkt vom currentUser$ ab ---
+  public globalRoles$: Observable<GlobalRole[]>;
+  public choirRoles$: Observable<ChoirRole[]>;
   public isAdmin$: Observable<boolean>;
   public isLibrarian$: Observable<boolean>;
+  public isChoirAdmin$: Observable<boolean>;
+  public isDirector$: Observable<boolean>;
+  public isSinger$: Observable<boolean>;
+  public isSingerOnly$: Observable<boolean>;
 
   constructor(private http: HttpClient,
               private router: Router,
@@ -48,21 +54,44 @@ export class AuthService {
       this.availableChoirs$.next(storedUser.availableChoirs || []);
     }
 
-    this.isAdmin$ = this.currentUser$.pipe(
-      map(user => {
-        const roles = Array.isArray(user?.roles)
-          ? user.roles
-          : user?.roles ? [user.roles] : [];
-        return roles.includes('admin');
-      })
+    this.globalRoles$ = this.currentUser$.pipe(
+      map(user => this.extractGlobalRoles(user)),
+      distinctUntilChanged((prev, curr) => this.rolesEqual(prev, curr))
     );
-    this.isLibrarian$ = this.currentUser$.pipe(
-      map(user => {
-        const roles = Array.isArray(user?.roles)
-          ? user.roles
-          : user?.roles ? [user.roles] : [];
-        return roles.includes('librarian');
-      })
+
+    this.choirRoles$ = this.activeChoir$.pipe(
+      map(choir => this.extractChoirRoles(choir)),
+      distinctUntilChanged((prev, curr) => this.rolesEqual(prev, curr))
+    );
+
+    this.isAdmin$ = this.globalRoles$.pipe(
+      map(roles => roles.includes('admin')),
+      distinctUntilChanged()
+    );
+
+    this.isLibrarian$ = this.globalRoles$.pipe(
+      map(roles => roles.includes('librarian')),
+      distinctUntilChanged()
+    );
+
+    this.isChoirAdmin$ = combineLatest([this.isAdmin$, this.choirRoles$]).pipe(
+      map(([isAdmin, choirRoles]) => isAdmin || choirRoles.includes('choir_admin')),
+      distinctUntilChanged()
+    );
+
+    this.isDirector$ = combineLatest([this.isAdmin$, this.choirRoles$]).pipe(
+      map(([isAdmin, choirRoles]) => isAdmin || choirRoles.includes('director')),
+      distinctUntilChanged()
+    );
+
+    this.isSinger$ = this.choirRoles$.pipe(
+      map(roles => roles.includes('singer')),
+      distinctUntilChanged()
+    );
+
+    this.isSingerOnly$ = combineLatest([this.globalRoles$, this.choirRoles$]).pipe(
+      map(([globalRoles, choirRoles]) => this.computeIsSingerOnly(globalRoles, choirRoles)),
+      distinctUntilChanged()
     );
 
     if (this.hasToken()) {
@@ -220,5 +249,39 @@ export class AuthService {
       available: choirs
     });
     this.availableChoirs$.next(choirs);
+  }
+
+  private extractGlobalRoles(user: User | null): GlobalRole[] {
+    const roles = Array.isArray(user?.roles) ? user!.roles : [];
+    const normalized: GlobalRole[] = roles.length ? roles : ['user'];
+    return this.normalizeRoles(normalized);
+  }
+
+  private extractChoirRoles(choir: Choir | null): ChoirRole[] {
+    const roles = choir?.membership?.rolesInChoir ?? [];
+    return this.normalizeRoles(roles);
+  }
+
+  private normalizeRoles<T extends string>(roles: T[]): T[] {
+    return Array.from(new Set(roles)).sort();
+  }
+
+  private rolesEqual<T extends string>(a: T[], b: T[]): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    return a.every((role, idx) => role === b[idx]);
+  }
+
+  private computeIsSingerOnly(globalRoles: GlobalRole[], choirRoles: ChoirRole[]): boolean {
+    if (!choirRoles.includes('singer')) {
+      return false;
+    }
+    const hasGlobalPrivilege = globalRoles.some(role => role === 'admin' || role === 'librarian');
+    if (hasGlobalPrivilege) {
+      return false;
+    }
+    const hasChoirPrivilege = choirRoles.some(role => role === 'choir_admin' || role === 'director' || role === 'organist');
+    return !hasChoirPrivilege;
   }
 }

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -252,8 +252,16 @@ export class AuthService {
   }
 
   private extractGlobalRoles(user: User | null): GlobalRole[] {
-    const roles = Array.isArray(user?.roles) ? user!.roles : [];
-    const normalized: GlobalRole[] = roles.length ? roles : ['user'];
+    const rawRoles = user?.roles as unknown;
+    let normalized: GlobalRole[];
+    if (Array.isArray(rawRoles)) {
+      const rolesArray = rawRoles as GlobalRole[];
+      normalized = rolesArray.length ? rolesArray : ['user'];
+    } else if (typeof rawRoles === 'string' && rawRoles.length > 0) {
+      normalized = [rawRoles as GlobalRole];
+    } else {
+      normalized = ['user'];
+    }
     return this.normalizeRoles(normalized);
   }
 

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { User } from '../models/user';
+import { User, GlobalRole } from '../models/user';
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] }): Observable<any> {
+  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.html
@@ -31,11 +31,10 @@
           (ngModelChange)="onRolesChange(element, $event)"
           multiple
         >
-          <mat-option value="director">Dirigent</mat-option>
-          <mat-option value="choir_admin">Chor-Admin</mat-option>
-          <mat-option value="singer">Sänger</mat-option>
-          <mat-option value="admin">Admin</mat-option>
+          <mat-option value="user" disabled>Standardnutzer</mat-option>
+          <mat-option value="admin">Administrator</mat-option>
           <mat-option value="librarian">Bibliothekar</mat-option>
+          <mat-option value="demo">Demo</mat-option>
         </mat-select>
       </mat-form-field>
     </mat-cell>
@@ -101,11 +100,10 @@
             (ngModelChange)="onRolesChange(element, $event)"
             multiple
           >
-            <mat-option value="director">Dirigent</mat-option>
-            <mat-option value="choir_admin">Chor-Admin</mat-option>
-            <mat-option value="singer">Sänger</mat-option>
-            <mat-option value="admin">Admin</mat-option>
+            <mat-option value="user" disabled>Standardnutzer</mat-option>
+            <mat-option value="admin">Administrator</mat-option>
             <mat-option value="librarian">Bibliothekar</mat-option>
+            <mat-option value="demo">Demo</mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/manage-users.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from 'src/app/core/services/api.service';
-import { User } from 'src/app/core/models/user';
+import { User, GlobalRole } from 'src/app/core/models/user';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -123,9 +123,13 @@ export class ManageUsersComponent implements OnInit {
     this.applyFilter(value);
   }
 
-  onRolesChange(user: User, roles: ('director' | 'choir_admin' | 'admin' | 'librarian' | 'singer')[]): void {
-    this.api.updateUser(user.id, { roles }).subscribe(() => {
-      user.roles = roles;
+  onRolesChange(user: User, roles: GlobalRole[]): void {
+    const normalized = Array.from(new Set<GlobalRole>(roles ?? []));
+    if (!normalized.includes('user')) {
+      normalized.push('user');
+    }
+    this.api.updateUser(user.id, { roles: normalized }).subscribe(() => {
+      user.roles = normalized;
       this.snack.open('Rollen aktualisiert', 'OK', { duration: 3000 });
     });
   }

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -63,11 +63,10 @@
     <mat-form-field appearance="outline">
       <mat-label>Rollen</mat-label>
       <mat-select formControlName="roles" multiple>
-        <mat-option value="director">Dirigent</mat-option>
-        <mat-option value="choir_admin">Chor-Admin</mat-option>
-        <mat-option value="singer">Sänger</mat-option>
-        <mat-option value="admin">Admin</mat-option>
+        <mat-option value="user" disabled>Standardnutzer</mat-option>
+        <mat-option value="admin">Administrator</mat-option>
         <mat-option value="librarian">Bibliothekar</mat-option>
+        <mat-option value="demo">Demo</mat-option>
       </mat-select>
     </mat-form-field>
   </form>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MaterialModule } from '@modules/material.module';
-import { User } from 'src/app/core/models/user';
+import { User, GlobalRole } from 'src/app/core/models/user';
 import { ApiService } from '@core/services/api.service';
 import { District } from '@core/models/district';
 import { Congregation } from '@core/models/congregation';
@@ -39,7 +39,7 @@ export class UserDialogComponent implements OnInit {
       congregation: [data?.congregation || ''],
       voice: [data?.voice || ''],
       shareWithChoir: [data?.shareWithChoir || false],
-      roles: [data?.roles || ['director'], Validators.required],
+      roles: [data?.roles || ['user'], Validators.required],
       password: ['', data ? [] : [Validators.required]]
     });
   }
@@ -56,6 +56,13 @@ export class UserDialogComponent implements OnInit {
   onSave(): void {
     if (this.form.valid) {
       const value = { ...this.form.value };
+      if (Array.isArray(value.roles)) {
+        const normalized = Array.from(new Set<GlobalRole>(value.roles));
+        if (!normalized.includes('user')) {
+          normalized.push('user');
+        }
+        value.roles = normalized;
+      }
       if (!value.password) {
         delete value.password;
       }

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -118,9 +118,8 @@ export class ManageChoirComponent implements OnInit {
   ngOnInit(): void {
     const choirIdParam = this.route.snapshot.queryParamMap.get('choirId');
     this.adminChoirId = choirIdParam ? parseInt(choirIdParam, 10) : null;
-    this.authService.currentUser$.pipe(take(1)).subscribe(user => {
-      const roles = Array.isArray(user?.roles) ? user!.roles : [];
-      this.isDirector = roles.includes('director');
+    this.authService.isDirector$.pipe(take(1)).subscribe(isDirector => {
+      this.isDirector = isDirector;
       this.updateCanManageMenu();
     });
     this.authService.isAdmin$.pipe(take(1)).subscribe(isAdmin => {

--- a/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
+++ b/choir-app-frontend/src/app/features/events/event-list/event-list.component.ts
@@ -71,18 +71,16 @@ export class EventListComponent implements OnInit, AfterViewInit {
       this.apiService.getEventById(eventId).subscribe(e => this.selectedEvent = e);
     }
     this.typeControl.valueChanges.pipe(startWith('ALL')).subscribe(() => this.loadEvents());
-    this.apiService.checkChoirAdminStatus().subscribe(s => {
-      this.isChoirAdmin = s.isChoirAdmin;
+    this.authService.isChoirAdmin$.subscribe(isChoirAdmin => {
+      this.isChoirAdmin = isChoirAdmin;
       this.updateDisplayedColumns();
     });
     this.authService.isAdmin$.subscribe(isAdmin => {
       this.isAdmin = isAdmin;
       this.updateDisplayedColumns();
     });
-    this.authService.currentUser$.subscribe(user => {
-      const roles = Array.isArray(user?.roles) ? user!.roles : [];
-      this.isSingerOnly = roles.includes('singer') &&
-        !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
+    this.authService.isSingerOnly$.subscribe(isSingerOnly => {
+      this.isSingerOnly = isSingerOnly;
       this.updateDisplayedColumns();
     });
   }

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -103,13 +103,7 @@ export class DashboardComponent implements OnInit {
   ) {
     this.activeChoir$ = this.authService.activeChoir$;
     this.isAdmin$ = this.authService.isAdmin$;
-    this.isSingerOnly$ = this.authService.currentUser$.pipe(
-      map(user => {
-        const roles = Array.isArray(user?.roles) ? user.roles : [];
-        return roles.includes('singer') &&
-          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
-      })
-    );
+    this.isSingerOnly$ = this.authService.isSingerOnly$;
     this.authService.availableChoirs$.subscribe(choirs => {
       choirs.forEach((c, idx) => {
         this.choirColors[c.id] = this.colorPalette[idx % this.colorPalette.length];

--- a/choir-app-frontend/src/app/features/library/library.component.ts
+++ b/choir-app-frontend/src/app/features/library/library.component.ts
@@ -57,10 +57,7 @@ export class LibraryComponent implements OnInit, AfterViewInit {
     this.collections$ = this.apiService.getCollections();
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
     this.auth.isLibrarian$.subscribe(l => this.isLibrarian = l);
-    this.auth.currentUser$.subscribe(user => {
-      const roles = Array.isArray(user?.roles) ? user.roles : [];
-      this.isSingerOnly = roles.includes('singer') && !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
-    });
+    this.auth.isSingerOnly$.subscribe(isSingerOnly => this.isSingerOnly = isSingerOnly);
   }
 
   ngAfterViewInit(): void {

--- a/choir-app-frontend/src/app/features/library/loan-cart.component.ts
+++ b/choir-app-frontend/src/app/features/library/loan-cart.component.ts
@@ -30,10 +30,9 @@ export class LoanCartComponent {
     this.items$ = this.cart.items$;
     this.choir$ = this.api.getMyChoirDetails();
     this.user$ = this.auth.currentUser$;
-    this.auth.currentUser$.subscribe(user => {
-      const roles = Array.isArray(user?.roles) ? user.roles : [];
-      this.isSingerOnly = roles.includes('singer') && !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
-      if (this.isSingerOnly) {
+    this.auth.isSingerOnly$.subscribe(isSingerOnly => {
+      this.isSingerOnly = isSingerOnly;
+      if (isSingerOnly) {
         this.router.navigate(['/library']);
       }
     });

--- a/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
+++ b/choir-app-frontend/src/app/features/literature/literature-list/literature-list.component.ts
@@ -132,9 +132,9 @@ export class LiteratureListComponent implements OnInit, AfterViewInit {
       switchMap(ids => this.apiService.getCategories(ids.length ? ids : undefined))
     );
     this.loadPresets();
-    this.apiService.checkChoirAdminStatus().subscribe(s => this.isChoirAdmin = s.isChoirAdmin);
+    this.authService.isChoirAdmin$.subscribe(isChoirAdmin => this.isChoirAdmin = isChoirAdmin);
     this.authService.isAdmin$.subscribe(a => this.isAdmin = a);
-    this.authService.currentUser$.subscribe(u => this.isDirector = u?.roles?.includes('director') || false);
+    this.authService.isDirector$.subscribe(isDirector => this.isDirector = isDirector);
 
     const saved = localStorage.getItem(this.FILTER_KEY);
     if (saved) {

--- a/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
+++ b/choir-app-frontend/src/app/features/literature/piece-detail/piece-detail.component.ts
@@ -18,6 +18,7 @@ import { HttpClient } from '@angular/common/http';
 import { LibraryItem } from '@core/models/library-item';
 import { LibraryItemInfoDialogComponent } from '../../library/library-item-info-dialog.component';
 import { PureDatePipe } from '@shared/pipes/pure-date.pipe';
+import { combineLatest } from 'rxjs';
 
 @Component({
   selector: 'app-piece-detail',
@@ -62,9 +63,8 @@ export class PieceDetailComponent implements OnInit {
     });
     this.auth.currentUser$.subscribe(u => this.userId = u?.id || null);
     this.auth.isAdmin$.subscribe(a => this.isAdmin = a);
-    this.auth.currentUser$.subscribe(u => {
-      const roles = u?.roles || [];
-      this.canRate = roles.includes('director') || roles.includes('choir_admin') || roles.includes('admin');
+    combineLatest([this.auth.isChoirAdmin$, this.auth.isDirector$]).subscribe(([isChoirAdmin, isDirector]) => {
+      this.canRate = isChoirAdmin || isDirector;
     });
     this.loadLibraryItems();
   }

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -7,6 +7,7 @@ import { AuthService } from '@core/services/auth.service';
 import { UserInChoir } from '@core/models/user';
 import { MemberAvailability } from '@core/models/member-availability';
 import { parseDateOnly } from '@shared/util/date';
+import { combineLatest } from 'rxjs';
 
 interface EventColumn {
   key: string;
@@ -47,9 +48,8 @@ export class ParticipationComponent implements OnInit {
   constructor(private api: ApiService, private auth: AuthService) {}
 
   ngOnInit(): void {
-    this.auth.currentUser$.subscribe(user => {
-      const roles = Array.isArray(user?.roles) ? user.roles : user?.roles ? [user.roles] : [];
-      this.isChoirAdmin = roles.some(r => ['choir_admin', 'director', 'admin'].includes(r));
+    combineLatest([this.auth.isChoirAdmin$, this.auth.isDirector$]).subscribe(([isChoirAdmin, isDirector]) => {
+      this.isChoirAdmin = isChoirAdmin || isDirector;
     });
     this.loadMembers();
     this.loadEvents();

--- a/choir-app-frontend/src/app/features/posts/post-list.component.ts
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.ts
@@ -34,13 +34,9 @@ export class PostListComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadPosts();
-    this.auth.currentUser$.subscribe(u => {
-      this.currentUserId = u?.id || null;
-      const roles = Array.isArray(u?.roles) ? u!.roles : [];
-      this.isSingerOnly = roles.includes('singer') &&
-        !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r));
-    });
-    this.api.checkChoirAdminStatus().subscribe(r => this.isChoirAdmin = r.isChoirAdmin);
+    this.auth.currentUser$.subscribe(u => this.currentUserId = u?.id || null);
+    this.auth.isSingerOnly$.subscribe(isSingerOnly => this.isSingerOnly = isSingerOnly);
+    this.auth.isChoirAdmin$.subscribe(isChoirAdmin => this.isChoirAdmin = isChoirAdmin);
   }
 
   loadPosts(): void {

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -93,10 +93,10 @@
             <mat-form-field appearance="outline">
               <mat-label>Systemrollen</mat-label>
               <mat-select formControlName="roles" multiple>
-                <mat-option value="director">Dirigent</mat-option>
-                <mat-option value="choir_admin">Chor-Admin</mat-option>
+                <mat-option value="user" disabled>Standardnutzer</mat-option>
                 <mat-option value="admin" disabled>Administrator</mat-option>
                 <mat-option value="librarian">Bibliothekar</mat-option>
+                <mat-option value="demo">Demo</mat-option>
               </mat-select>
             </mat-form-field>
           </ng-container>

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -5,7 +5,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
-import { User } from '@core/models/user';
+import { User, GlobalRole } from '@core/models/user';
 import { Choir } from '@core/models/choir';
 import { Observable } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
@@ -108,7 +108,7 @@ export class ProfileComponent implements OnInit {
 
     const formValue = this.profileForm.value;
     const oldEmail = this.currentUser?.email;
-    const updatePayload: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: string[] } = {
+    const updatePayload: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] } = {
       firstName: formValue.firstName,
       name: formValue.name,
       email: formValue.email,
@@ -122,8 +122,15 @@ export class ProfileComponent implements OnInit {
     };
 
     if (this.profileForm.get('roles')?.enabled) {
-      const roles = formValue.roles as string[];
-      updatePayload.roles = roles?.includes('admin') ? roles : [...roles, 'admin'];
+      const roles = (formValue.roles as GlobalRole[] | undefined) ?? [];
+      const normalized = Array.from(new Set<GlobalRole>(roles));
+      if (!normalized.includes('user')) {
+        normalized.push('user');
+      }
+      if (this.currentUser?.roles?.includes('admin') && !normalized.includes('admin')) {
+        normalized.push('admin');
+      }
+      updatePayload.roles = normalized;
     }
 
     const passwordGroup = formValue.passwords;

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -122,7 +122,7 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
         const globalExtras = globalRoles.filter(role => role !== 'user');
         const combined = [...globalExtras, ...choirRoles];
         if (!combined.length) {
-          return globalRoles.includes('user') ? this.roleTranslations.user : undefined;
+          return globalRoles.includes('user') ? this.roleTranslations['user'] : undefined;
         }
         combined.forEach(role => displayRoles.push(this.roleTranslations[role] ?? role));
         return displayRoles.join(', ');

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.ts
@@ -59,7 +59,8 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
     demo: 'Demo',
     singer: 'Sänger',
     librarian: 'Bibliothekar',
-    organist: 'Organist'
+    organist: 'Organist',
+    user: 'Mitglied'
   };
   currentTheme: Theme;
   showAdminSubmenu: boolean = true;
@@ -115,15 +116,16 @@ export class MainLayoutComponent implements OnInit, AfterViewInit, OnDestroy{
     this.isLoggedIn$ = this.authService.isLoggedIn$;
     this.isAdmin$ = this.authService.isAdmin$;
     this.userName$ = this.authService.currentUser$.pipe(map(u => u?.firstName + ' ' + u?.name));
-    this.userRole$ = combineLatest([this.authService.currentUser$, this.authService.activeChoir$]).pipe(
-      map(([user]) => {
-        const roles = Array.isArray(user?.roles)
-          ? user.roles
-          : user?.roles ? [user.roles] : [];
-        if (roles.length === 0) {
-          return undefined;
+    this.userRole$ = combineLatest([this.authService.globalRoles$, this.authService.choirRoles$]).pipe(
+      map(([globalRoles, choirRoles]) => {
+        const displayRoles: string[] = [];
+        const globalExtras = globalRoles.filter(role => role !== 'user');
+        const combined = [...globalExtras, ...choirRoles];
+        if (!combined.length) {
+          return globalRoles.includes('user') ? this.roleTranslations.user : undefined;
         }
-        return roles.map(r => this.roleTranslations[r] ?? r).join(', ');
+        combined.forEach(role => displayRoles.push(this.roleTranslations[role] ?? role));
+        return displayRoles.join(', ');
       })
     );
     this.donatedRecently$ = this.authService.currentUser$.pipe(

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
@@ -3,7 +3,8 @@ import { HelpWizardComponent } from './help-wizard.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { AuthService } from '@core/services/auth.service';
 import { MenuVisibilityService } from '@core/services/menu-visibility.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, of } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('HelpWizardComponent', () => {
@@ -11,9 +12,25 @@ describe('HelpWizardComponent', () => {
   let fixture: ComponentFixture<HelpWizardComponent>;
 
   beforeEach(async () => {
+    const globalRolesSubject = new BehaviorSubject<string[]>(['user']);
+    const choirRolesSubject = new BehaviorSubject<string[]>(['singer']);
+    const activeChoirSubject = new BehaviorSubject<any>({ modules: { singerMenu: { events: false, participation: false } } });
+    const isSingerOnly$ = combineLatest([globalRolesSubject.asObservable(), choirRolesSubject.asObservable()]).pipe(
+      map(([globalRoles, choirRoles]) => {
+        const hasGlobalPrivilege = globalRoles.some(role => role === 'admin' || role === 'librarian');
+        const hasChoirPrivilege = choirRoles.some(role => ['choir_admin', 'director', 'organist'].includes(role));
+        return choirRoles.includes('singer') && !hasGlobalPrivilege && !hasChoirPrivilege;
+      })
+    );
     const authServiceMock = {
-      currentUser$: new BehaviorSubject<any>({ roles: ['singer'] }),
-      activeChoir$: new BehaviorSubject<any>({ modules: { singerMenu: { events: false, participation: false } } })
+      globalRoles$: globalRolesSubject.asObservable(),
+      choirRoles$: choirRolesSubject.asObservable(),
+      activeChoir$: activeChoirSubject,
+      isSingerOnly$,
+      isAdmin$: of(false),
+      isChoirAdmin$: of(false),
+      isDirector$: of(false),
+      isLibrarian$: of(false)
     };
 
     await TestBed.configureTestingModule({

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.ts
@@ -3,8 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MatDialogRef, MatDialogContent } from '@angular/material/dialog';
 import { MatStepperModule, MatStepper } from '@angular/material/stepper';
 import { MaterialModule } from '@modules/material.module';
-import { Observable, combineLatest } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
 import { MenuVisibilityService } from '@core/services/menu-visibility.service';
 
@@ -30,18 +29,7 @@ export class HelpWizardComponent {
     private auth: AuthService,
     private menu: MenuVisibilityService
   ) {
-    this.isSingerOnly$ = combineLatest([
-      this.auth.currentUser$,
-      this.auth.activeChoir$
-    ]).pipe(
-      map(([user]) => {
-        const roles = Array.isArray(user?.roles) ? user!.roles : [];
-        return (
-          roles.includes('singer') &&
-          !roles.some(r => ['choir_admin', 'director', 'admin', 'librarian'].includes(r))
-        );
-      })
-    );
+    this.isSingerOnly$ = this.auth.isSingerOnly$;
   }
 
   /**


### PR DESCRIPTION
## Summary
- constrain user roles to global role types, add choir membership typing, and expose derived permission observables in the auth service
- update guards, menu visibility, and feature components to rely on choir-level roles from the active choir when determining permissions
- adjust profile and admin user management forms to manage only global roles

## Testing
- npm run lint *(fails: existing lint errors outside touched areas)*

------
https://chatgpt.com/codex/tasks/task_e_68c91964cba0832088cc80c5e83d38a3