### PR TITLE
Fix Dienstplan rights and remember planning month

### DIFF
--- a/choir-app-backend/src/middleware/role.middleware.js
+++ b/choir-app-backend/src/middleware/role.middleware.js
@@ -1,6 +1,7 @@
 const db = require('../models');
 
 const DIRECTOR_ROLES = ['director'];
+const DIENSTPLAN_MANAGER_ROLES = ['choir_admin', ...DIRECTOR_ROLES];
 
 async function getActiveChoirMembership(req) {
     if (!req.userId || !req.activeChoirId) {
@@ -66,6 +67,27 @@ async function requireChoirAdmin(req, res, next) {
             return next();
         }
         return res.status(403).send({ message: 'Require Choir Admin Role!' });
+    } catch (err) {
+        return res.status(500).send({ message: 'Error checking permissions.' });
+    }
+}
+
+/**
+ * Middleware that allows users who may manage the monthly duty plan.
+ *
+ * The duty plan is intentionally broader than choir-admin-only: directors
+ * normally prepare the plan, while choir admins retain the same access.
+ */
+async function requireDienstplanManager(req, res, next) {
+    if (req.userRoles.includes('admin')) {
+        return next();
+    }
+    try {
+        const hasRole = await userHasChoirRole(req, DIENSTPLAN_MANAGER_ROLES);
+        if (hasRole) {
+            return next();
+        }
+        return res.status(403).send({ message: 'Require Dienstplan Manager Role!' });
     } catch (err) {
         return res.status(500).send({ message: 'Error checking permissions.' });
     }
@@ -181,4 +203,4 @@ async function requireNonSinger(req, res, next) {
     }
 }
 
-module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector, requireLibrarian, requireDirectorOrHigher, requireChoirAdminOrNotenwart, requireNonSinger };
+module.exports = { requireNonDemo, requireAdmin, requireChoirAdmin, requireDienstplanManager, requireDirector, requireLibrarian, requireDirectorOrHigher, requireChoirAdminOrNotenwart, requireNonSinger };

--- a/choir-app-backend/src/routes/availability.routes.js
+++ b/choir-app-backend/src/routes/availability.routes.js
@@ -6,10 +6,10 @@ const { handler: wrap } = require("../utils/async");
 
 router.use(auth.verifyToken);
 
-router.get("/:year/:month/all", role.requireChoirAdmin, wrap(controller.findAllByMonth));
-router.get("/:year/:month/user/:userId", role.requireChoirAdmin, wrap(controller.findByMonthForUser));
+router.get("/:year/:month/all", role.requireDienstplanManager, wrap(controller.findAllByMonth));
+router.get("/:year/:month/user/:userId", role.requireDienstplanManager, wrap(controller.findByMonthForUser));
 router.get("/:year/:month", wrap(controller.findByMonth));
-router.put("/:userId", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.setUserAvailability));
+router.put("/:userId", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.setUserAvailability));
 router.put("/", role.requireNonDemo, wrap(controller.setAvailability));
 
 module.exports = router;

--- a/choir-app-backend/src/routes/monthlyPlan.routes.js
+++ b/choir-app-backend/src/routes/monthlyPlan.routes.js
@@ -9,11 +9,11 @@ router.use(auth.verifyToken);
 // Specific ID-based routes must be defined before the year/month route to
 // avoid conflicts like GET /1/pdf being handled as year=1, month='pdf'.
 router.get("/:id/pdf", wrap(controller.downloadPdf));
-router.post("/:id/email", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.emailPdf));
-router.post("/:id/request-availability", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.requestAvailability));
+router.post("/:id/email", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.emailPdf));
+router.post("/:id/request-availability", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.requestAvailability));
 router.get("/:year/:month", wrap(controller.findByMonth));
-router.post("/", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.create));
-router.put("/:id/finalize", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.finalize));
-router.put("/:id/reopen", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.reopen));
+router.post("/", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.create));
+router.put("/:id/finalize", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.finalize));
+router.put("/:id/reopen", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.reopen));
 
 module.exports = router;

