### PR TITLE
Enable multi-contact selection for choir dashboard

### DIFF
--- a/choir-app-backend/src/routes/choir-management.routes.js
+++ b/choir-app-backend/src/routes/choir-management.routes.js
@@ -10,7 +10,7 @@ router.use(verifyToken);
 
 // Chor-Informationen können von allen Mitgliedern gelesen werden
 router.get("/", wrap(controller.getMyChoirDetails));
-router.get("/dashboard-contact", wrap(controller.getDashboardContact));
+router.get("/dashboard-contact", wrap(controller.getDashboardContacts));
 
 // Ab hier: Member-Management und Einstellungen nur für Choir-Admins
 router.put("/", role.requireChoirAdmin, role.requireNonDemo, wrap(controller.updateMyChoir));

--- a/choir-app-frontend/src/app/core/models/choir.ts
+++ b/choir-app-frontend/src/app/core/models/choir.ts
@@ -25,13 +25,13 @@ export interface Choir {
          */
         singerMenu?: Record<string, boolean>;
         /**
-         * User id of the contact person that should be highlighted on the dashboard.
+         * User ids of the contact persons that should be highlighted on the dashboard.
          */
-        dashboardContactUserId?: number | null;
+        dashboardContactUserIds?: number[];
         /**
-         * Optional cached details of the selected contact.
+         * Optional cached details of the selected contacts.
          */
-        dashboardContact?: DashboardContact | null;
+        dashboardContacts?: DashboardContact[] | null;
     };
     joinHash?: string;
     membership?: ChoirMembership;

--- a/choir-app-frontend/src/app/core/services/api.service.ts
+++ b/choir-app-frontend/src/app/core/services/api.service.ts
@@ -661,8 +661,8 @@ export class ApiService {
     return this.choirService.getChoirMemberCount(options?.choirId);
   }
 
