### PR TITLE
refactor: rely on auth choir admin status

### DIFF
--- a/choir-app-frontend/src/app/core/services/admin.service.ts
+++ b/choir-app-frontend/src/app/core/services/admin.service.ts
@@ -133,10 +133,6 @@ export class AdminService {
     return this.http.post(`${this.apiUrl}/backup/import`, formData);
   }
 
-  checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {
-    return this.http.get<{ isChoirAdmin: boolean }>(`${this.apiUrl}/auth/check-choir-admin`);
-  }
-
   getStatistics(startDate?: Date | string, endDate?: Date | string, activeMonths?: number, global?: boolean): Observable<StatsSummary> {
     const params: any = {};
     if (startDate) {

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -870,10 +870,6 @@ export class ApiService {
     return this.adminService.updateSystemAdminEmail({ value });
   }
 
-  checkChoirAdminStatus(): Observable<{ isChoirAdmin: boolean }> {
-    return this.adminService.checkChoirAdminStatus();
-  }
-
   getStatistics(startDate?: Date, endDate?: Date, activeMonths?: number, global?: boolean): Observable<StatsSummary> {
     return this.adminService.getStatistics(startDate, endDate, activeMonths, global);
   }

--- a/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-edit/collection-edit.component.ts
@@ -138,9 +138,9 @@ export class CollectionEditComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     ngOnInit(): void {
-        combineLatest([this.authService.isAdmin$, this.apiService.checkChoirAdminStatus()]).subscribe(([isAdmin, s]) => {
+        combineLatest([this.authService.isAdmin$, this.authService.isChoirAdmin$]).subscribe(([isAdmin, isChoirAdmin]) => {
             this.isAdmin = isAdmin;
-            this.isChoirAdmin = s.isChoirAdmin;
+            this.isChoirAdmin = isChoirAdmin;
             if (!this.isAdmin && !this.isChoirAdmin) {
                 this.router.navigate(['/collections']);
                 this.snackBar.open('Keine Berechtigung Sammlungen zu bearbeiten.', 'Schließen');

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.spec.ts
@@ -21,12 +21,11 @@ describe('CollectionListComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialog, useValue: {} },
         { provide: MatSnackBar, useValue: { open: () => {} } },
-        { provide: AuthService, useValue: { isAdmin$: of(false) } },
+        { provide: AuthService, useValue: { isAdmin$: of(false), isChoirAdmin$: of(false), isDirector$: of(false) } },
         {
           provide: ApiService,
           useValue: {
             getCollections: () => of([]),
-            checkChoirAdminStatus: () => of({ isChoirAdmin: false }),
             getLibraryItems: () => of([])
           }
         }

--- a/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
+++ b/choir-app-frontend/src/app/features/collections/collection-list/collection-list.component.ts
@@ -86,9 +86,6 @@ export class CollectionListComponent implements OnInit, AfterViewInit {
         }
       });
     });
-    this.apiService.checkChoirAdminStatus().subscribe(r => {
-      this.isChoirAdmin = r.isChoirAdmin;
-    });
     this.authService.isChoirAdmin$.subscribe(v => this.isChoirAdmin = v);
     this.authService.isDirector$.subscribe(v => this.isDirector = v);
     this.authService.isAdmin$.subscribe(v => this.isAdmin = v);

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -49,6 +49,7 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
   counterPlanRows: { user: UserInChoir; assignments: Record<string, string>; }[] = [];
 
   private userSub?: Subscription;
+  private roleSub?: Subscription;
 
   timestamp(date: string | Date): string {
     return parseDateOnly(date).getTime().toString();
@@ -179,8 +180,8 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
     });
 
     this.userSub = this.auth.currentUser$.subscribe(u => this.currentUserId = u?.id || null);
-    this.api.checkChoirAdminStatus().subscribe(r => {
-      this.isChoirAdmin = r.isChoirAdmin;
+    this.roleSub = this.auth.isChoirAdmin$.subscribe(isChoirAdmin => {
+      this.isChoirAdmin = isChoirAdmin;
       this.updateDisplayedColumns();
       if (this.isChoirAdmin) {
         this.api.getChoirMembers().subscribe(m => {
@@ -192,6 +193,13 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
           this.organists = m.filter(u => u.membership?.rolesInChoir?.includes('organist'));
           this.updateCounterPlan();
         });
+        this.loadAvailabilities(this.selectedYear, this.selectedMonth);
+      } else {
+        this.members = [];
+        this.directors = [];
+        this.organists = [];
+        this.availabilityMap = {};
+        this.updateCounterPlan();
       }
     });
   }
@@ -404,5 +412,6 @@ export class MonthlyPlanComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     if (this.userSub) this.userSub.unsubscribe();
+    if (this.roleSub) this.roleSub.unsubscribe();
   }
 }


### PR DESCRIPTION
## Summary
- use `AuthService.isChoirAdmin$` in the resolver and collection features instead of calling `ApiService.checkChoirAdminStatus`
- react to choir admin status changes in the monthly plan component to refresh member data and clear state when permissions change
- remove the unused `checkChoirAdminStatus` wrappers from the API/admin services and update tests accordingly

## Testing
- npm run lint --prefix choir-app-frontend

------
https://chatgpt.com/codex/tasks/task_e_68c9a5169904832083928bd3ffa7d0bc