### PR TITLE
feat: allow users to leave choirs from profile

### DIFF
--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -1,10 +1,51 @@
 const db = require("../models");
 const User = db.user;
 const Choir = db.choir;
+const UserChoir = db.user_choir;
+const Lending = db.lending;
+const ChoirLog = db.choir_log;
 const bcrypt = require("bcryptjs");
 const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
 const { Op } = require('sequelize');
 const emailService = require('../services/email.service');
+
+async function countOpenBorrowings(userId) {
+    return Lending.count({ where: { borrowerId: userId, status: 'borrowed' } });
+}
+
+async function isLastChoirAdmin(userId, choirId) {
+    const memberships = await UserChoir.findAll({
+        where: { choirId },
+        attributes: ['userId', 'rolesInChoir', 'registrationStatus']
+    });
+
+    return !memberships.some(entry => {
+        if (entry.userId === userId) return false;
+        if (entry.registrationStatus !== 'REGISTERED') return false;
+        const roles = Array.isArray(entry.rolesInChoir) ? entry.rolesInChoir : [];
+        return roles.includes('choir_admin');
+    });
+}
+
+function buildRestrictionMessage(reasons) {
+    if (!reasons.length) {
+        return null;
+    }
+    const prefix = 'Abmeldung nicht möglich: ';
+    if (reasons.length === 1) {
+        return `${prefix}${reasons[0]}`;
+    }
+    return `${prefix}${reasons.join(' ')}`;
+}
+
+function createAccessToken(user, activeChoirId) {
+    return jwt.sign(
+        { id: user.id, activeChoirId, roles: user.roles },
+        process.env.JWT_SECRET,
+        { expiresIn: '8h' }
+    );
+}
 
 exports.getMe = async (req, res) => {
     try {
@@ -195,6 +236,148 @@ exports.confirmEmailChange = async (req, res) => {
             emailChangeTokenExpiry: null
         });
         res.status(200).send({ message: 'E-Mail-Adresse bestätigt.' });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.leaveChoir = async (req, res) => {
+    const choirId = parseInt(req.params.choirId, 10);
+    if (Number.isNaN(choirId)) {
+        return res.status(400).send({ message: 'Ungültige Chor-ID.' });
+    }
+
+    try {
+        const user = await User.findByPk(req.userId);
+        if (!user) {
+            return res.status(404).send({ message: 'User not found.' });
+        }
+
+        const membership = await UserChoir.findOne({
+            where: { userId: req.userId, choirId },
+            include: [{ model: Choir, attributes: ['id', 'name'] }]
+        });
+
+        if (!membership) {
+            return res.status(404).send({ message: 'Du bist kein Mitglied dieses Chors.' });
+        }
+
+        const reasons = [];
+        const openBorrowings = await countOpenBorrowings(req.userId);
+        if (openBorrowings > 0) {
+            reasons.push(openBorrowings === 1
+                ? 'Es besteht noch eine offene Ausleihe. Bitte gib diese zuerst zurück.'
+                : `Es bestehen noch ${openBorrowings} offene Ausleihen. Bitte gib diese zuerst zurück.`);
+        }
+
+        const roles = Array.isArray(membership.rolesInChoir) ? membership.rolesInChoir : [];
+        if (roles.includes('choir_admin')) {
+            const lastAdmin = await isLastChoirAdmin(req.userId, choirId);
+            if (lastAdmin) {
+                const choirName = membership.choir?.name || 'diesem Chor';
+                reasons.push(`Im Chor ${choirName} bist du der letzte Chor-Admin. Bitte übertrage die Rolle, bevor du dich abmeldest.`);
+            }
+        }
+
+        const restrictionMessage = buildRestrictionMessage(reasons);
+        if (restrictionMessage) {
+            return res.status(409).send({ message: restrictionMessage });
+        }
+
+        const choirName = membership.choir?.name || 'dem Chor';
+        await membership.destroy();
+
+        await ChoirLog.create({ choirId, userId: req.userId, action: 'member_leave', details: { selfService: true } }).catch(() => {});
+
+        const userDetails = user.toJSON();
+        try {
+            await emailService.sendMemberLeftNotification(choirId, userDetails, { accountDeleted: false });
+        } catch (err) {
+            // Fehler beim Mailversand werden im Service geloggt
+        }
+
+        const remainingMemberships = await UserChoir.findAll({
+            where: { userId: req.userId },
+            include: [{ model: Choir, attributes: ['id', 'name'] }]
+        });
+
+        if (remainingMemberships.length === 0) {
+            await user.destroy();
+            return res.status(200).send({ message: 'Dein Profil wurde gelöscht.', accountDeleted: true });
+        }
+
+        let activeChoirId = req.activeChoirId;
+        const stillHasActiveChoir = remainingMemberships.some(entry => entry.choirId === activeChoirId);
+        if (!stillHasActiveChoir || activeChoirId === choirId) {
+            activeChoirId = remainingMemberships[0].choirId;
+        }
+
+        const activeMembership = remainingMemberships.find(entry => entry.choirId === activeChoirId) || remainingMemberships[0];
+        const token = createAccessToken(user, activeChoirId);
+
+        res.status(200).send({
+            message: `Du hast den Chor ${choirName} verlassen.`,
+            accessToken: token,
+            activeChoir: activeMembership.choir || null,
+            accountDeleted: false
+        });
+    } catch (err) {
+        res.status(500).send({ message: err.message });
+    }
+};
+
+exports.deleteMe = async (req, res) => {
+    try {
+        const user = await User.findByPk(req.userId);
+        if (!user) {
+            return res.status(404).send({ message: 'User not found.' });
+        }
+
+        const memberships = await UserChoir.findAll({
+            where: { userId: req.userId },
+            include: [{ model: Choir, attributes: ['id', 'name'] }]
+        });
+
+        const reasons = [];
+        const openBorrowings = await countOpenBorrowings(req.userId);
+        if (openBorrowings > 0) {
+            reasons.push(openBorrowings === 1
+                ? 'Es besteht noch eine offene Ausleihe. Bitte gib diese zuerst zurück.'
+                : `Es bestehen noch ${openBorrowings} offene Ausleihen. Bitte gib diese zuerst zurück.`);
+        }
+
+        for (const membership of memberships) {
+            const roles = Array.isArray(membership.rolesInChoir) ? membership.rolesInChoir : [];
+            if (!roles.includes('choir_admin')) {
+                continue;
+            }
+            const lastAdmin = await isLastChoirAdmin(req.userId, membership.choirId);
+            if (lastAdmin) {
+                const choirName = membership.choir?.name || 'diesem Chor';
+                reasons.push(`Im Chor ${choirName} bist du der letzte Chor-Admin. Bitte übertrage die Rolle, bevor du dich abmeldest.`);
+            }
+        }
+
+        const restrictionMessage = buildRestrictionMessage(reasons);
+        if (restrictionMessage) {
+            return res.status(409).send({ message: restrictionMessage });
+        }
+
+        const userDetails = user.toJSON();
+        for (const membership of memberships) {
+            const choirId = membership.choirId;
+            await membership.destroy();
+            await ChoirLog.create({ choirId, userId: req.userId, action: 'member_leave', details: { selfService: true, systemExit: true } }).catch(() => {});
+            try {
+                await emailService.sendMemberLeftNotification(choirId, userDetails, { accountDeleted: true });
+            } catch (err) {
+                // Fehler beim Mailversand werden im Service geloggt
+            }
+        }
+
+        await user.destroy();
+
+        res.status(200).send({ message: 'Dein Profil wurde gelöscht.', accountDeleted: true });
     } catch (err) {
         res.status(500).send({ message: err.message });
     }

--- a/choir-app-backend/src/routes/user.routes.js
+++ b/choir-app-backend/src/routes/user.routes.js
@@ -11,4 +11,7 @@ router.put("/me", role.requireNonDemo, wrap(controller.updateMe));
 router.post("/me/donate", wrap(controller.registerDonation));
 router.get("/me/preferences", wrap(controller.getPreferences));
 router.put("/me/preferences", wrap(controller.updatePreferences));
+router.delete("/me/choirs/:choirId", role.requireNonDemo, wrap(controller.leaveChoir));
+router.delete("/me", role.requireNonDemo, wrap(controller.deleteMe));
+
 module.exports = router;

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -62,3 +62,10 @@ export interface UserInChoir extends User {
         registrationStatus: 'REGISTERED' | 'PENDING';
     }
 }
+
+export interface LeaveChoirResponse {
+  message: string;
+  accessToken?: string;
+  activeChoir?: Choir | null;
+  accountDeleted?: boolean;
+}

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { Piece } from '../models/piece';
 import { Composer } from '../models/composer';
 import { Category } from '../models/category';
-import { User, UserInChoir } from '../models/user';
+import { LeaveChoirResponse, User, UserInChoir } from '../models/user';
 import { LoginAttempt } from '../models/login-attempt';
 import { CreateEventResponse, Event } from '../models/event';
 import { MonthlyPlan } from '../models/monthly-plan';
@@ -883,7 +883,15 @@ export class ApiService {
     }
 
   registerDonation(amount: number): Observable<any> {
-        return this.userService.registerDonation(amount);
+    return this.userService.registerDonation(amount);
+  }
+
+  leaveChoir(choirId: number): Observable<LeaveChoirResponse> {
+    return this.userService.leaveChoir(choirId);
+  }
+
+  deleteMyAccount(): Observable<LeaveChoirResponse> {
+    return this.userService.deleteAccount();
   }
 
   getDonations(): Observable<Donation[]> {

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { User } from '../models/user';
+import { LeaveChoirResponse, User } from '../models/user';
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
@@ -52,5 +52,13 @@ export class UserService {
 
   registerDonation(amount: number): Observable<any> {
     return this.http.post(`${this.apiUrl}/users/me/donate`, { amount });
+  }
+
+  leaveChoir(choirId: number): Observable<LeaveChoirResponse> {
+    return this.http.delete<LeaveChoirResponse>(`${this.apiUrl}/users/me/choirs/${choirId}`);
+  }
+
+  deleteAccount(): Observable<LeaveChoirResponse> {
+    return this.http.delete<LeaveChoirResponse>(`${this.apiUrl}/users/me`);
   }
 }

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -138,10 +138,36 @@
           <mat-card-title>Verknüpfte Chöre</mat-card-title>
         </mat-card-header>
         <mat-card-content>
-         <div class="choir-name" *ngFor="let choir of choirs">
-            {{ choir.name }}
+          <div *ngIf="choirs.length === 0" class="choir-empty">
+            Du bist derzeit mit keinem Chor verknüpft.
+          </div>
+          <div class="choir-entry" *ngFor="let choir of choirs">
+            <div class="choir-name">{{ choir.name }}</div>
+            <button
+              mat-stroked-button
+              color="warn"
+              type="button"
+              (click)="onLeaveChoir(choir)"
+              [disabled]="currentUser?.roles?.includes('demo')"
+            >
+              Aus Chor abmelden
+            </button>
+          </div>
+          <div class="choir-hint" *ngIf="choirs.length === 1">
+            Das Verlassen dieses Chors löscht dein Profil vollständig.
           </div>
         </mat-card-content>
+        <mat-card-actions *ngIf="choirs.length > 1">
+          <button
+            mat-flat-button
+            color="warn"
+            type="button"
+            (click)="onDeleteAccount()"
+            [disabled]="currentUser?.roles?.includes('demo')"
+          >
+            Vom gesamten System abmelden
+          </button>
+        </mat-card-actions>
       </mat-card>
 
       <div class="actions-footer" *ngIf="!(currentUser?.roles?.includes('demo'))">

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.scss
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.scss
@@ -26,6 +26,31 @@
 .choir-name {
     font-size: 1.1rem;
     font-weight: 500;
+    flex: 1;
+}
+
+.choir-entry {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.choir-entry:last-child {
+    margin-bottom: 0;
+}
+
+.choir-empty {
+    color: #666;
+    font-size: 0.95rem;
+}
+
+.choir-hint {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+    color: #555;
 }
 
 .actions-footer {

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -1,16 +1,19 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators, ValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialog } from '@angular/material/dialog';
 
 import { MaterialModule } from '@modules/material.module';
 import { ApiService } from '@core/services/api.service';
-import { User } from '@core/models/user';
+import { LeaveChoirResponse, User } from '@core/models/user';
 import { Choir } from '@core/models/choir';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { AuthService } from '@core/services/auth.service';
 import { District } from '@core/models/district';
 import { Congregation } from '@core/models/congregation';
+import { ConfirmDialogComponent, ConfirmDialogData } from '@shared/components/confirm-dialog/confirm-dialog.component';
 
 export function passwordsMatchValidator(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
@@ -26,24 +29,28 @@ export function passwordsMatchValidator(): ValidatorFn {
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    MaterialModule
+    MaterialModule,
+    ConfirmDialogComponent
   ],
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.scss']
 })
-export class ProfileComponent implements OnInit {
+export class ProfileComponent implements OnInit, OnDestroy {
   profileForm: FormGroup;
   currentUser: User | null = null;
   isLoading = true;
   availableChoirs$: Observable<Choir[]>;
   districts: District[] = [];
   congregations: Congregation[] = [];
+  choirList: Choir[] = [];
+  private destroy$ = new Subject<void>();
 
   constructor(
     private fb: FormBuilder,
     private apiService: ApiService,
     private snackBar: MatSnackBar,
-    private authService: AuthService
+    private authService: AuthService,
+    private dialog: MatDialog
   ) {
     this.availableChoirs$ = this.authService.availableChoirs$;
     this.profileForm = this.fb.group({
@@ -67,6 +74,9 @@ export class ProfileComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.availableChoirs$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(choirs => this.choirList = Array.isArray(choirs) ? choirs : []);
     this.apiService.getDistricts().subscribe(ds => this.districts = ds);
     this.apiService.getCongregations().subscribe(cs => this.congregations = cs);
     this.apiService.getCurrentUser().subscribe({
@@ -99,6 +109,11 @@ export class ProfileComponent implements OnInit {
         this.isLoading = false;
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   onSubmit(): void {
@@ -145,6 +160,78 @@ export class ProfileComponent implements OnInit {
       error: (err) => {
         const errorMessage = err.error?.message || 'Profilaktualisierung fehlgeschlagen.';
         this.snackBar.open(errorMessage, 'Schließen', { duration: 5000,  verticalPosition: 'top'  });
+      }
+    });
+  }
+
+  onLeaveChoir(choir: Choir): void {
+    const multipleChoirs = this.choirList.length > 1;
+    const dialogData: ConfirmDialogData = {
+      title: 'Abmeldung bestätigen',
+      message: multipleChoirs
+        ? `Möchtest du dich wirklich vom Chor "${choir.name}" abmelden?`
+        : `Wenn du dich vom Chor "${choir.name}" abmeldest, wird dein Profil vollständig gelöscht.`,
+      confirmButtonText: 'Abmelden',
+      cancelButtonText: 'Abbrechen'
+    };
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, { data: dialogData });
+    dialogRef.afterClosed().subscribe(confirmed => {
+      if (!confirmed) {
+        return;
+      }
+      this.apiService.leaveChoir(choir.id).subscribe({
+        next: (response) => this.handleMembershipChange(response, `Du hast den Chor ${choir.name} verlassen.`),
+        error: (err) => {
+          const message = err.error?.message || 'Abmeldung fehlgeschlagen.';
+          this.snackBar.open(message, 'Schließen', { duration: 5000, verticalPosition: 'top' });
+        }
+      });
+    });
+  }
+
+  onDeleteAccount(): void {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: 'Vom System abmelden',
+        message: 'Möchtest du dich wirklich vom gesamten System abmelden? Dein Profil wird dauerhaft gelöscht.',
+        confirmButtonText: 'Profil löschen',
+        cancelButtonText: 'Abbrechen'
+      }
+    });
+    dialogRef.afterClosed().subscribe(confirmed => {
+      if (!confirmed) {
+        return;
+      }
+      this.apiService.deleteMyAccount().subscribe({
+        next: (response) => this.handleMembershipChange(response, 'Dein Profil wurde gelöscht.'),
+        error: (err) => {
+          const message = err.error?.message || 'Abmeldung fehlgeschlagen.';
+          this.snackBar.open(message, 'Schließen', { duration: 5000, verticalPosition: 'top' });
+        }
+      });
+    });
+  }
+
+  private handleMembershipChange(response: LeaveChoirResponse, fallback: string): void {
+    const message = response?.message || fallback;
+    if (response?.accountDeleted) {
+      this.snackBar.open(message, 'OK', { duration: 5000, verticalPosition: 'top' });
+      this.authService.logout();
+      return;
+    }
+
+    if (response?.accessToken) {
+      localStorage.setItem('auth-token', response.accessToken);
+    }
+
+    this.apiService.getCurrentUser().subscribe({
+      next: (user) => {
+        this.authService.setCurrentUser(user);
+        this.currentUser = user;
+        this.snackBar.open(message, 'OK', { duration: 4000, verticalPosition: 'top' });
+      },
+      error: () => {
+        this.snackBar.open(message, 'OK', { duration: 4000, verticalPosition: 'top' });
       }
     });
   }


### PR DESCRIPTION
## Summary
- add backend safeguards and endpoints so users can leave individual choirs or delete their account while preventing removals with open loans or last-admin status
- notify choir admins about self-removals via email and update JWTs when the active choir changes
- expose new profile actions in the frontend, including API helpers and UI controls for leaving choirs or the whole system

## Testing
- `npm test`
- `npm run lint` *(fails due to existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c92c035dc4832092238418c73f82d3