-  getDashboardContact(options?: { choirId?: number }): Observable<DashboardContact | null> {
-    return this.choirService.getDashboardContact(options?.choirId);
+  getDashboardContacts(options?: { choirId?: number }): Observable<DashboardContact[]> {
+    return this.choirService.getDashboardContacts(options?.choirId);
   }
 
   inviteUserToChoir(

--- a/choir-app-frontend/src/app/core/services/choir.service.ts
+++ b/choir-app-frontend/src/app/core/services/choir.service.ts
@@ -39,9 +39,9 @@ export class ChoirService {
       .pipe(map(res => res.count));
   }
 
-  getDashboardContact(choirId?: number): Observable<DashboardContact | null> {
+  getDashboardContacts(choirId?: number): Observable<DashboardContact[]> {
     const params = choirId ? new HttpParams().set('choirId', choirId.toString()) : undefined;
-    return this.http.get<DashboardContact | null>(`${this.apiUrl}/choir-management/dashboard-contact`, { params });
+    return this.http.get<DashboardContact[]>(`${this.apiUrl}/choir-management/dashboard-contact`, { params });
   }
 
   inviteUserToChoir(email: string, rolesInChoir: string[], choirId?: number): Observable<{ message: string }> {

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.html
@@ -52,22 +52,36 @@
       </mat-checkbox>
       <p *ngIf="joinByLinkEnabled && joinLink">Beitrittslink: <a [href]="joinLink" target="_blank">{{joinLink}}</a></p>
 
-      <mat-form-field appearance="outline" class="dashboard-contact-field">
-        <mat-label>Kontakt auf dem Dashboard</mat-label>
-        <mat-select [(ngModel)]="dashboardContactUserId" (ngModelChange)="onDashboardContactChange($event)">
-          <mat-option [value]="null">Keinen Kontakt anzeigen</mat-option>
-          <mat-option *ngFor="let director of directorOptions" [value]="director.id">
-            {{ director.firstName ? director.firstName + ' ' : '' }}{{ director.name }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <div class="contact-preview" *ngIf="selectedDashboardContact as contact">
-        <div>E-Mail: <a [href]="'mailto:' + contact.email">{{ contact.email }}</a></div>
-        <div *ngIf="contact.phone; else noPhone">Telefon: <a [href]="'tel:' + contact.phone">{{ contact.phone }}</a></div>
-        <ng-template #noPhone>
-          <div class="muted">Keine Telefonnummer hinterlegt.</div>
+      <section class="dashboard-contact-settings" aria-label="Kontaktpersonen auf dem Dashboard">
+        <h3>Kontaktpersonen auf dem Dashboard</h3>
+        <p class="muted contact-hint">
+          Markiere in der Chorleiterliste unten die Personen, die auf der Startseite sichtbar sein sollen.
+        </p>
+        <div *ngIf="selectedDashboardContacts.length; else noDashboardContacts" class="contact-preview-list">
+          <div *ngFor="let contact of selectedDashboardContacts" class="contact-preview-entry">
+            <div class="contact-preview-name">
+              {{ contact.firstName ? contact.firstName + ' ' : '' }}{{ contact.name }}
+            </div>
+            <div class="contact-preview-detail">
+              <mat-icon aria-hidden="true">mail</mat-icon>
+              <a [href]="'mailto:' + contact.email">{{ contact.email }}</a>
+            </div>
+            <div class="contact-preview-detail" *ngIf="contact.phone; else noPhonePreview">
+              <mat-icon aria-hidden="true">call</mat-icon>
+              <a [href]="'tel:' + contact.phone">{{ contact.phone }}</a>
+            </div>
+            <ng-template #noPhonePreview>
+              <div class="contact-preview-detail muted">
+                <mat-icon aria-hidden="true">call</mat-icon>
+                <span>Keine Telefonnummer hinterlegt.</span>
+              </div>
+            </ng-template>
+          </div>
+        </div>
+        <ng-template #noDashboardContacts>
+          <p class="muted">Es wurden noch keine Kontaktpersonen ausgewählt.</p>
         </ng-template>
-      </div>
+      </section>
 
       <div class="service-settings" *ngIf="dienstplanEnabled">
         <h3>Gottesdienste</h3>
@@ -140,6 +154,18 @@
       <div class="table-wrapper mat-elevation-z4">
         <mat-table [dataSource]="dataSource">
           <!-- Name Column -->
+          <ng-container matColumnDef="dashboardContact">
+            <mat-header-cell *matHeaderCellDef class="contact-column-header">Startseite</mat-header-cell>
+            <mat-cell *matCellDef="let user" class="contact-column-cell">
+              <mat-checkbox
+                [checked]="isDashboardContactSelected(user.id)"
+                [disabled]="!canManageMenu || !hasDirectorRole(user)"
+                (change)="onDashboardContactToggle(user, $event.checked)"
+                (click)="$event.stopPropagation()"
+                aria-label="Kontakt auf der Startseite anzeigen">
+              </mat-checkbox>
+            </mat-cell>
+          </ng-container>
           <ng-container matColumnDef="name">
             <mat-header-cell *matHeaderCellDef> Name </mat-header-cell>
             <mat-cell *matCellDef="let user"> {{user.name}}, {{ user.firstName }} </mat-cell>

--- a/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
+++ b/choir-app-frontend/src/app/features/choir-management/manage-choir/manage-choir.component.scss
@@ -101,22 +101,84 @@ mat-card-content form {
   margin-left: 8px;
 }
 
-.dashboard-contact-field {
-  display: block;
-  margin-top: 1rem;
-  max-width: 320px;
+.dashboard-contact-settings {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.contact-preview {
-  margin: 0.5rem 0 1rem;
+.contact-hint {
+  margin: 0;
   font-size: 0.9rem;
-  line-height: 1.4;
+}
+
+.contact-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.contact-preview-entry {
+  padding: 0.75rem 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+
+  &:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+}
+
+.contact-preview-name {
+  font-weight: 600;
+}
+
+.contact-preview-detail {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  font-size: 0.95rem;
+
+  mat-icon {
+    font-size: 1.1rem;
+  }
 
   a {
     color: inherit;
+    text-decoration: none;
+  }
+}
+
+.contact-column-header,
+.contact-column-cell {
+  width: 90px;
+  text-align: center;
+}
+
+.contact-column-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.contact-preview-entry .muted,
+.contact-hint.muted {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+@media (prefers-color-scheme: dark) {
+  .contact-preview-entry {
+    border-top-color: rgba(255, 255, 255, 0.12);
   }
 
+  .contact-preview-entry .muted,
+  .contact-hint.muted,
   .muted {
-    color: rgba(0, 0, 0, 0.54);
+    color: rgba(255, 255, 255, 0.6);
   }
 }

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.html
@@ -47,8 +47,9 @@
         <!-- GRID (links/rechts) -->
         <section class="content-grid" role="region" aria-labelledby="next-events">
           <app-dashboard-contact-widget
+            *ngIf="vm.dashboardContacts.length > 0"
             class="right-tile"
-            [contact]="vm.dashboardContact">
+            [contacts]="vm.dashboardContacts">
           </app-dashboard-contact-widget>
 
           <app-upcoming-events-widget

--- a/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/dashboard.component.ts
@@ -44,7 +44,7 @@ type VM = {
   latestPost: any | null;
   lastProgram: Program | null;
   upcomingEvents: any[];
-  dashboardContact: DashboardContact | null;
+  dashboardContacts: DashboardContact[];
 };
 
 @Component({
@@ -87,7 +87,7 @@ export class DashboardComponent implements OnInit {
   openTasksCount$!: Observable<number>;
   latestPost$!: Observable<import('@core/models/post').Post | null>;
   borrowedItems$!: Observable<LibraryItem[]>;
-  dashboardContact$!: Observable<DashboardContact | null>;
+  dashboardContacts$!: Observable<DashboardContact[]>;
   showOnlyMine = false;
   isAdmin$: Observable<boolean | false>;
   isSingerOnly$!: Observable<boolean>;
@@ -164,8 +164,8 @@ export class DashboardComponent implements OnInit {
       switchMap(() => this.apiService.getLatestPost())
     );
 
-    this.dashboardContact$ = this.refresh$.pipe(
-      switchMap(() => this.apiService.getDashboardContact()),
+    this.dashboardContacts$ = this.refresh$.pipe(
+      switchMap(() => this.apiService.getDashboardContacts()),
       shareReplay(1)
     );
 
@@ -186,7 +186,7 @@ export class DashboardComponent implements OnInit {
       latestPost: this.latestPost$,
       lastProgram: this.lastProgram$,
       upcomingEvents: this.upcomingEvents$,
-      dashboardContact: this.dashboardContact$
+      dashboardContacts: this.dashboardContacts$
     }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
   }
 

--- a/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.html
+++ b/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.html
@@ -1,10 +1,10 @@
-<mat-card class="contact-card" role="region" aria-labelledby="dashboard-contact-title">
+<mat-card *ngIf="hasContacts" class="contact-card" role="region" aria-labelledby="dashboard-contact-title">
   <mat-card-header>
     <mat-card-title id="dashboard-contact-title">Kontakt Chorleitung</mat-card-title>
   </mat-card-header>
-  <ng-container *ngIf="hasContact && contact; else noContact">
-    <mat-card-content>
-      <div class="contact-name">{{ displayName }}</div>
+  <mat-card-content>
+    <div class="contact-entry" *ngFor="let contact of contacts; trackBy: trackById">
+      <div class="contact-name">{{ displayName(contact) }}</div>
       <div class="contact-detail">
         <mat-icon aria-hidden="true">mail</mat-icon>
         <a [href]="'mailto:' + contact.email">{{ contact.email }}</a>
@@ -13,19 +13,12 @@
         <mat-icon aria-hidden="true">call</mat-icon>
         <a [href]="'tel:' + contact.phone">{{ contact.phone }}</a>
       </div>
-    </mat-card-content>
-  </ng-container>
-</mat-card>
-
-<ng-template #noContact>
-  <mat-card-content class="empty-state">
-    <p>Es wurde noch kein Kontakt ausgewählt.</p>
+      <ng-template #noPhone>
+        <div class="contact-detail muted">
+          <mat-icon aria-hidden="true">call</mat-icon>
+          <span>Keine Telefonnummer hinterlegt.</span>
+        </div>
+      </ng-template>
+    </div>
   </mat-card-content>
-</ng-template>
-
-<ng-template #noPhone>
-  <div class="contact-detail muted">
-    <mat-icon aria-hidden="true">call</mat-icon>
-    <span>Keine Telefonnummer hinterlegt.</span>
-  </div>
-</ng-template>
+</mat-card>

--- a/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.scss
+++ b/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.scss
@@ -4,6 +4,14 @@
   min-height: 200px;
 }
 
+.contact-entry {
+  &:not(:last-child) {
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  }
+}
+
 .contact-name {
   font-size: 1.2rem;
   font-weight: 600;
@@ -26,21 +34,13 @@
   }
 }
 
-.empty-state {
-  font-size: 0.95rem;
-  color: rgba(0, 0, 0, 0.6);
-  min-height: 140px;
-  display: flex;
-  align-items: center;
-}
-
 .muted {
   color: rgba(0, 0, 0, 0.54);
 }
 
 @media (prefers-color-scheme: dark) {
-  .empty-state {
-    color: rgba(255, 255, 255, 0.7);
+  .contact-entry:not(:last-child) {
+    border-bottom-color: rgba(255, 255, 255, 0.12);
   }
 
   .muted {

--- a/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.ts
+++ b/choir-app-frontend/src/app/features/home/dashboard/widgets/dashboard-contact-widget.component.ts
@@ -11,17 +11,18 @@ import { DashboardContact } from '@core/models/dashboard-contact';
   styleUrls: ['./dashboard-contact-widget.component.scss']
 })
 export class DashboardContactWidgetComponent {
-  @Input() contact: DashboardContact | null = null;
+  @Input() contacts: DashboardContact[] | null = [];
 
-  get hasContact(): boolean {
-    return !!this.contact;
+  get hasContacts(): boolean {
+    return Array.isArray(this.contacts) && this.contacts.length > 0;
   }
 
-  get displayName(): string {
-    if (!this.contact) {
-      return '';
-    }
-    const firstName = this.contact.firstName ? `${this.contact.firstName} ` : '';
-    return `${firstName}${this.contact.name}`.trim();
+  trackById(_: number, contact: DashboardContact): number {
+    return contact.id;
+  }
+
+  displayName(contact: DashboardContact): string {
+    const firstName = contact.firstName ? `${contact.firstName} ` : '';
+    return `${firstName}${contact.name}`.trim();
   }
 }


### PR DESCRIPTION
## Summary
- allow choir admins to mark multiple directors as homepage contacts via checkboxes in the "Mein Chor" administration view
- persist the selected contact ids as arrays in the backend and expose them through an updated dashboard contacts endpoint
- render the dashboard contact widget only when contacts exist and list all chosen contact persons with their details

## Testing
- npm run lint *(fails: existing template lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e353e154788320ada2db2234f16cb6