### PR TITLE
test: add role-aware backend and frontend specs

### DIFF
--- a/choir-app-backend/tests/choir-management.controller.test.js
+++ b/choir-app-backend/tests/choir-management.controller.test.js
@@ -4,15 +4,18 @@ process.env.DB_DIALECT = 'sqlite';
 process.env.DB_NAME = ':memory:';
 
 const db = require('../src/models');
+const { createUserWithRoles } = require('./utils/userFactory');
 const controller = require('../src/controllers/choir-management.controller');
 
 (async () => {
   try {
     await db.sequelize.sync({ force: true });
     const choir = await db.choir.create({ name: 'Test Choir' });
-    const adminUser = await db.user.create({ email: 'a@example.com', roles: ['admin'] });
-    const member = await db.user.create({ email: 'u@example.com', roles: ['user'] });
-    await choir.addUser(member, { through: { rolesInChoir: ['choirleiter'] } });
+    const adminUser = await createUserWithRoles(db, { email: 'a@example.com', globalRoles: ['admin'] });
+    const member = await createUserWithRoles(db, {
+      email: 'u@example.com',
+      choirMemberships: [{ choirId: choir.id, rolesInChoir: ['choirleiter'] }]
+    });
 
     const res = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
 
@@ -27,10 +30,26 @@ const controller = require('../src/controllers/choir-management.controller');
     await controller.updateMyChoir({ activeChoirId: choir.id, userId: adminUser.id, userRoles: ['admin'], body: { modules: { dienstplan: false } } }, res);
     assert.strictEqual(res.statusCode, 200, 'admin should change modules');
 
-    const hidden = await db.user.create({ email: 'h@example.com', roles: ['user'], firstName: 'H', name: 'Hidden', street: 's', postalCode: '1', city: 'c', shareWithChoir: false });
-    const shared = await db.user.create({ email: 's@example.com', roles: ['user'], firstName: 'S', name: 'Shared', street: 's', postalCode: '1', city: 'c', shareWithChoir: true });
-    await choir.addUser(hidden, { through: { rolesInChoir: ['singer'], registrationStatus: 'REGISTERED' } });
-    await choir.addUser(shared, { through: { rolesInChoir: ['singer'], registrationStatus: 'REGISTERED' } });
+    const hidden = await createUserWithRoles(db, {
+      email: 'h@example.com',
+      firstName: 'H',
+      name: 'Hidden',
+      street: 's',
+      postalCode: '1',
+      city: 'c',
+      shareWithChoir: false,
+      choirMemberships: [{ choirId: choir.id, rolesInChoir: ['singer'], registrationStatus: 'REGISTERED' }]
+    });
+    const shared = await createUserWithRoles(db, {
+      email: 's@example.com',
+      firstName: 'S',
+      name: 'Shared',
+      street: 's',
+      postalCode: '1',
+      city: 'c',
+      shareWithChoir: true,
+      choirMemberships: [{ choirId: choir.id, rolesInChoir: ['singer'], registrationStatus: 'REGISTERED' }]
+    });
 
     await controller.getChoirMembers({ activeChoirId: choir.id, userRoles: ['user'] }, res);
     assert.strictEqual(res.statusCode, 200, 'should fetch members');

--- a/choir-app-backend/tests/role.middleware.test.js
+++ b/choir-app-backend/tests/role.middleware.test.js
@@ -6,6 +6,7 @@ process.env.DB_DIALECT = 'sqlite';
 process.env.DB_NAME = ':memory:';
 
 const db = require('../src/models');
+const { createUserWithRoles } = require('./utils/userFactory');
 const { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector, requireDirectorOrHigher } = require('../src/middleware/role.middleware');
 
 async function sendRequest(middleware, context) {
@@ -30,14 +31,20 @@ async function sendRequest(middleware, context) {
     // Create test data for choir admin checks
     const choir = await db.choir.create({ name: 'Test Choir' });
     const otherChoir = await db.choir.create({ name: 'Second Choir' });
-    const admin = await db.user.create({ email: 'a@example.com', roles: ['admin'] });
-    const choirAdmin = await db.user.create({ email: 'c@example.com', roles: ['user'] });
-    const choirDirector = await db.user.create({ email: 'd@example.com', roles: ['user'] });
-    const normal = await db.user.create({ email: 'n@example.com', roles: ['user'] });
-    const otherChoirAdmin = await db.user.create({ email: 'oc@example.com', roles: ['user'] });
-    await db.user_choir.create({ userId: choirAdmin.id, choirId: choir.id, rolesInChoir: ['choir_admin'] });
-    await db.user_choir.create({ userId: choirDirector.id, choirId: choir.id, rolesInChoir: ['choirleiter'] });
-    await db.user_choir.create({ userId: otherChoirAdmin.id, choirId: otherChoir.id, rolesInChoir: ['choir_admin'] });
+    const admin = await createUserWithRoles(db, { email: 'a@example.com', globalRoles: ['admin'] });
+    const choirAdmin = await createUserWithRoles(db, {
+      email: 'c@example.com',
+      choirMemberships: [{ choirId: choir.id, rolesInChoir: ['choir_admin'] }]
+    });
+    const choirDirector = await createUserWithRoles(db, {
+      email: 'd@example.com',
+      choirMemberships: [{ choirId: choir.id, rolesInChoir: ['choirleiter'] }]
+    });
+    const normal = await createUserWithRoles(db, { email: 'n@example.com' });
+    const otherChoirAdmin = await createUserWithRoles(db, {
+      email: 'oc@example.com',
+      choirMemberships: [{ choirId: otherChoir.id, rolesInChoir: ['choir_admin'] }]
+    });
 
     // requireNonDemo success
     let res = await sendRequest(requireNonDemo, { userRoles: ['admin'] });

--- a/choir-app-backend/tests/utils/userFactory.js
+++ b/choir-app-backend/tests/utils/userFactory.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+
+/**
+ * Helper to create a user with optional choir memberships for tests.
+ *
+ * @param {import('../../src/models')} db - The database models instance.
+ * @param {Object} options
+ * @param {string} options.email - Email for the new user.
+ * @param {string[]} [options.globalRoles=['user']] - Global application roles.
+ * @param {Object[]} [options.choirMemberships] - Choir specific roles.
+ * @returns {Promise<import('../../src/models').user>} The persisted user instance.
+ */
+async function createUserWithRoles(db, { email, globalRoles = ['user'], choirMemberships = [], ...attributes }) {
+  assert(email, 'Email is required for test users');
+  const user = await db.user.create({ email, roles: globalRoles, ...attributes });
+
+  for (const membership of choirMemberships) {
+    if (!membership) continue;
+    const { choirId, choir, rolesInChoir = ['singer'], ...rest } = membership;
+    const resolvedChoirId = choirId ?? choir?.id;
+    if (!resolvedChoirId) {
+      throw new Error('choirMemberships entries require a choirId or choir with id');
+    }
+    await db.user_choir.create({
+      userId: user.id,
+      choirId: resolvedChoirId,
+      rolesInChoir,
+      ...rest
+    });
+  }
+
+  return user;
+}
+
+module.exports = { createUserWithRoles };

--- a/choir-app-frontend/src/app/core/guards/admin-guard.spec.ts
+++ b/choir-app-frontend/src/app/core/guards/admin-guard.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+
+import { AdminGuard } from './admin-guard';
+import { AuthService } from '../services/auth.service';
+
+describe('AdminGuard', () => {
+  let guard: AdminGuard;
+  let isAdminSubject: BehaviorSubject<boolean>;
+  let router: jasmine.SpyObj<Router>;
+  let redirectTree: UrlTree;
+
+  beforeEach(() => {
+    isAdminSubject = new BehaviorSubject<boolean>(false);
+    router = jasmine.createSpyObj('Router', ['createUrlTree']);
+    redirectTree = {} as UrlTree;
+    router.createUrlTree.and.returnValue(redirectTree);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AdminGuard,
+        { provide: AuthService, useValue: { isAdmin$: isAdminSubject.asObservable() } },
+        { provide: Router, useValue: router }
+      ]
+    });
+
+    guard = TestBed.inject(AdminGuard);
+  });
+
+  it('allows access for global admins', async () => {
+    isAdminSubject.next(true);
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBeTrue();
+  });
+
+  it('redirects non-admin users to the dashboard', async () => {
+    isAdminSubject.next(false);
+    const result = await firstValueFrom(guard.canActivate());
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/dashboard']);
+    expect(result).toEqual(redirectTree);
+  });
+});

--- a/choir-app-frontend/src/app/core/guards/choir-admin.guard.spec.ts
+++ b/choir-app-frontend/src/app/core/guards/choir-admin.guard.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { BehaviorSubject, firstValueFrom, of } from 'rxjs';
+
+import { ChoirAdminGuard } from './choir-admin.guard';
+import { AuthService } from '../services/auth.service';
+import { ApiService } from '../services/api.service';
+
+describe('ChoirAdminGuard', () => {
+  let guard: ChoirAdminGuard;
+  let isAdminSubject: BehaviorSubject<boolean>;
+  let router: jasmine.SpyObj<Router>;
+  let redirectTree: UrlTree;
+  let apiService: { checkChoirAdminStatus: jasmine.Spy };
+
+  beforeEach(() => {
+    isAdminSubject = new BehaviorSubject<boolean>(false);
+    router = jasmine.createSpyObj('Router', ['createUrlTree']);
+    redirectTree = {} as UrlTree;
+    router.createUrlTree.and.returnValue(redirectTree);
+    apiService = {
+      checkChoirAdminStatus: jasmine.createSpy('checkChoirAdminStatus').and.returnValue(of({ isChoirAdmin: false }))
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ChoirAdminGuard,
+        { provide: AuthService, useValue: { isAdmin$: isAdminSubject.asObservable() } },
+        { provide: ApiService, useValue: apiService },
+        { provide: Router, useValue: router }
+      ]
+    });
+
+    guard = TestBed.inject(ChoirAdminGuard);
+  });
+
+  it('allows global admins regardless of choir membership', async () => {
+    isAdminSubject.next(true);
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBeTrue();
+  });
+
+  it('allows choir admins returned by the API', async () => {
+    apiService.checkChoirAdminStatus.and.returnValue(of({ isChoirAdmin: true }));
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBeTrue();
+  });
+
+  it('redirects users without sufficient privileges', async () => {
+    apiService.checkChoirAdminStatus.and.returnValue(of({ isChoirAdmin: false }));
+    const result = await firstValueFrom(guard.canActivate());
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/collections']);
+    expect(result).toEqual(redirectTree);
+  });
+});