--- a/choir-app-backend/src/routes/planEntry.routes.js
+++ b/choir-app-backend/src/routes/planEntry.routes.js
@@ -6,8 +6,8 @@ const { handler: wrap } = require("../utils/async");
 
 router.use(auth.verifyToken);
 
-router.post("/", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.create));
-router.put("/:id", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.update));
-router.delete("/:id", role.requireNonDemo, role.requireChoirAdmin, wrap(controller.delete));
+router.post("/", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.create));
+router.put("/:id", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.update));
+router.delete("/:id", role.requireNonDemo, role.requireDienstplanManager, wrap(controller.delete));
 
 module.exports = router;

--- a/choir-app-backend/tests/role.middleware.test.js
+++ b/choir-app-backend/tests/role.middleware.test.js
@@ -7,7 +7,7 @@ process.env.DB_NAME = ':memory:';
 
 const db = require('../src/models');
 const { createUserWithRoles } = require('./utils/userFactory');
-const { requireNonDemo, requireAdmin, requireChoirAdmin, requireDirector, requireDirectorOrHigher, requireChoirAdminOrNotenwart, requireLibrarian, requireNonSinger } = require('../src/middleware/role.middleware');
+const { requireNonDemo, requireAdmin, requireChoirAdmin, requireDienstplanManager, requireDirector, requireDirectorOrHigher, requireChoirAdminOrNotenwart, requireLibrarian, requireNonSinger } = require('../src/middleware/role.middleware');
 
 async function sendRequest(middleware, context) {
   const app = express();
@@ -128,6 +128,26 @@ async function sendRequest(middleware, context) {
     res = await sendRequest(requireChoirAdmin, { userRoles: ['user'], userId: normal.id, activeChoirId: choir.id });
     assert.strictEqual(res.status, 500, 'db error should return 500');
     db.user_choir.findOne = originalFindOne;
+
+    // requireDienstplanManager success as global admin
+    res = await sendRequest(requireDienstplanManager, { userRoles: ['admin'], userId: admin.id, activeChoirId: choir.id });
+    assert.strictEqual(res.status, 200, 'global admin should pass dienstplan manager middleware');
+
+    // requireDienstplanManager success as choir admin
+    res = await sendRequest(requireDienstplanManager, { userRoles: ['user'], userId: choirAdmin.id, activeChoirId: choir.id });
+    assert.strictEqual(res.status, 200, 'choir admin should pass dienstplan manager middleware');
+
+    // requireDienstplanManager success as choir director
+    res = await sendRequest(requireDienstplanManager, { userRoles: ['user'], userId: choirDirector.id, activeChoirId: choir.id });
+    assert.strictEqual(res.status, 200, 'choir director should pass dienstplan manager middleware');
+
+    // requireDienstplanManager failure as organist
+    res = await sendRequest(requireDienstplanManager, { userRoles: ['user'], userId: choirOrganist.id, activeChoirId: choir.id });
+    assert.strictEqual(res.status, 403, 'organist should not pass dienstplan manager middleware');
+
+    // requireDienstplanManager failure as global librarian
+    res = await sendRequest(requireDienstplanManager, { userRoles: ['librarian'], userId: normal.id, activeChoirId: choir.id });
+    assert.strictEqual(res.status, 403, 'librarian should not pass dienstplan manager middleware');
 
     // requireDirector success as global admin
     res = await sendRequest(requireDirector, { userRoles: ['admin'], userId: admin.id, activeChoirId: choir.id });

--- a/choir-app-frontend/src/app/core/services/auth.service.ts
+++ b/choir-app-frontend/src/app/core/services/auth.service.ts
@@ -37,6 +37,7 @@ export class AuthService {
   public isDemo$: Observable<boolean>;
   public isChoirAdmin$: Observable<boolean>;
   public isDirector$: Observable<boolean>;
+  public isDienstplanManager$: Observable<boolean>;
   public isNotenwart$: Observable<boolean>;
   public isChoirAdminOrNotenwart$: Observable<boolean>;
   public isSinger$: Observable<boolean>;
@@ -96,6 +97,12 @@ export class AuthService {
         }
         return choirRoles.includes('director');
       }),
+      distinctUntilChanged()
+    );
+
+    this.isDienstplanManager$ = combineLatest([this.isAdmin$, this.choirRoles$]).pipe(
+      map(([isAdmin, choirRoles]) =>
+        isAdmin || choirRoles.includes('choir_admin') || choirRoles.includes('director')),
       distinctUntilChanged()
     );
 

