### PR TITLE
Improve post and comment layout

### DIFF
--- a/choir-app-frontend/src/app/features/posts/post-list.component.html
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.html
@@ -4,8 +4,8 @@
 
 <ng-container *ngIf="posts.length; else noPosts">
   <div class="post-list">
-    <ng-container *ngFor="let p of posts | slice:0:displayCount; let last = last">
-      <mat-card id="post-{{ p.id }}">
+    <ng-container *ngFor="let p of posts | slice:0:displayCount">
+      <mat-card id="post-{{ p.id }}" class="post-card">
         <mat-card-header>
           <mat-card-title>{{ p.title }}</mat-card-title>
           <mat-card-subtitle>{{ p.updatedAt | date:'short' }} – {{ p.author?.name }} <span *ngIf="!p.published">(Entwurf)</span></mat-card-subtitle>
@@ -54,7 +54,7 @@
 
         <div class="comments" *ngIf="p.comments?.length">
           <ng-container *ngFor="let comment of p.comments">
-            <ng-container *ngTemplateOutlet="commentTemplate; context: { $implicit: comment, post: p, depth: 0 }"></ng-container>
+            <ng-container *ngTemplateOutlet="commentTemplate; context: { $implicit: comment, post: p, depth: 0, parent: null }"></ng-container>
           </ng-container>
         </div>
 
@@ -64,7 +64,6 @@
           <button mat-icon-button (click)="deletePost(p)" matTooltip="Löschen"><mat-icon>delete</mat-icon></button>
         </mat-card-actions>
       </mat-card>
-      <mat-divider *ngIf="!last"></mat-divider>
     </ng-container>
     <div class="load-more" *ngIf="displayCount < posts.length">
       <a (click)="showMore()">Ältere anzeigen</a>
@@ -72,11 +71,16 @@
   </div>
 </ng-container>
 
-<ng-template #commentTemplate let-comment let-post="post" let-depth="depth">
+<ng-template #commentTemplate let-comment let-post="post" let-depth="depth" let-parent="parent">
   <div class="comment" [class.reply]="depth > 0">
     <div class="comment-header">
-      <span class="author">{{ comment.author?.name || 'Unbekannt' }}</span>
-      <span class="time">{{ comment.createdAt | date:'short' }}</span>
+      <div class="author-line">
+        <span class="author">{{ comment.author?.name || 'Unbekannt' }}</span>
+        <span class="time">{{ comment.createdAt | date:'short' }}</span>
+      </div>
+      <div class="reply-context" *ngIf="parent">
+        Antwort auf <span class="reply-target">{{ parent.author?.name || 'Unbekannt' }}</span>
+      </div>
     </div>
     <div class="comment-body">{{ comment.text }}</div>
 
@@ -116,7 +120,7 @@
 
     <div class="replies" *ngIf="comment.replies?.length">
       <ng-container *ngFor="let child of comment.replies">
-        <ng-container *ngTemplateOutlet="commentTemplate; context: { $implicit: child, post: post, depth: depth + 1 }"></ng-container>
+        <ng-container *ngTemplateOutlet="commentTemplate; context: { $implicit: child, post: post, depth: depth + 1, parent: comment }"></ng-container>
       </ng-container>
     </div>
   </div>

--- a/choir-app-frontend/src/app/features/posts/post-list.component.scss
+++ b/choir-app-frontend/src/app/features/posts/post-list.component.scss
@@ -12,6 +12,16 @@
 .post-list {
   flex: 1 1 auto;
   overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 8px;
+}
+
+mat-card.post-card {
+  border: 1px solid #e4e7ec;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
 }
 
 
@@ -95,34 +105,94 @@ mat-divider {
 }
 
 .comments {
-  padding: 0 16px 12px;
+  padding: 10px 16px 16px;
+  margin: 0 8px 12px;
+  border-radius: 10px;
+  border: 1px solid #e6e9ef;
+  background: linear-gradient(180deg, #fbfcff 0%, #f7f8fb 100%);
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
 .comment {
-  background: #f7f7f7;
-  border-radius: 6px;
-  padding: 10px 12px;
+  position: relative;
+  background: #fff;
+  border-radius: 10px;
+  padding: 12px 14px;
+  border: 1px solid #e4e7ec;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
 }
 
 .comment.reply {
-  margin-left: 16px;
-  background: #fafafa;
+  margin-left: 20px;
+}
+
+.comment.reply::before {
+  content: '';
+  position: absolute;
+  left: -14px;
+  top: 20px;
+  bottom: 10px;
+  border-left: 2px solid #dfe4ea;
+}
+
+.comment.reply::after {
+  content: '';
+  position: absolute;
+  left: -16px;
+  top: 18px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #dfe4ea;
 }
 
 .comment-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.author-line {
+  display: flex;
   align-items: baseline;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 14px;
+  color: #1f2937;
+}
+
+.author {
+  letter-spacing: 0.01em;
+}
+
+.time {
+  font-size: 12px;
+  color: #6b7280;
   font-weight: 600;
-  font-size: 13px;
+}
+
+.reply-context {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #4b5563;
+  background: #eef2ff;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.reply-target {
+  font-weight: 700;
 }
 
 .comment-body {
-  margin: 6px 0;
+  margin: 8px 0;
   white-space: pre-wrap;
+  color: #374151;
+  line-height: 1.45;
 }
 
 .comment-actions-row {


### PR DESCRIPTION
## Summary
- Increase spacing and card styling for posts to visually separate entries
- Redesign comment thread layout to show reply context and clearer nesting indicators
- Refresh comment blocks with background, border, and header styling for readability

## Testing
- npm test --prefix choir-app-frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950015d81148320bfaf9971ea20f5e7)