### PR TITLE
Fix choir role normalization type inference

### DIFF
--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -204,18 +204,18 @@ export class AuthService {
       rolesInChoir: [],
       registrationStatus: 'REGISTERED'
     };
-    const roles = membership.rolesInChoir ?? [];
+    const roles: ChoirRole[] = membership.rolesInChoir ?? [];
     const hasRole = roles.includes('choir_admin');
 
     if (hasRole === isChoirAdmin) {
       return;
     }
 
-    const updatedRoles = isChoirAdmin
+    const updatedRoles: ChoirRole[] = isChoirAdmin
       ? [...roles, 'choir_admin']
       : roles.filter(role => role !== 'choir_admin');
 
-    const normalizedRoles = this.normalizeRoles(updatedRoles);
+    const normalizedRoles = this.normalizeRoles<ChoirRole>(updatedRoles);
 
     const updatedActiveChoir: Choir = {
       ...activeChoir,


### PR DESCRIPTION
## Summary
- ensure choir admin role updates keep choir role arrays typed as `ChoirRole`
- normalize choir membership updates with the typed helper to avoid leaking plain string arrays into the user model

## Testing
- npm test *(fails: ChromeHeadless is missing libatk-1.0.so.0 in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b628bdc883208fd38157eb1cc229