--- a/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
+++ b/choir-app-frontend/src/app/core/services/menu-visibility.service.ts
@@ -115,7 +115,7 @@ export class MenuVisibilityService {
     return {
       [MenuKey.DASHBOARD]: true,
       [MenuKey.EVENTS]: true,
-      [MenuKey.DIENSTPLAN]: modules.dienstplan === true && hasPrivilegedRole,
+      [MenuKey.DIENSTPLAN]: modules.dienstplan === true,
       [MenuKey.AVAILABILITY]: true,
       [MenuKey.PARTICIPATION]: hasPrivilegedRole,
       [MenuKey.POSTS]: true,
@@ -142,6 +142,9 @@ export class MenuVisibilityService {
   private applySingerMenuRestrictions(visibility: MenuVisibility, modules: any): void {
     const singerMenu = modules.singerMenu || {};
     MENU_KEYS.forEach(key => {
+      if (key === MenuKey.DIENSTPLAN && modules.dienstplan === true) {
+        return;
+      }
       if (singerMenu[key] === false) {
         (visibility as any)[key] = false;
       }

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.spec.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.spec.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { MonthlyPlanComponent } from './monthly-plan.component';
 import { MonthlyPlan } from '@core/models/monthly-plan';
 import { PlanEntry } from '@core/models/plan-entry';
@@ -15,8 +15,12 @@ describe('MonthlyPlanComponent', () => {
     getMonthlyPlan: jasmine.Spy;
     clearMonthlyPlanCache: jasmine.Spy;
   };
+  let authStub: any;
+  let routerStub: any;
+  let routeStub: any;
 
   beforeEach(() => {
+    localStorage.clear();
     apiStub = {
       getMemberAvailabilities: jasmine.createSpy('getMemberAvailabilities'),
       getChoirMembers: jasmine.createSpy('getChoirMembers')
@@ -25,15 +29,28 @@ describe('MonthlyPlanComponent', () => {
       getMonthlyPlan: jasmine.createSpy('getMonthlyPlan'),
       clearMonthlyPlanCache: jasmine.createSpy('clearMonthlyPlanCache')
     };
+    planServiceStub.getMonthlyPlan.and.returnValue(of(null));
+    authStub = {
+      activeChoir$: new BehaviorSubject<any>({ id: 42 }),
+      isDienstplanManager$: of(false),
+      currentUser$: of(null)
+    };
+    routerStub = {
+      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve())
+    };
+    routeStub = {
+      snapshot: { queryParamMap: new Map() },
+      queryParamMap: of(new Map())
+    };
 
     component = new MonthlyPlanComponent(
       apiStub as any,
       planServiceStub as any,
-      {} as any,
+      authStub as any,
       {} as any,
       { open: () => null } as any,
-      {} as any,
-      { snapshot: { queryParamMap: new Map() } } as any,
+      routerStub as any,
+      routeStub as any,
       {} as any,
       { prevLabel: () => '', nextLabel: () => '', previous: () => ({ year: 0, month: 0 }), next: () => ({ year: 0, month: 0 }) } as any,
       {} as any,
@@ -111,5 +128,28 @@ describe('MonthlyPlanComponent', () => {
     expect(component.organists.map(o => o.id)).toEqual([6]);
     expect(component.availabilityMap[5]['2024-07-01']).toBe('AVAILABLE');
     expect(component.isLoadingPlan).toBeFalse();
+  });
+
+  it('should remember the selected month and tab per choir when month changes', () => {
+    component.selectedYear = 2026;
+    component.selectedMonth = 9;
+    component.selectedTab = 1;
+
+    component.monthChanged();
+
+    const raw = localStorage.getItem('monthlyPlan:lastState:42');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toEqual({ year: 2026, month: 9, tab: 1 });
+    expect(routerStub.navigate).toHaveBeenCalledWith([], jasmine.objectContaining({
+      queryParams: { year: 2026, month: 9, tab: 'avail' }
+    }));
+  });
+
+  it('should restore a previously stored planning month for the active choir', () => {
+    localStorage.setItem('monthlyPlan:lastState:42', JSON.stringify({ year: 2026, month: 11, tab: 1 }));
+
+    const restored = (component as any).getStoredPlanningState();
+
+    expect(restored).toEqual({ year: 2026, month: 11, tab: 1 });
   });
 });

--- a/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
+++ b/choir-app-frontend/src/app/features/monthly-plan/monthly-plan.component.ts
@@ -75,6 +75,7 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
   availabilityMap: { [userId: number]: { [date: string]: string } } = {};
   selectedTab = 0;
   isLoadingPlan = false;
+  private readonly planningStateKeyPrefix = 'monthlyPlan:lastState';
 
   counterPlanDates: Date[] = [];
   counterPlanDateKeys: string[] = [];
@@ -394,16 +395,17 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
     const initialParams = this.route.snapshot.queryParamMap;
     const initialYear = Number(initialParams.get('year'));
     const initialMonth = Number(initialParams.get('month'));
+    const storedState = this.getStoredPlanningState();
 
     this.selectedYear = !Number.isNaN(initialYear) && initialYear > 0
       ? initialYear
-      : now.getFullYear();
+      : (storedState?.year ?? now.getFullYear());
     this.selectedMonth = !Number.isNaN(initialMonth) && initialMonth > 0
       ? initialMonth
-      : now.getMonth() + 1;
-    this.selectedTab = initialParams.get('tab') === 'avail' ? 1 : 0;
+      : (storedState?.month ?? now.getMonth() + 1);
+    this.selectedTab = initialParams.get('tab') === 'avail' ? 1 : (storedState?.tab ?? 0);
 
-    this.auth.isChoirAdmin$.pipe(take(1)).subscribe(isChoirAdmin => {
+    this.auth.isDienstplanManager$.pipe(take(1)).subscribe(isChoirAdmin => {
       this.isChoirAdmin = isChoirAdmin;
       this.updateDisplayedColumns();
       if (isChoirAdmin) {
@@ -415,7 +417,8 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
     this.paramSub = this.route.queryParamMap.pipe(
       takeUntil(this.destroy$)
     ).subscribe(params => {
-      const tabIndex = params.get('tab') === 'avail' ? 1 : 0;
+      const tabParam = params.get('tab');
+      const tabIndex = tabParam === 'avail' ? 1 : (tabParam === null ? this.selectedTab : 0);
       if (this.selectedTab !== tabIndex) {
         this.selectedTab = tabIndex;
       }
@@ -440,6 +443,7 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
       }
 
       if (shouldReload) {
+        this.savePlanningState();
         this.loadPlan(this.selectedYear, this.selectedMonth);
       }
     });
@@ -448,7 +452,7 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
       takeUntil(this.destroy$)
     ).subscribe(u => this.currentUserId = u?.id || null);
 
-    this.roleSub = this.auth.isChoirAdmin$.pipe(
+    this.roleSub = this.auth.isDienstplanManager$.pipe(
       takeUntil(this.destroy$)
     ).subscribe(isChoirAdmin => {
       const wasAdmin = this.isChoirAdmin;
@@ -608,6 +612,7 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
   }
 
   monthChanged(): void {
+    this.savePlanningState();
     this.skipNextParamLoad = true;
     void this.router.navigate([], {
       relativeTo: this.route,
@@ -625,6 +630,7 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
 
   tabChanged(index: number): void {
     this.selectedTab = index;
+    this.savePlanningState();
     this.skipNextParamLoad = true;
     void this.router.navigate([], {
       relativeTo: this.route,
@@ -660,6 +666,49 @@ export class MonthlyPlanComponent extends BaseComponent implements OnInit, OnDes
     this.selectedYear = next.year;
     this.selectedMonth = next.month;
     this.monthChanged();
+  }
+
+  private getStoredPlanningState(): { year: number; month: number; tab: number } | null {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    try {
+      const raw = localStorage.getItem(this.getPlanningStateKey());
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      const year = Number(parsed?.year);
+      const month = Number(parsed?.month);
+      const tab = Number(parsed?.tab);
+      if (!Number.isInteger(year) || year <= 0 || !Number.isInteger(month) || month < 1 || month > 12) {
+        return null;
+      }
+      return { year, month, tab: tab === 1 ? 1 : 0 };
+    } catch {
+      return null;
+    }
+  }
+
+  private savePlanningState(): void {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    try {
+      localStorage.setItem(this.getPlanningStateKey(), JSON.stringify({
+        year: this.selectedYear,
+        month: this.selectedMonth,
+        tab: this.selectedTab
+      }));
+    } catch {
+      // Ignore storage failures in private browsing or restricted environments.
+    }
+  }
+
+  private getPlanningStateKey(): string {
+    const activeChoir = this.auth?.activeChoir$;
+    const choirId = activeChoir && 'value' in activeChoir ? activeChoir.value?.id : null;
+    return `${this.planningStateKeyPrefix}:${choirId ?? 'default'}`;
   }
 
   updateDirector(ev: PlanEntry, userId: number | null): void {

--- a/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
+++ b/choir-app-frontend/src/app/layout/main-layout/main-layout.component.spec.ts
@@ -121,13 +121,27 @@ describe('MainLayoutComponent', () => {
     expect(visible).toBeFalse();
   });
 
-  it('shows dienstplan for organists even if singers cannot see it', async () => {
+  it('shows dienstplan for singers when the choir module is enabled', async () => {
     globalRolesSubject.next(['user']);
-    choirRolesSubject.next(['singer', 'organist']);
+    choirRolesSubject.next(['singer']);
     currentUserSubject.next({ roles: ['user'] });
     activeChoirSubject.next({
       modules: { dienstplan: true, singerMenu: { dienstplan: false } },
-      membership: { rolesInChoir: ['singer', 'organist'] }
+      membership: { rolesInChoir: ['singer'] }
+    });
+    fixture.detectChanges();
+    const dienstplanItem = component.navItems.find(i => i.key === 'dienstplan');
+    const visible = await firstValueFrom(dienstplanItem!.visibleSubject!);
+    expect(visible).toBeTrue();
+  });
+
+  it('shows dienstplan for global admins when the choir module is enabled', async () => {
+    globalRolesSubject.next(['admin']);
+    choirRolesSubject.next(['singer']);
+    currentUserSubject.next({ roles: ['admin'] });
+    activeChoirSubject.next({
+      modules: { dienstplan: true, singerMenu: { dienstplan: false } },
+      membership: { rolesInChoir: ['singer'] }
     });
     fixture.detectChanges();
     const dienstplanItem = component.navItems.find(i => i.key === 'dienstplan');


### PR DESCRIPTION
## Summary
- Keep Dienstplan visible for choir members when the choir module is enabled, including singers, directors, choir admins, and global admins
- Add a dedicated Dienstplan manager permission for global admins, choir admins, and directors
- Use that permission consistently for Dienstplan, plan entries, and managed availability actions/endpoints
- Align MonthlyPlan editing actions with the same permission
- Remember the last selected Dienstplan month/tab per active choir

## Tests
- `node tests\role.middleware.test.js`
- `node tests\monthlyPlan.controller.test.js`
- `npm test -- --watch=false --include src/app/features/monthly-plan/monthly-plan.component.spec.ts`
- `npm test -- --watch=false --include src/app/layout/main-layout/main-layout.component.spec.ts`