--- a/choir-app-frontend/src/app/core/guards/program.guard.spec.ts
+++ b/choir-app-frontend/src/app/core/guards/program.guard.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+
+import { ProgramGuard } from './program.guard';
+import { AuthService } from '../services/auth.service';
+
+describe('ProgramGuard', () => {
+  let guard: ProgramGuard;
+  let isAdminSubject: BehaviorSubject<boolean>;
+  let activeChoirSubject: BehaviorSubject<any>;
+  let router: jasmine.SpyObj<Router>;
+  let redirectTree: UrlTree;
+
+  beforeEach(() => {
+    isAdminSubject = new BehaviorSubject<boolean>(false);
+    activeChoirSubject = new BehaviorSubject<any>(null);
+    router = jasmine.createSpyObj('Router', ['createUrlTree']);
+    redirectTree = {} as UrlTree;
+    router.createUrlTree.and.returnValue(redirectTree);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ProgramGuard,
+        {
+          provide: AuthService,
+          useValue: {
+            isAdmin$: isAdminSubject.asObservable(),
+            activeChoir$: activeChoirSubject.asObservable()
+          }
+        },
+        { provide: Router, useValue: router }
+      ]
+    });
+
+    guard = TestBed.inject(ProgramGuard);
+  });
+
+  it('allows access when choir admin and module enabled', async () => {
+    activeChoirSubject.next({ modules: { programs: true }, membership: { rolesInChoir: ['choir_admin'] } });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBeTrue();
+  });
+
+  it('allows access for global admins even without choir privileges', async () => {
+    isAdminSubject.next(true);
+    activeChoirSubject.next({ modules: { programs: true }, membership: { rolesInChoir: ['singer'] } });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBeTrue();
+  });
+
+  it('redirects when programs module is disabled', async () => {
+    isAdminSubject.next(true);
+    activeChoirSubject.next({ modules: { programs: false }, membership: { rolesInChoir: ['choir_admin'] } });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/dashboard']);
+    expect(result).toEqual(redirectTree);
+  });
+
+  it('redirects singer-only users even if the module is available', async () => {
+    activeChoirSubject.next({ modules: { programs: true }, membership: { rolesInChoir: ['singer'] } });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/dashboard']);
+    expect(result).toEqual(redirectTree);
+  });
+});

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -148,6 +148,17 @@ describe('MainLayoutComponent', () => {
     expect(visible).toBeFalse();
   });
 
