### PR TITLE
Align front-end role checks with choir memberships

### DIFF
--- a/choir-app-frontend/src/app/core/guards/program.guard.ts
+++ b/choir-app-frontend/src/app/core/guards/program.guard.ts
@@ -9,11 +9,13 @@ export class ProgramGuard implements CanActivate {
   constructor(private auth: AuthService, private router: Router) {}
 
   canActivate(): Observable<boolean | UrlTree> {
-    return combineLatest([this.auth.isChoirAdmin$, this.auth.isDirector$, this.auth.activeChoir$]).pipe(
-      map(([isChoirAdmin, isDirector, choir]) => {
-        const allowed = isChoirAdmin || isDirector;
+    return combineLatest([this.auth.isAdmin$, this.auth.activeChoir$]).pipe(
+      map(([isAdmin, choir]) => {
         const moduleEnabled = choir?.modules?.programs !== false;
-        return allowed && moduleEnabled ? true : this.router.createUrlTree(['/dashboard']);
+        const roles = choir?.membership?.rolesInChoir ?? [];
+        const choirPrivilege = roles.some(role => ['choir_admin', 'choirleiter', 'director'].includes(role));
+        const allowed = moduleEnabled && (isAdmin || choirPrivilege);
+        return allowed ? true : this.router.createUrlTree(['/dashboard']);
       })
     );
   }

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -1,4 +1,4 @@
-export type ChoirRole = 'director' | 'choir_admin' | 'organist' | 'singer';
+export type ChoirRole = 'director' | 'choirleiter' | 'choir_admin' | 'organist' | 'singer';
 
 export interface ChoirMembership {
     rolesInChoir: ChoirRole[];

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -80,7 +80,12 @@ export class AuthService {
     );
 
     this.isDirector$ = combineLatest([this.isAdmin$, this.choirRoles$]).pipe(
-      map(([isAdmin, choirRoles]) => isAdmin || choirRoles.includes('director')),
+      map(([isAdmin, choirRoles]) => {
+        if (isAdmin) {
+          return true;
+        }
+        return choirRoles.some(role => role === 'director' || role === 'choirleiter');
+      }),
       distinctUntilChanged()
     );
 
@@ -289,7 +294,8 @@ export class AuthService {
     if (hasGlobalPrivilege) {
       return false;
     }
-    const hasChoirPrivilege = choirRoles.some(role => role === 'choir_admin' || role === 'director' || role === 'organist');
+    const hasChoirPrivilege = choirRoles.some(role =>
+      role === 'choir_admin' || role === 'director' || role === 'choirleiter' || role === 'organist');
     return !hasChoirPrivilege;
   }
 }

--- a/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
+++ b/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
@@ -34,7 +34,8 @@ export class MenuVisibilityService {
       keys.forEach(k => visibility[k] = false);
       if (choir) {
         const modules = choir.modules || {};
-        const hasChoirPrivilege = choirRoles.some(role => ['director', 'choir_admin', 'organist'].includes(role));
+        const hasChoirPrivilege = choirRoles.some(role =>
+          ['director', 'choirleiter', 'choir_admin', 'organist'].includes(role));
         const hasGlobalPrivilege = globalRoles.some(role => role === 'admin' || role === 'librarian');
         const hasPrivilegedRole = hasChoirPrivilege || hasGlobalPrivilege;
         const base: MenuVisibility = {

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/add-member-dialog/add-member-dialog.component.ts
@@ -26,7 +26,7 @@ export class AddMemberDialogComponent implements OnInit {
   ) {
     this.form = this.fb.group({
       user: ['', Validators.required],
-      roles: [['director'], Validators.required]
+      roles: [['choirleiter'], Validators.required]
     });
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-choirs/choir-dialog/choir-dialog.component.ts
@@ -91,7 +91,7 @@ export class ChoirDialogComponent implements OnInit {
   toggleOrganist(user: UserInChoir, checked: boolean): void {
     if (!this.data?.id) return;
     const roles = user.membership?.rolesInChoir || [];
-    const updated = (checked ? [...new Set([...roles, 'organist'])] : roles.filter(r => r !== 'organist')) as ('director' | 'choir_admin' | 'organist' | 'singer')[];
+    const updated = (checked ? [...new Set([...roles, 'organist'])] : roles.filter(r => r !== 'organist')) as ('director' | 'choirleiter' | 'choir_admin' | 'organist' | 'singer')[];
     this.api.updateChoirMemberAdmin(this.data.id, user.id, { rolesInChoir: updated }).subscribe({
       next: () => user.membership!.rolesInChoir = updated,
       error: () => this.snackBar.open('Fehler beim Aktualisieren', 'Schließen')

--- a/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/invite-user-dialog/invite-user-dialog.component.ts
@@ -19,7 +19,7 @@ export class InviteUserDialogComponent {
   ) {
     this.inviteForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
-      roles: [['director'], Validators.required]
+      roles: [['choirleiter'], Validators.required]
     });
   }
 

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.ts
@@ -344,7 +344,7 @@ export class ManageChoirComponent implements OnInit {
   }
 
 
-  onRolesChange(user: UserInChoir, roles: ('director' | 'choir_admin' | 'organist' | 'singer')[]): void {
+  onRolesChange(user: UserInChoir, roles: ('director' | 'choirleiter' | 'choir_admin' | 'organist' | 'singer')[]): void {
     if (!this.isChoirAdmin) return;
     const previous = [...(user.membership?.rolesInChoir || [])];
     user.membership!.rolesInChoir = roles;

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -186,7 +186,10 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
       if (this.isChoirAdmin) {
         this.api.getChoirMembers().subscribe(m => {
           this.members = m;
-          this.directors = m.filter(u => u.membership?.rolesInChoir?.includes('director') || u.membership?.rolesInChoir?.includes('choir_admin'));
+          this.directors = m.filter(u => {
+            const roles = u.membership?.rolesInChoir || [];
+            return roles.includes('director') || roles.includes('choirleiter') || roles.includes('choir_admin');
+          });
           this.organists = m.filter(u => u.membership?.rolesInChoir?.includes('organist'));
           this.updateCounterPlan();
         });
@@ -346,6 +349,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     if (!this.plan) return;
     const people = this.members.filter(m =>
       m.membership?.rolesInChoir?.includes('director') ||
+      m.membership?.rolesInChoir?.includes('choirleiter') ||
       m.membership?.rolesInChoir?.includes('choir_admin') ||
       m.membership?.rolesInChoir?.includes('organist'));
     const ref = this.dialog.open(RequestAvailabilityDialogComponent, { data: { members: people } });

--- a/choir-app-frontend/src/app/features/participation/participation.component.ts
+++ b/choir-app-frontend/src/app/features/participation/participation.component.ts
@@ -48,8 +48,10 @@ export class ParticipationComponent implements OnInit {
   constructor(private api: ApiService, private auth: AuthService) {}
 
   ngOnInit(): void {
-    combineLatest([this.auth.isChoirAdmin$, this.auth.isDirector$]).subscribe(([isChoirAdmin, isDirector]) => {
-      this.isChoirAdmin = isChoirAdmin || isDirector;
+    combineLatest([this.auth.isAdmin$, this.auth.activeChoir$]).subscribe(([isAdmin, choir]) => {
+      const roles = choir?.membership?.rolesInChoir ?? [];
+      const privilegedRoles = ['choir_admin', 'choirleiter', 'director'];
+      this.isChoirAdmin = isAdmin || roles.some(role => privilegedRoles.includes(role));
     });
     this.loadMembers();
     this.loadEvents();

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
@@ -3,8 +3,7 @@ import { HelpWizardComponent } from './help-wizard.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { AuthService } from '@core/services/auth.service';
 import { MenuVisibilityService } from '@core/services/menu-visibility.service';
-import { BehaviorSubject, combineLatest, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { BehaviorSubject, of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('HelpWizardComponent', () => {
@@ -14,19 +13,15 @@ describe('HelpWizardComponent', () => {
   beforeEach(async () => {
     const globalRolesSubject = new BehaviorSubject<string[]>(['user']);
     const choirRolesSubject = new BehaviorSubject<string[]>(['singer']);
-    const activeChoirSubject = new BehaviorSubject<any>({ modules: { singerMenu: { events: false, participation: false } } });
-    const isSingerOnly$ = combineLatest([globalRolesSubject.asObservable(), choirRolesSubject.asObservable()]).pipe(
-      map(([globalRoles, choirRoles]) => {
-        const hasGlobalPrivilege = globalRoles.some(role => role === 'admin' || role === 'librarian');
-        const hasChoirPrivilege = choirRoles.some(role => ['choir_admin', 'director', 'organist'].includes(role));
-        return choirRoles.includes('singer') && !hasGlobalPrivilege && !hasChoirPrivilege;
-      })
-    );
+    const activeChoirSubject = new BehaviorSubject<any>({
+      modules: { singerMenu: { events: false, participation: false } },
+      membership: { rolesInChoir: ['singer'] }
+    });
     const authServiceMock = {
       globalRoles$: globalRolesSubject.asObservable(),
       choirRoles$: choirRolesSubject.asObservable(),
       activeChoir$: activeChoirSubject,
-      isSingerOnly$,
+      isSingerOnly$: of(true),
       isAdmin$: of(false),
       isChoirAdmin$: of(false),
       isDirector$: of(false),


### PR DESCRIPTION
## Summary
- merge global and active-choir roles for the dashboard header and translate the new choirleiter role
- base help wizard, participation view, and the programs guard on choir membership roles with admin overrides
- update monthly plan filtering and choir management forms to recognise choirleiter membership and default invitations accordingly

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c944f9513c83208a12d8b24901f6d2