### PR TITLE
Replace legacy Chorleiter role with director

### DIFF
--- a/choir-app-backend/src/middleware/role.middleware.js
+++ b/choir-app-backend/src/middleware/role.middleware.js
@@ -1,6 +1,6 @@
 const db = require('../models');
 
-const DIRECTOR_ROLES = ['choirleiter', 'director'];
+const DIRECTOR_ROLES = ['director'];
 
 async function getActiveChoirMembership(req) {
     if (!req.userId || !req.activeChoirId) {
@@ -71,7 +71,7 @@ async function requireChoirAdmin(req, res, next) {
 }
 
 /**
- * Middleware that allows directors (choirleiter) or choir admins of the active
+ * Middleware that allows directors or choir admins of the active
  * choir as well as global librarians and admins.
  *
  * Global access is validated through {@link req.userRoles}; choir-specific
@@ -86,7 +86,7 @@ async function requireDirector(req, res, next) {
         if (hasDirectorRole) {
             return next();
         }
-        return res.status(403).send({ message: 'Require Choirleiter Role!' });
+        return res.status(403).send({ message: 'Require Director Role!' });
     } catch (err) {
         return res.status(500).send({ message: 'Error checking permissions.' });
     }
@@ -103,7 +103,7 @@ function requireLibrarian(req, res, next) {
 }
 
 /**
- * Middleware that allows directors (choirleiter) or choir admins of the active
+ * Middleware that allows directors or choir admins of the active
  * choir in addition to global admins.
  *
  * Global access is validated through {@link req.userRoles}; choir-specific
@@ -118,7 +118,7 @@ async function requireDirectorOrHigher(req, res, next) {
         if (hasDirectorRole) {
             return next();
         }
-        return res.status(403).send({ message: 'Require Choirleiter Role!' });
+        return res.status(403).send({ message: 'Require Director Role!' });
     } catch (err) {
         return res.status(500).send({ message: 'Error checking permissions.' });
     }

--- a/choir-app-backend/tests/choir-management.controller.test.js
+++ b/choir-app-backend/tests/choir-management.controller.test.js
@@ -12,12 +12,12 @@ const controller = require('../src/controllers/choir-management.controller');
     const choir = await db.choir.create({ name: 'Test Choir' });
     const adminUser = await db.user.create({ email: 'a@example.com', roles: ['admin'] });
     const member = await db.user.create({ email: 'u@example.com', roles: ['user'] });
-    await choir.addUser(member, { through: { rolesInChoir: ['choirleiter'] } });
+    await choir.addUser(member, { through: { rolesInChoir: ['director'] } });
 
     const res = { status(code) { this.statusCode = code; return this; }, send(data) { this.data = data; } };
 
     await controller.updateMyChoir({ activeChoirId: choir.id, userId: member.id, userRoles: ['user'], body: { modules: { dienstplan: true } } }, res);
-    assert.strictEqual(res.statusCode, 403, 'choirleiter should not change modules');
+    assert.strictEqual(res.statusCode, 403, 'director should not change modules');
 
     const assoc = await db.user_choir.findOne({ where: { userId: member.id, choirId: choir.id } });
     await assoc.update({ rolesInChoir: ['choir_admin'] });

--- a/choir-app-backend/tests/role.middleware.test.js
+++ b/choir-app-backend/tests/role.middleware.test.js
@@ -36,7 +36,7 @@ async function sendRequest(middleware, context) {
     const normal = await db.user.create({ email: 'n@example.com', roles: ['user'] });
     const otherChoirAdmin = await db.user.create({ email: 'oc@example.com', roles: ['user'] });
     await db.user_choir.create({ userId: choirAdmin.id, choirId: choir.id, rolesInChoir: ['choir_admin'] });
-    await db.user_choir.create({ userId: choirDirector.id, choirId: choir.id, rolesInChoir: ['choirleiter'] });
+    await db.user_choir.create({ userId: choirDirector.id, choirId: choir.id, rolesInChoir: ['director'] });
     await db.user_choir.create({ userId: otherChoirAdmin.id, choirId: otherChoir.id, rolesInChoir: ['choir_admin'] });
 
     // requireNonDemo success


### PR DESCRIPTION
## Summary
- restrict choir membership roles to the canonical set and normalize legacy Chorleiter values to the director role
- update role middleware messaging to reference the director role only
- refresh backend tests to expect the director role instead of the legacy name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9626b80b08320ad87f2d391cdf94d