+  it('shows participation for global admins even when choir roles are singer only', async () => {
+    globalRolesSubject.next(['admin']);
+    choirRolesSubject.next(['singer']);
+    currentUserSubject.next({ roles: ['admin'] });
+    activeChoirSubject.next({ modules: {}, membership: { rolesInChoir: ['singer'] } });
+    fixture.detectChanges();
+    const item = component.navItems.find(i => i.key === 'participation');
+    const visible = await firstValueFrom(item!.visibleSubject!);
+    expect(visible).toBeTrue();
+  });
+
   it('translates user roles and updates tooltip on changes', async () => {
     let role = await firstValueFrom(component.userRole$);
     expect(role).toBe('Sänger');

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HelpService } from '@core/services/help.service';
 import { AuthService } from '@core/services/auth.service';
 import { MenuVisibilityService } from '@core/services/menu-visibility.service';
@@ -70,7 +71,7 @@ describe('MainLayoutComponent', () => {
     const themeMock = { getCurrentTheme: () => 'light', setTheme: () => {} };
     const cartMock = { items$: of([]) };
     await TestBed.configureTestingModule({
-      imports: [MainLayoutComponent, HttpClientTestingModule, RouterTestingModule],
+      imports: [MainLayoutComponent, HttpClientTestingModule, RouterTestingModule, NoopAnimationsModule],
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },

--- a/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
+++ b/choir-app-frontend/src/app/shared/components/help-wizard/help-wizard.component.spec.ts
@@ -3,17 +3,20 @@ import { HelpWizardComponent } from './help-wizard.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { AuthService } from '@core/services/auth.service';
 import { MenuVisibilityService } from '@core/services/menu-visibility.service';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('HelpWizardComponent', () => {
   let component: HelpWizardComponent;
   let fixture: ComponentFixture<HelpWizardComponent>;
+  let globalRolesSubject: BehaviorSubject<string[]>;
+  let choirRolesSubject: BehaviorSubject<string[]>;
+  let activeChoirSubject: BehaviorSubject<any>;
 
   beforeEach(async () => {
-    const globalRolesSubject = new BehaviorSubject<string[]>(['user']);
-    const choirRolesSubject = new BehaviorSubject<string[]>(['singer']);
-    const activeChoirSubject = new BehaviorSubject<any>({
+    globalRolesSubject = new BehaviorSubject<string[]>(['user']);
+    choirRolesSubject = new BehaviorSubject<string[]>(['singer']);
+    activeChoirSubject = new BehaviorSubject<any>({
       modules: { singerMenu: { events: false, participation: false } },
       membership: { rolesInChoir: ['singer'] }
     });
@@ -51,5 +54,11 @@ describe('HelpWizardComponent', () => {
         done();
       });
     });
+  });
+
+  it('shows privileged entries when singer also has a global admin role', async () => {
+    globalRolesSubject.next(['admin']);
+    const participationVisible = await firstValueFrom(component.menuVisible('participation'));
+    expect(participationVisible).toBeTrue();
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable test helper for creating users with global and choir roles and update the role-dependent backend specs to use it
- add Angular guard specs to verify admin, choir admin, and program access combinations of global and choir roles
- extend main layout and help wizard specs to cover singer visibility when global admin privileges are present

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9612042308320ac1f9d3e45fac5da