### PR TITLE
Add dashboard contact selection and contact tile

### DIFF
--- a/choir-app-backend/src/controllers/admin.controller.js
+++ b/choir-app-backend/src/controllers/admin.controller.js
@@ -90,7 +90,7 @@ exports.getAllUsers = async (req, res) => {
     try {
         const users = await db.user.findAll({
             order: [['name', 'ASC']],
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin', 'resetToken', 'resetTokenExpiry'],
+            attributes: ['id', 'firstName', 'name', 'email', 'phone', 'roles', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin', 'resetToken', 'resetTokenExpiry'],
             include: [{
                 model: db.choir,
                 as: 'choirs',
@@ -107,7 +107,7 @@ exports.getAllUsers = async (req, res) => {
 const bcrypt = require('bcryptjs');
 
 exports.createUser = async (req, res) => {
-    const { firstName, name, email, password, roles, street, postalCode, city, congregation, district, voice, shareWithChoir } = req.body;
+    const { firstName, name, email, password, roles, phone, street, postalCode, city, congregation, district, voice, shareWithChoir } = req.body;
     try {
         const VOICE_OPTIONS = db.user.rawAttributes.voice.values;
         const normalizedVoice = voice === '' ? null : voice;
@@ -121,6 +121,7 @@ exports.createUser = async (req, res) => {
             email,
             roles: roles || ['user'],
             password: password ? bcrypt.hashSync(password, 8) : null,
+            phone: phone === '' ? null : phone,
             street,
             postalCode,
             city,
@@ -141,7 +142,7 @@ exports.createUser = async (req, res) => {
 
 exports.updateUser = async (req, res) => {
     const { id } = req.params;
-    const { firstName, name, email, password, roles, street, postalCode, city, congregation, district, voice, shareWithChoir } = req.body;
+    const { firstName, name, email, password, roles, phone, street, postalCode, city, congregation, district, voice, shareWithChoir } = req.body;
     try {
         const VOICE_OPTIONS = db.user.rawAttributes.voice.values;
         const user = await db.user.findByPk(id);
@@ -152,6 +153,7 @@ exports.updateUser = async (req, res) => {
             name: name ?? user.name,
             email: email ?? user.email,
             roles: roles ?? user.roles,
+            phone: phone !== undefined ? (phone === '' ? null : phone) : user.phone,
             street: street ?? user.street,
             postalCode: postalCode ?? user.postalCode,
             city: city ?? user.city,
@@ -195,7 +197,7 @@ exports.getUserByEmail = async (req, res) => {
     try {
         const user = await db.user.findOne({
             where: { email },
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
+            attributes: ['id', 'firstName', 'name', 'email', 'phone', 'roles', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'lastDonation', 'lastLogin'],
             include: [{
                 model: db.choir,
                 as: 'choirs',

--- a/choir-app-backend/src/controllers/auth.controller.js
+++ b/choir-app-backend/src/controllers/auth.controller.js
@@ -165,6 +165,7 @@ exports.signin = async (req, res) => {
       firstName: user.firstName,
       name: user.name,
       email: user.email,
+      phone: user.phone,
       voice: user.voice,
       roles: user.roles,
       helpShown: user.helpShown,

--- a/choir-app-backend/src/controllers/user.controller.js
+++ b/choir-app-backend/src/controllers/user.controller.js
@@ -50,7 +50,7 @@ function createAccessToken(user, activeChoirId) {
 exports.getMe = async (req, res) => {
     try {
         const user = await User.findByPk(req.userId, {
-            attributes: ['id', 'firstName', 'name', 'email', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'helpShown'],
+            attributes: ['id', 'firstName', 'name', 'email', 'phone', 'roles', 'lastDonation', 'street', 'postalCode', 'city', 'congregation', 'district', 'voice', 'shareWithChoir', 'helpShown'],
             include: [{
                 model: Choir,
                 as: 'choirs', // Use the plural alias 'choirs' defined in the association
@@ -77,8 +77,8 @@ exports.getMe = async (req, res) => {
 /**
  * @description Update the profile of the currently logged-in user.
  */
- exports.updateMe = async (req, res) => {
-    const { firstName, name, email, street, postalCode, city, congregation, district, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
+exports.updateMe = async (req, res) => {
+    const { firstName, name, email, phone, street, postalCode, city, congregation, district, voice, shareWithChoir, helpShown, oldPassword, newPassword, roles } = req.body;
 
     try {
         const VOICE_OPTIONS = User.rawAttributes.voice.values;
@@ -107,6 +107,9 @@ exports.getMe = async (req, res) => {
             updateData.emailChangeToken = token;
             updateData.emailChangeTokenExpiry = expiry;
             emailMessage = 'Eine Bestätigungsmail wurde an die neue Adresse gesendet. Der Link ist 2 Stunden gültig.';
+        }
+        if (phone !== undefined) {
+            updateData.phone = phone === '' ? null : phone;
         }
         if (street !== undefined) {
             updateData.street = street;

--- a/choir-app-backend/src/models/user.model.js
+++ b/choir-app-backend/src/models/user.model.js
@@ -15,6 +15,10 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       unique: true
     },
+    phone: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
     password: {
       type: DataTypes.STRING,
       allowNull: true

--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -10,6 +10,7 @@ router.use(verifyToken);
 
 // Chor-Informationen können von allen Mitgliedern gelesen werden
 router.get("/", wrap(controller.getMyChoirDetails));
+router.get("/dashboard-contact", wrap(controller.getDashboardContact));
 
 // Ab hier: Member-Management und Einstellungen nur für Choir-Admins
 router.put("/", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.updateMyChoir));

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -1,3 +1,5 @@
+import { DashboardContact } from './dashboard-contact';
+
 export type ChoirRole = 'director' | 'choir_admin' | 'organist' | 'singer';
 
 export interface ChoirMembership {
@@ -22,6 +24,14 @@ export interface Choir {
          * true means the item is visible, false hides it.
          */
         singerMenu?: Record<string, boolean>;
+        /**
+         * User id of the contact person that should be highlighted on the dashboard.
+         */
+        dashboardContactUserId?: number | null;
+        /**
+         * Optional cached details of the selected contact.
+         */
+        dashboardContact?: DashboardContact | null;
     };
     joinHash?: string;
     membership?: ChoirMembership;

--- a/choir-app-frontend/src/app/core/models/dashboard-contact.ts
+++ b/choir-app-frontend/src/app/core/models/dashboard-contact.ts
@@ -1,0 +1,8 @@
+export interface DashboardContact {
+  id: number;
+  firstName?: string | null;
+  name: string;
+  email: string;
+  phone?: string | null;
+  rolesInChoir?: string[];
+}

--- a/choir-app-frontend/src/app/core/models/user.ts
+++ b/choir-app-frontend/src/app/core/models/user.ts
@@ -25,6 +25,11 @@ export interface User {
    */
   email: string;
 
+  /**
+   * Optional phone number for direct contact.
+   */
+  phone?: string | null;
+
   street?: string;
   postalCode?: string;
   city?: string;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -15,6 +15,7 @@ import { LookupPiece } from '@core/models/lookup-piece';
 import { Author } from '@core/models/author';
 import { Publisher } from '@core/models/publisher';
 import { Choir } from '@core/models/choir';
+import { DashboardContact } from '../models/dashboard-contact';
 import { ChoirLog } from '../models/choir-log';
 import { PlanRule } from '@core/models/plan-rule';
 import { PieceChange } from '../models/piece-change';
@@ -524,7 +525,7 @@ export class ApiService {
     return this.userService.getCurrentUser();
   }
 
-  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] }): Observable<any> {
+  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; phone?: string; street?: string; postalCode?: string; city?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] }): Observable<any> {
     return this.userService.updateCurrentUser(profileData);
   }
 
@@ -658,6 +659,10 @@ export class ApiService {
 
   getChoirMemberCount(options?: { choirId?: number }): Observable<number> {
     return this.choirService.getChoirMemberCount(options?.choirId);
+  }
+
+  getDashboardContact(options?: { choirId?: number }): Observable<DashboardContact | null> {
+    return this.choirService.getDashboardContact(options?.choirId);
   }
 
   inviteUserToChoir(

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { Choir, normalizeChoir, normalizeMembers } from '../models/choir';
+import { DashboardContact } from '../models/dashboard-contact';
 import { UserInChoir } from '../models/user';
 import { Collection } from '../models/collection';
 import { ChoirLog } from '../models/choir-log';
@@ -36,6 +37,11 @@ export class ChoirService {
     return this.http
       .get<{ count: number }>(`${this.apiUrl}/choir-management/members/count`, { params })
       .pipe(map(res => res.count));
+  }
+
+  getDashboardContact(choirId?: number): Observable<DashboardContact | null> {
+    const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
+    return this.http.get<DashboardContact | null>(`${this.apiUrl}/choir-management/dashboard-contact`, { params });
   }
 
   inviteUserToChoir(email: string, rolesInChoir: string[], choirId?: number): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/core/services/user.service.ts
+++ b/choir-app-frontend/src/app/core/services/user.service.ts
@@ -14,7 +14,7 @@ export class UserService {
     return this.http.get<User>(`${this.apiUrl}/users/me`);
   }
 
-  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] }): Observable<any> {
+  updateCurrentUser(profileData: { firstName?: string; name?: string; email?: string; phone?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; helpShown?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] }): Observable<any> {
     return this.http.put(`${this.apiUrl}/users/me`, profileData);
   }
 

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.html
@@ -16,6 +16,10 @@
       <input matInput formControlName="email">
     </mat-form-field>
     <mat-form-field appearance="outline">
+      <mat-label>Telefon</mat-label>
+      <input matInput formControlName="phone" type="tel">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
       <mat-label>Straße</mat-label>
       <input matInput formControlName="street">
     </mat-form-field>

--- a/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-users/user-dialog/user-dialog.component.ts
@@ -32,6 +32,7 @@ export class UserDialogComponent implements OnInit {
       firstName: [data?.firstName || '', Validators.required],
       name: [data?.name || '', Validators.required],
       email: [data?.email || '', [Validators.required, Validators.email]],
+      phone: [data?.phone || ''],
       street: [data?.street || ''],
       postalCode: [data?.postalCode || ''],
       city: [data?.city || ''],
@@ -62,6 +63,9 @@ export class UserDialogComponent implements OnInit {
           normalized.push('user');
         }
         value.roles = normalized;
+      }
+      if (typeof value.phone === 'string') {
+        value.phone = value.phone.trim();
       }
       if (!value.password) {
         delete value.password;

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -34,7 +34,7 @@
   </mat-card>
 
   <!-- Einstellungen Card -->
-  <mat-card class="form-card" *ngIf="isChoirAdmin" class="collapsible-header" (click)="toggleChoirSetting()">
+  <mat-card class="form-card collapsible-header" *ngIf="isChoirAdmin" (click)="toggleChoirSetting()">
     <mat-card-header>
       <mat-card-title>Einstellungen</mat-card-title>
     </mat-card-header>
@@ -51,6 +51,23 @@
         Beitritt als Sänger per Link erlauben
       </mat-checkbox>
       <p *ngIf="joinByLinkEnabled && joinLink">Beitrittslink: <a [href]="joinLink" target="_blank">{{joinLink}}</a></p>
+
+      <mat-form-field appearance="outline" class="dashboard-contact-field">
+        <mat-label>Kontakt auf dem Dashboard</mat-label>
+        <mat-select [(ngModel)]="dashboardContactUserId" (ngModelChange)="onDashboardContactChange($event)">
+          <mat-option [value]="null">Keinen Kontakt anzeigen</mat-option>
+          <mat-option *ngFor="let director of directorOptions" [value]="director.id">
+            {{ director.firstName ? director.firstName + ' ' : '' }}{{ director.name }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <div class="contact-preview" *ngIf="selectedDashboardContact as contact">
+        <div>E-Mail: <a [href]="'mailto:' + contact.email">{{ contact.email }}</a></div>
+        <div *ngIf="contact.phone; else noPhone">Telefon: <a [href]="'tel:' + contact.phone">{{ contact.phone }}</a></div>
+        <ng-template #noPhone>
+          <div class="muted">Keine Telefonnummer hinterlegt.</div>
+        </ng-template>
+      </div>
 
       <div class="service-settings" *ngIf="dienstplanEnabled">
         <h3>Gottesdienste</h3>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
@@ -100,3 +100,23 @@ mat-card-content form {
 .library-icon {
   margin-left: 8px;
 }
+
+.dashboard-contact-field {
+  display: block;
+  margin-top: 1rem;
+  max-width: 320px;
+}
+
+.contact-preview {
+  margin: 0.5rem 0 1rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+
+  a {
+    color: inherit;
+  }
+
+  .muted {
+    color: rgba(0, 0, 0, 0.54);
+  }
+}

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -46,6 +46,11 @@
 
         <!-- GRID (links/rechts) -->
         <section class="content-grid" role="region" aria-labelledby="next-events">
+          <app-dashboard-contact-widget
+            class="right-tile"
+            [contact]="vm.dashboardContact">
+          </app-dashboard-contact-widget>
+
           <app-upcoming-events-widget
             [events]="vm.upcomingEvents" [choirColors]="choirColors"
             (open)="openEvent($event)" class="left-tile">

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -32,6 +32,8 @@ import { KpiWidgetComponent } from './widgets/kpi-widget.component';
 import { LatestPostWidgetComponent } from './widgets/latest-post-widget.component';
 import { CurrentProgramWidgetComponent } from './widgets/current-program.component';
 import { PureDatePipe } from '@shared/pipes/pure-date.pipe';
+import { DashboardContactWidgetComponent } from './widgets/dashboard-contact-widget.component';
+import { DashboardContact } from '@core/models/dashboard-contact';
 
 type VM = {
   activeChoir: any | null;
@@ -42,6 +44,7 @@ type VM = {
   latestPost: any | null;
   lastProgram: Program | null;
   upcomingEvents: any[];
+  dashboardContact: DashboardContact | null;
 };
 
 @Component({
@@ -60,6 +63,7 @@ type VM = {
     UpcomingEventsWidgetComponent,
     LatestPostWidgetComponent,
     CurrentProgramWidgetComponent,
+    DashboardContactWidgetComponent,
     PureDatePipe,
   ],
   templateUrl: './dashboard.component.html',
@@ -83,6 +87,7 @@ export class DashboardComponent implements OnInit {
   openTasksCount$!: Observable<number>;
   latestPost$!: Observable<import('@core/models/post').Post | null>;
   borrowedItems$!: Observable<LibraryItem[]>;
+  dashboardContact$!: Observable<DashboardContact | null>;
   showOnlyMine = false;
   isAdmin$: Observable<boolean | false>;
   isSingerOnly$!: Observable<boolean>;
@@ -159,6 +164,11 @@ export class DashboardComponent implements OnInit {
       switchMap(() => this.apiService.getLatestPost())
     );
 
+    this.dashboardContact$ = this.refresh$.pipe(
+      switchMap(() => this.apiService.getDashboardContact()),
+      shareReplay(1)
+    );
+
     this.userService.getCurrentUser().pipe(take(1)).subscribe(user => {
       this.authService.setCurrentUser(user);
       if (this.help.shouldShowHelp(user)) {
@@ -175,7 +185,8 @@ export class DashboardComponent implements OnInit {
       lastService: this.lastService$,
       latestPost: this.latestPost$,
       lastProgram: this.lastProgram$,
-      upcomingEvents: this.upcomingEvents$
+      upcomingEvents: this.upcomingEvents$,
+      dashboardContact: this.dashboardContact$
     }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
   }
 

--- a/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.html
@@ -1,0 +1,31 @@
+<mat-card class="contact-card" role="region" aria-labelledby="dashboard-contact-title">
+  <mat-card-header>
+    <mat-card-title id="dashboard-contact-title">Kontakt Chorleitung</mat-card-title>
+  </mat-card-header>
+  <ng-container *ngIf="hasContact && contact; else noContact">
+    <mat-card-content>
+      <div class="contact-name">{{ displayName }}</div>
+      <div class="contact-detail">
+        <mat-icon aria-hidden="true">mail</mat-icon>
+        <a [href]="'mailto:' + contact.email">{{ contact.email }}</a>
+      </div>
+      <div class="contact-detail" *ngIf="contact.phone; else noPhone">
+        <mat-icon aria-hidden="true">call</mat-icon>
+        <a [href]="'tel:' + contact.phone">{{ contact.phone }}</a>
+      </div>
+    </mat-card-content>
+  </ng-container>
+</mat-card>
+
+<ng-template #noContact>
+  <mat-card-content class="empty-state">
+    <p>Es wurde noch kein Kontakt ausgewählt.</p>
+  </mat-card-content>
+</ng-template>
+
+<ng-template #noPhone>
+  <div class="contact-detail muted">
+    <mat-icon aria-hidden="true">call</mat-icon>
+    <span>Keine Telefonnummer hinterlegt.</span>
+  </div>
+</ng-template>

--- a/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.scss
@@ -1,0 +1,49 @@
+.contact-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+.contact-name {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.contact-detail {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+
+  mat-icon {
+    font-size: 1.1rem;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+.empty-state {
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.6);
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+@media (prefers-color-scheme: dark) {
+  .empty-state {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .muted {
+    color: rgba(255, 255, 255, 0.6);
+  }
+}

--- a/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '@modules/material.module';
+import { DashboardContact } from '@core/models/dashboard-contact';
+
+@Component({
+  selector: 'app-dashboard-contact-widget',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './dashboard-contact-widget.component.html',
+  styleUrls: ['./dashboard-contact-widget.component.scss']
+})
+export class DashboardContactWidgetComponent {
+  @Input() contact: DashboardContact | null = null;
+
+  get hasContact(): boolean {
+    return !!this.contact;
+  }
+
+  get displayName(): string {
+    if (!this.contact) {
+      return '';
+    }
+    const firstName = this.contact.firstName ? `${this.contact.firstName} ` : '';
+    return `${firstName}${this.contact.name}`.trim();
+  }
+}

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.html
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.html
@@ -35,6 +35,11 @@
           </mat-form-field>
 
           <mat-form-field appearance="outline">
+            <mat-label>Telefonnummer</mat-label>
+            <input matInput formControlName="phone" type="tel">
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
             <mat-label>Straße</mat-label>
             <input matInput formControlName="street">
           </mat-form-field>

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -60,6 +60,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
       firstName: ['', Validators.required],
       name: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
+      phone: [''],
       street: [''],
       postalCode: [''],
       city: [''],
@@ -97,6 +98,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
           firstName: user.firstName || '',
           name: user.name,
           email: user.email,
+          phone: user.phone || '',
           street: user.street || '',
           postalCode: user.postalCode || '',
           city: user.city || '',
@@ -134,10 +136,12 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
     const formValue = this.profileForm.value;
     const oldEmail = this.currentUser?.email;
-    const updatePayload: { firstName?: string; name?: string; email?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] } = {
+    const trimmedPhone = typeof formValue.phone === 'string' ? formValue.phone.trim() : formValue.phone;
+    const updatePayload: { firstName?: string; name?: string; email?: string; phone?: string | null; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] } = {
       firstName: formValue.firstName,
       name: formValue.name,
       email: formValue.email,
+      phone: trimmedPhone,
       street: formValue.street,
       postalCode: formValue.postalCode,
       city: formValue.city,

--- a/choir-app-frontend/src/app/features/user/profile/profile.component.ts
+++ b/choir-app-frontend/src/app/features/user/profile/profile.component.ts
@@ -136,12 +136,12 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
     const formValue = this.profileForm.value;
     const oldEmail = this.currentUser?.email;
-    const trimmedPhone = typeof formValue.phone === 'string' ? formValue.phone.trim() : formValue.phone;
-    const updatePayload: { firstName?: string; name?: string; email?: string; phone?: string | null; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] } = {
+    const trimmedPhone = typeof formValue.phone === 'string' ? formValue.phone.trim() : undefined;
+    const updatePayload: { firstName?: string; name?: string; email?: string; phone?: string; street?: string; postalCode?: string; city?: string; congregation?: string; district?: string; voice?: string; shareWithChoir?: boolean; oldPassword?: string; newPassword?: string; roles?: GlobalRole[] } = {
       firstName: formValue.firstName,
       name: formValue.name,
       email: formValue.email,
-      phone: trimmedPhone,
+      phone: trimmedPhone || undefined,
       street: formValue.street,
       postalCode: formValue.postalCode,
       city: formValue.city,


### PR DESCRIPTION
## Summary
- add a phone field to the backend user model/responses and provide a dashboard contact endpoint with permission-aware phone visibility
- allow choir admins to choose a dashboard contact in the manage-choir view and display the selection with a dedicated widget on the dashboard
- enable phone editing in the user profile and admin user dialog while updating shared models/services for the new contact data

## Testing
- npm run lint --prefix choir-app-backend *(fails: pre-existing eslint errors in unrelated files)*
- npm run lint --prefix choir-app-frontend *(fails: existing template lint violations outside the touched areas)*
- npm run test:backend *(terminated after hanging in long-running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c84e12b4832087c246a88f34929c