### PR TITLE
Allow opening unassigned score images from admin

### DIFF
--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.html
@@ -40,7 +40,11 @@
     <mat-table [dataSource]="images" class="mat-elevation-z1" *ngIf="images.length > 0">
       <ng-container matColumnDef="filename">
         <mat-header-cell *matHeaderCellDef>Datei</mat-header-cell>
-        <mat-cell *matCellDef="let f">{{ f.filename }}</mat-cell>
+        <mat-cell *matCellDef="let f">
+          <a [href]="getImageUrl(f.filename)" target="_blank" rel="noopener">
+            {{ f.filename }}
+          </a>
+        </mat-cell>
       </ng-container>
       <ng-container matColumnDef="linked">
         <mat-header-cell *matHeaderCellDef>Zugewiesen</mat-header-cell>

--- a/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
+++ b/choir-app-frontend/src/app/features/admin/manage-files/manage-files.component.ts
@@ -4,6 +4,7 @@ import { MaterialModule } from '@modules/material.module';
 import { RouterModule } from '@angular/router';
 import { ApiService } from 'src/app/core/services/api.service';
 import { BackendFile, UploadOverview } from 'src/app/core/models/backend-file';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-manage-files',
@@ -18,6 +19,7 @@ export class ManageFilesComponent implements OnInit {
   files: BackendFile[] = [];
   displayedColumns = ['filename', 'linked', 'actions'];
   displayedFileColumns = ['filename', 'downloadName', 'linked', 'actions'];
+  private readonly apiBase = environment.apiUrl.replace(/\/api\/?$/, '');
 
   constructor(private api: ApiService) {}
 
@@ -48,5 +50,9 @@ export class ManageFilesComponent implements OnInit {
 
   get unassignedFiles(): number {
     return this.files.filter((f) => !f.pieceId).length;
+  }
+
+  getImageUrl(filename: string): string {
+    return `${this.apiBase}/uploads/piece-images/${encodeURIComponent(filename)}`;
   }
 }


### PR DESCRIPTION
## Summary
- add URL helper in the admin manage-files component to build links to uploaded images
- render unassigned score image filenames as anchors so they can be opened directly

## Testing
- npm run lint *(fails: existing template lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e34d32d3788320a168ab8bc24988ac